### PR TITLE
 use correct wording for messages in the Generate XYZ tiles algorithms  (fix ##62157)

### DIFF
--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -58,14 +58,6 @@ double tileY2lat( const int y, const int z )
   return 180.0 / M_PI * std::atan( 0.5 * ( std::exp( n ) - std::exp( -n ) ) );
 }
 
-void extent2TileXY( QgsRectangle extent, const int zoom, int &xMin, int &yMin, int &xMax, int &yMax )
-{
-  xMin = lon2tileX( extent.xMinimum(), zoom );
-  yMin = lat2tileY( extent.yMinimum(), zoom );
-  xMax = lon2tileX( extent.xMaximum(), zoom );
-  yMax = lat2tileY( extent.xMaximum(), zoom );
-}
-
 QList<MetaTile> getMetatiles( const QgsRectangle extent, const int zoom, const int tileSize )
 {
   int minX = lon2tileX( extent.xMinimum(), zoom );

--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -58,13 +58,13 @@ double tileY2lat( const int y, const int z )
   return 180.0 / M_PI * std::atan( 0.5 * ( std::exp( n ) - std::exp( -n ) ) );
 }
 
-QList<MetaTile> getMetatiles( const QgsRectangle extent, const int zoom, const int tileSize )
+QList<MetaTile> getMetatiles( const QgsRectangle extent, const int zoom, long long &tileCount, const int tileSize )
 {
   int minX = lon2tileX( extent.xMinimum(), zoom );
   int minY = lat2tileY( extent.yMaximum(), zoom );
   int maxX = lon2tileX( extent.xMaximum(), zoom );
   int maxY = lat2tileY( extent.yMinimum(), zoom );
-  ;
+  tileCount = static_cast<long long>( maxX - minX + 1 ) * static_cast<long long>( maxY - minY + 1 );
 
   int i = 0;
   QMap<QString, MetaTile> tiles;
@@ -329,17 +329,20 @@ QVariantMap QgsXyzTilesDirectoryAlgorithm::processAlgorithm( const QVariantMap &
   mOutputDir = outputDir;
   mTms = tms;
 
+  long long totalTiles = 0;
   mTotalMetaTiles = 0;
   for ( int z = mMinZoom; z <= mMaxZoom; z++ )
   {
     if ( feedback->isCanceled() )
       break;
 
-    mMetaTiles += getMetatiles( mWgs84Extent, z, mMetaTileSize );
-    feedback->pushInfo( QObject::tr( "%1 metatiles will be created for zoom level %2" ).arg( mMetaTiles.size() - mTotalMetaTiles ).arg( z ) );
+    long long tileCount = 0;
+    mMetaTiles += getMetatiles( mWgs84Extent, z, tileCount, mMetaTileSize );
+    feedback->pushInfo( QObject::tr( "%1 metatiles (%2 tiles) will be created for zoom level %3" ).arg( mMetaTiles.size() - mTotalMetaTiles ).arg( tileCount ).arg( z ) );
     mTotalMetaTiles = mMetaTiles.size();
+    totalTiles += tileCount;
   }
-  feedback->pushInfo( QObject::tr( "A total of %1 metatiles will be created" ).arg( mTotalMetaTiles ) );
+  feedback->pushInfo( QObject::tr( "A total of %1 metatiles (%2 tiles) will be created" ).arg( mTotalMetaTiles ).arg( totalTiles ) );
 
   checkLayersUsagePolicy( feedback );
 
@@ -525,17 +528,20 @@ QVariantMap QgsXyzTilesMbtilesAlgorithm::processAlgorithm( const QVariantMap &pa
   QString boundsStr = QString( "%1,%2,%3,%4" ).arg( mWgs84Extent.xMinimum() ).arg( mWgs84Extent.yMinimum() ).arg( mWgs84Extent.xMaximum() ).arg( mWgs84Extent.yMaximum() );
   mMbtilesWriter->setMetadataValue( "bounds", boundsStr );
 
+  long long totalTiles = 0;
   mTotalMetaTiles = 0;
   for ( int z = mMinZoom; z <= mMaxZoom; z++ )
   {
     if ( feedback->isCanceled() )
       break;
 
-    mMetaTiles += getMetatiles( mWgs84Extent, z, mMetaTileSize );
-    feedback->pushInfo( QObject::tr( "%1 metatiles will be created for zoom level %2" ).arg( mMetaTiles.size() - mTotalMetaTiles ).arg( z ) );
+    long long tileCount = 0;
+    mMetaTiles += getMetatiles( mWgs84Extent, z, tileCount, mMetaTileSize );
+    feedback->pushInfo( QObject::tr( "%1 metatiles (%2 tiles) will be created for zoom level %3" ).arg( mMetaTiles.size() - mTotalMetaTiles ).arg( tileCount ).arg( z ) );
     mTotalMetaTiles = mMetaTiles.size();
+    totalTiles += tileCount;
   }
-  feedback->pushInfo( QObject::tr( "A total of %1 metdtiles will be created" ).arg( mTotalMetaTiles ) );
+  feedback->pushInfo( QObject::tr( "A total of %1 metatiles (%2 tiles) will be created" ).arg( mTotalMetaTiles ).arg( totalTiles ) );
 
   checkLayersUsagePolicy( feedback );
 

--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -211,7 +211,7 @@ bool QgsXyzTilesBaseAlgorithm::prepareAlgorithm( const QVariantMap &parameters, 
 
 void QgsXyzTilesBaseAlgorithm::checkLayersUsagePolicy( QgsProcessingFeedback *feedback )
 {
-  if ( mTotalTiles > MAXIMUM_OPENSTREETMAP_TILES_FETCH )
+  if ( mTotalMetaTiles > MAXIMUM_OPENSTREETMAP_TILES_FETCH )
   {
     for ( QgsMapLayer *layer : std::as_const( mLayers ) )
     {
@@ -337,17 +337,17 @@ QVariantMap QgsXyzTilesDirectoryAlgorithm::processAlgorithm( const QVariantMap &
   mOutputDir = outputDir;
   mTms = tms;
 
-  mTotalTiles = 0;
+  mTotalMetaTiles = 0;
   for ( int z = mMinZoom; z <= mMaxZoom; z++ )
   {
     if ( feedback->isCanceled() )
       break;
 
     mMetaTiles += getMetatiles( mWgs84Extent, z, mMetaTileSize );
-    feedback->pushWarning( QObject::tr( "%1 tiles will be created for zoom level %2" ).arg( mMetaTiles.size() - mTotalTiles ).arg( z ) );
-    mTotalTiles = mMetaTiles.size();
+    feedback->pushInfo( QObject::tr( "%1 metatiles will be created for zoom level %2" ).arg( mMetaTiles.size() - mTotalMetaTiles ).arg( z ) );
+    mTotalMetaTiles = mMetaTiles.size();
   }
-  feedback->pushWarning( QObject::tr( "A total of %1 tiles will be created" ).arg( mTotalTiles ) );
+  feedback->pushInfo( QObject::tr( "A total of %1 metatiles will be created" ).arg( mTotalMetaTiles ) );
 
   checkLayersUsagePolicy( feedback );
 
@@ -449,7 +449,7 @@ void QgsXyzTilesDirectoryAlgorithm::processMetaTile( QgsMapRendererSequentialJob
   mRendererJobs.remove( job );
   job->deleteLater();
 
-  mFeedback->setProgress( 100.0 * ( mProcessedTiles++ ) / mTotalTiles );
+  mFeedback->setProgress( 100.0 * ( mProcessedMetaTiles++ ) / mTotalMetaTiles );
 
   if ( mFeedback->isCanceled() )
   {
@@ -533,17 +533,17 @@ QVariantMap QgsXyzTilesMbtilesAlgorithm::processAlgorithm( const QVariantMap &pa
   QString boundsStr = QString( "%1,%2,%3,%4" ).arg( mWgs84Extent.xMinimum() ).arg( mWgs84Extent.yMinimum() ).arg( mWgs84Extent.xMaximum() ).arg( mWgs84Extent.yMaximum() );
   mMbtilesWriter->setMetadataValue( "bounds", boundsStr );
 
-  mTotalTiles = 0;
+  mTotalMetaTiles = 0;
   for ( int z = mMinZoom; z <= mMaxZoom; z++ )
   {
     if ( feedback->isCanceled() )
       break;
 
     mMetaTiles += getMetatiles( mWgs84Extent, z, mMetaTileSize );
-    feedback->pushInfo( QObject::tr( "%1 tiles will be created for zoom level %2" ).arg( mMetaTiles.size() - mTotalTiles ).arg( z ) );
-    mTotalTiles = mMetaTiles.size();
+    feedback->pushInfo( QObject::tr( "%1 metatiles will be created for zoom level %2" ).arg( mMetaTiles.size() - mTotalMetaTiles ).arg( z ) );
+    mTotalMetaTiles = mMetaTiles.size();
   }
-  feedback->pushInfo( QObject::tr( "A total of %1 tiles will be created" ).arg( mTotalTiles ) );
+  feedback->pushInfo( QObject::tr( "A total of %1 metdtiles will be created" ).arg( mTotalMetaTiles ) );
 
   checkLayersUsagePolicy( feedback );
 
@@ -588,7 +588,7 @@ void QgsXyzTilesMbtilesAlgorithm::processMetaTile( QgsMapRendererSequentialJob *
   mRendererJobs.remove( job );
   job->deleteLater();
 
-  mFeedback->setProgress( 100.0 * ( mProcessedTiles++ ) / mTotalTiles );
+  mFeedback->setProgress( 100.0 * ( mProcessedMetaTiles++ ) / mTotalMetaTiles );
 
   if ( mFeedback->isCanceled() )
   {

--- a/src/analysis/processing/qgsalgorithmxyztiles.h
+++ b/src/analysis/processing/qgsalgorithmxyztiles.h
@@ -121,8 +121,8 @@ class QgsXyzTilesBaseAlgorithm : public QgsProcessingAlgorithm
     QgsCoordinateTransform mWgs2Mercator;
     QgsRectangle mWgs84Extent;
     QgsProcessingFeedback *mFeedback = nullptr;
-    long long mTotalTiles = 0;
-    long long mProcessedTiles = 0;
+    long long mTotalMetaTiles = 0;
+    long long mProcessedMetaTiles = 0;
     QgsCoordinateTransformContext mTransformContext;
     QString mEllipsoid;
     QPointer<QEventLoop> mEventLoop;

--- a/src/analysis/processing/qgsalgorithmxyztiles.h
+++ b/src/analysis/processing/qgsalgorithmxyztiles.h
@@ -75,7 +75,7 @@ struct MetaTile
     int rows = 0;
     int cols = 0;
 };
-QList<MetaTile> getMetatiles( const QgsRectangle extent, const int zoom, const int tileSize = 4 );
+QList<MetaTile> getMetatiles( const QgsRectangle extent, const int zoom, long long &tileCount, const int tileSize = 4 );
 
 
 /**

--- a/src/analysis/processing/qgsalgorithmxyztiles.h
+++ b/src/analysis/processing/qgsalgorithmxyztiles.h
@@ -33,7 +33,6 @@ int lon2tileX( const double lon, const int z );
 int lat2tileY( const double lat, const int z );
 double tileX2lon( const int x, const int z );
 double tileY2lat( const int y, const int z );
-void extent2TileXY( const QgsRectangle extent, const int zoom, int &xMin, int &yMin, int &xMax, int &yMax );
 
 struct Tile
 {


### PR DESCRIPTION
## Description

Generate XYZ tiles algorithms operate on metatiles while the messages mention just "tiles" which is confusing and makes an impression that calculated number of tiles is wrong.

Update messages so they correctly refer to metatiles and additionally show number of actual tiles. 

Fixes #62157

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
