### PR TITLE
[api] Add api to allow QgsConfigureShortcutsDialog filter text to be set in plugins

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsconfigureshortcutsdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsconfigureshortcutsdialog.sip.in
@@ -33,6 +33,17 @@ Constructor for QgsConfigureShortcutsDialog.
                 :py:class:`QgsShortcutsManager` instance.
 %End
 
+  public slots:
+
+    void setFilter( const QString &filterText );
+%Docstring
+Sets the text for the filter line edit.
+
+This will immediately filter the shortcuts list to only matching items.
+
+.. versionadded:: 4.2
+%End
+
   protected:
     virtual void keyPressEvent( QKeyEvent *event );
 

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -82,6 +82,11 @@ QgsConfigureShortcutsDialog::QgsConfigureShortcutsDialog( QWidget *parent, QgsSh
   populateActions();
 }
 
+void QgsConfigureShortcutsDialog::setFilter( const QString &filterText )
+{
+  mLeFilter->setText( filterText );
+}
+
 void QgsConfigureShortcutsDialog::populateActions()
 {
   const QList<QObject *> objects = mManager->listAll();

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -487,19 +487,19 @@ void QgsConfigureShortcutsDialog::keyPressEvent( QKeyEvent *event )
   {
     // modifiers
     case Qt::Key_Meta:
-      mModifiers |= Qt::META;
+      mModifiers.setFlag( Qt::KeyboardModifier::MetaModifier );
       updateShortcutText();
       break;
     case Qt::Key_Alt:
-      mModifiers |= Qt::ALT;
+      mModifiers.setFlag( Qt::KeyboardModifier::AltModifier );
       updateShortcutText();
       break;
     case Qt::Key_Control:
-      mModifiers |= Qt::CTRL;
+      mModifiers.setFlag( Qt::KeyboardModifier::ControlModifier );
       updateShortcutText();
       break;
     case Qt::Key_Shift:
-      mModifiers |= Qt::SHIFT;
+      mModifiers.setFlag( Qt::KeyboardModifier::ShiftModifier );
       updateShortcutText();
       break;
 
@@ -527,19 +527,19 @@ void QgsConfigureShortcutsDialog::keyReleaseEvent( QKeyEvent *event )
   {
     // modifiers
     case Qt::Key_Meta:
-      mModifiers &= ~Qt::META;
+      mModifiers.setFlag( Qt::KeyboardModifier::MetaModifier, false );
       updateShortcutText();
       break;
     case Qt::Key_Alt:
-      mModifiers &= ~Qt::ALT;
+      mModifiers.setFlag( Qt::KeyboardModifier::AltModifier, false );
       updateShortcutText();
       break;
     case Qt::Key_Control:
-      mModifiers &= ~Qt::CTRL;
+      mModifiers.setFlag( Qt::KeyboardModifier::ControlModifier, false );
       updateShortcutText();
       break;
     case Qt::Key_Shift:
-      mModifiers &= ~Qt::SHIFT;
+      mModifiers.setFlag( Qt::KeyboardModifier::ShiftModifier, false );
       updateShortcutText();
       break;
 
@@ -549,7 +549,7 @@ void QgsConfigureShortcutsDialog::keyReleaseEvent( QKeyEvent *event )
     default:
     {
       // an ordinary key - set it with modifiers as a shortcut
-      setCurrentActionShortcut( QKeySequence( mModifiers + mKey ) );
+      setCurrentActionShortcut( QKeySequence( static_cast< int >( mModifiers ) + mKey ) );
       setGettingShortcut( false );
     }
   }
@@ -567,13 +567,13 @@ QObject *QgsConfigureShortcutsDialog::currentObject()
 void QgsConfigureShortcutsDialog::updateShortcutText()
 {
   // update text of the button so that user can see what has typed already
-  const QKeySequence s( mModifiers + mKey );
+  const QKeySequence s( static_cast< int >( mModifiers ) + mKey );
   btnChangeShortcut->setText( tr( "Input: " ) + s.toString( QKeySequence::NativeText ) );
 }
 
 void QgsConfigureShortcutsDialog::setGettingShortcut( bool getting )
 {
-  mModifiers = 0;
+  mModifiers = Qt::KeyboardModifiers();
   mKey = 0;
   mGettingShortcut = getting;
   if ( !getting )

--- a/src/gui/qgsconfigureshortcutsdialog.h
+++ b/src/gui/qgsconfigureshortcutsdialog.h
@@ -97,7 +97,8 @@ class GUI_EXPORT QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsCo
     QAction *mSaveAsPdf = nullptr;
 
     bool mGettingShortcut = false;
-    int mModifiers = 0, mKey = 0;
+    Qt::KeyboardModifiers mModifiers = Qt::KeyboardModifiers();
+    int mKey = 0;
 };
 
 #endif //QGSCONFIGURESHORTCUTSDIALOG_H

--- a/src/gui/qgsconfigureshortcutsdialog.h
+++ b/src/gui/qgsconfigureshortcutsdialog.h
@@ -46,6 +46,17 @@ class GUI_EXPORT QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsCo
      */
     QgsConfigureShortcutsDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, QgsShortcutsManager *manager = nullptr );
 
+  public slots:
+
+    /**
+     * Sets the text for the filter line edit.
+     *
+     * This will immediately filter the shortcuts list to only matching items.
+     *
+     * \since QGIS 4.2
+     */
+    void setFilter( const QString &filterText );
+
   protected:
     void keyPressEvent( QKeyEvent *event ) override;
     void keyReleaseEvent( QKeyEvent *event ) override;


### PR DESCRIPTION
## Description

Add api to allow QgsConfigureShortcutsDialog filter text to be set in plugins. Handy if the plugin needs to expose a "set shortcut" action for a particular button, where you want that button to be the only one initially visible in the dialog. (Otherwise the user has to search out and find that button themselves)

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
