### PR TITLE
[raster] Fix bad layer properties not saved

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -847,16 +847,11 @@ void QgsRasterLayerProperties::apply()
     }
   }
 
-  // Do nothing on "bad" layers
-  if ( !mRasterLayer->isValid() )
-    return;
-
   // apply all plugin dialogs
   for ( QgsMapLayerConfigWidget *page : std::as_const( mConfigWidgets ) )
   {
     page->apply();
   }
-
 
   /*
    * Legend Tab

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -867,9 +867,12 @@ void QgsRasterLayerProperties::apply()
   //set whether the layer histogram should be inverted
   //mRasterLayer->setInvertHistogram( cboxInvertColorMap->isChecked() );
 
-  mRasterLayer->brightnessFilter()->setBrightness( mSliderBrightness->value() );
-  mRasterLayer->brightnessFilter()->setContrast( mSliderContrast->value() );
-  mRasterLayer->brightnessFilter()->setGamma( mGammaSpinBox->value() );
+  if ( mRasterLayer->brightnessFilter() )
+  {
+    mRasterLayer->brightnessFilter()->setBrightness( mSliderBrightness->value() );
+    mRasterLayer->brightnessFilter()->setContrast( mSliderContrast->value() );
+    mRasterLayer->brightnessFilter()->setGamma( mGammaSpinBox->value() );
+  }
 
   QgsDebugMsgLevel( u"processing transparency tab"_s, 3 );
   /*


### PR DESCRIPTION
Fix #66324 by partially reverting #9563 : I couldn't replicate the original crash so that might have been fixed.

Not recommended for backport.
