### PR TITLE
Add inja escape() function to HTML escape values

### DIFF
--- a/resources/server/api/ogc/templates/wfs3/getFeature.html
+++ b/resources/server/api/ogc/templates/wfs3/getFeature.html
@@ -8,7 +8,7 @@
             <dl class="row">
             {% for name, value in properties %}
                 <dt class="col-sm-12">{{ name }}</dt>
-                <dd class="col-sm-12">{{ value }}</dd>
+                <dd class="col-sm-12">{{ escape(value) }}</dd>
             {% endfor %}
             </dl>
         </div>

--- a/resources/server/api/ogc/templates/wfs3/getFeatures.html
+++ b/resources/server/api/ogc/templates/wfs3/getFeatures.html
@@ -54,7 +54,7 @@
                 <dl class="row">
                 {% for name, value in feature.properties %}
                     <dt class="col-sm-12">{{ name }}</dt>
-                    <dd class="col-sm-12">{{ if_nullptr_null_str(value) }}</dd>
+                    <dd class="col-sm-12">{{ escape(if_nullptr_null_str(value)) }}</dd>
                 {% endfor %}
                 </dl>
             {% endfor %}

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -315,7 +315,8 @@ void QgsServerOgcApiHandler::htmlDump( const json &data, const QgsServerApiConte
     // Get the template directory and the file name
     QFileInfo pathInfo { path };
     Environment env { QString( pathInfo.dir().path() + QDir::separator() ).toStdString() };
-    env.set_html_autoescape( true );
+    // Do not call env.set_html_autoescape( true ) because that would escape links too
+    // use the escape() function in the templates instead
 
     // For template debugging:
     env.add_callback( "json_dump", 0, [data]( Arguments & ) { return data.dump(); } );
@@ -466,6 +467,37 @@ void QgsServerOgcApiHandler::htmlDump( const json &data, const QgsServerApiConte
           out = jsonValue.dump();
       }
       return out;
+    } );
+
+    // HTML escape function
+    env.add_callback( "escape", 1, []( Arguments &args ) {
+      std::string str { args.at( 0 )->get<std::string>() };
+      std::string escaped;
+      escaped.reserve( str.size() );
+      for ( const char c : str )
+      {
+        switch ( c )
+        {
+          case '&':
+            escaped.append( "&amp;" );
+            break;
+          case '<':
+            escaped.append( "&lt;" );
+            break;
+          case '>':
+            escaped.append( "&gt;" );
+            break;
+          case '"':
+            escaped.append( "&quot;" );
+            break;
+          case '\'':
+            escaped.append( "&#39;" );
+            break;
+          default:
+            escaped.push_back( c );
+        }
+      }
+      return escaped;
     } );
 
     context.response()->write( env.render_file( pathInfo.fileName().toStdString(), data ) );

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -766,6 +766,45 @@ class QgsServerAPITest(QgsServerAPITestBase):
         )
         self.compareApi(request, project, "test_wfs3_collections_project.html")
 
+    def test_wfs3_getfeature_html_escape(self):
+
+        # Create mem layer with a single text field
+        layer = QgsVectorLayer(
+            "Point?crs=epsg:4326&field=txt:string", "test_layer", "memory"
+        )
+        self.assertTrue(layer.isValid())
+        f = QgsFeature(layer.fields())
+        f.setGeometry(QgsGeometry.fromWkt("POINT(1 1)"))
+        f.setAttribute("txt", "<b>test</b>")
+        layer.dataProvider().addFeatures([f])
+
+        p = QgsProject()
+        p.addMapLayer(layer)
+
+        # Expose to WFS
+        p.writeEntry("WFSLayers", "/", [layer.id()])
+
+        request = QgsBufferServerRequest(
+            "http://server.qgis.org/wfs3/collections/test_layer/items/1.html"
+        )
+        response = QgsBufferServerResponse()
+        server = QgsServer()
+
+        server.handleRequest(request, response, p)
+        self.assertEqual(response.statusCode(), 200)
+        self.assertNotIn("<b>test</b>", str(response.body(), "utf-8"))
+        self.assertIn("&lt;b&gt;test&lt;/b&gt;", str(response.body(), "utf-8"))
+
+        # Same test with the whole collection
+        request = QgsBufferServerRequest(
+            "http://server.qgis.org/wfs3/collections/test_layer/items.html"
+        )
+        response = QgsBufferServerResponse()
+        server.handleRequest(request, response, p)
+        self.assertEqual(response.statusCode(), 200)
+        self.assertNotIn("<b>test</b>", str(response.body(), "utf-8"))
+        self.assertIn("&lt;b&gt;test&lt;/b&gt;", str(response.body(), "utf-8"))
+
     def test_wfs3_collections_content_type(self):
         """Test WFS3 API collections in html format with Accept header"""
 


### PR DESCRIPTION
This fixes https://github.com/qgis/QGIS/security/advisories/GHSA-cr49-pm9v-m788

