### PR TITLE
fix(expression): concat return Empty string instead of Null

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2834,7 +2834,7 @@ static QVariant fcnCrsFromText( const QVariantList &values, const QgsExpressionC
 
 static QVariant fcnConcat( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QString concat;
+  QString concat( "" );
   for ( const QVariant &value : values )
   {
     if ( !QgsVariantUtils::isNull( value ) )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2289,6 +2289,8 @@ class TestQgsExpression : public QObject
       QTest::newRow( "concat" ) << "concat('a', 'b', 'c', 'd')" << false << QVariant( "abcd" );
       QTest::newRow( "concat function single" ) << "concat('a')" << false << QVariant( "a" );
       QTest::newRow( "concat function with NULL" ) << "concat(NULL,'a','b')" << false << QVariant( "ab" );
+      QTest::newRow( "concat function with only NULL" ) << "concat(NULL)" << false << QVariant( "" );
+      QTest::newRow( "concat function with multi NULL" ) << "concat(NULL, NULL)" << false << QVariant( "" );
       QTest::newRow( "concat_ws no args" ) << "concat_ws()" << true << QVariant();
       QTest::newRow( "concat_ws one arg" ) << "concat_ws(' ')" << true << QVariant();
       QTest::newRow( "concat_ws comma" ) << "concat_ws(',', 'b', NULL, 'd')" << false << QVariant( "b,d" );


### PR DESCRIPTION
## Description

Fixes https://github.com/qgis/QGIS/issues/65808 initializing `concat` variable.

After:

<img width="1377" height="956" alt="image" src="https://github.com/user-attachments/assets/d8b8591a-07b6-4672-ac4a-5dd68d4d6894" />
<img width="1377" height="956" alt="image" src="https://github.com/user-attachments/assets/ee34d945-e257-4323-9c1c-7bbf954bbc82" />
<img width="1377" height="956" alt="image" src="https://github.com/user-attachments/assets/eb4d6c64-835f-48a0-a0d9-e1685f43470c" />
<img width="1377" height="956" alt="image" src="https://github.com/user-attachments/assets/fb7830f9-8bdd-4e5e-ad49-6a67d8de3c12" />

@agiudiceandrea may I ask you to review/test this one?


## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
