### PR TITLE
Fix single band grey widget min/max live editing

### DIFF
--- a/src/gui/qgsdoublevalidator.cpp
+++ b/src/gui/qgsdoublevalidator.cpp
@@ -29,16 +29,14 @@
 
 #include "moc_qgsdoublevalidator.cpp"
 
-const QString PERMISSIVE_DOUBLE = R"([+\-%3]?[\d]{0,1000}([\.%1][\d]{0,1000})?([eE%4][+\-%3]?[\d]{0,%2})?)";
+const QString PERMISSIVE_DOUBLE = R"(^\s*[+\-%3]?[\d]{0,1000}([\.%1][\d]{0,1000})?([eE%4][+\-%3]?[\d]{0,%2})?\s*$)";
 
 QgsDoubleValidator::QgsDoubleValidator( QObject *parent )
   : QRegularExpressionValidator( parent )
   , mMinimum( std::numeric_limits<qreal>::lowest() )
   , mMaximum( std::numeric_limits<qreal>::max() )
 {
-  // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() ).arg( 1000 ).arg( QLocale().negativeSign() ).arg( QLocale().exponential() ) );
-  setRegularExpression( reg );
+  setRegularExpression( createExpression( 1000 ) );
 }
 
 QgsDoubleValidator::QgsDoubleValidator( const QRegularExpression &expression, double bottom, double top, QObject *parent )
@@ -54,9 +52,7 @@ QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, QObject *pare
   , mMinimum( bottom )
   , mMaximum( top )
 {
-  // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() ).arg( 1000 ).arg( QLocale().negativeSign() ).arg( QLocale().exponential() ) );
-  setRegularExpression( reg );
+  setRegularExpression( createExpression( 1000 ) );
 }
 
 QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, int decimal, QObject *parent )
@@ -64,9 +60,7 @@ QgsDoubleValidator::QgsDoubleValidator( double bottom, double top, int decimal, 
   , mMinimum( bottom )
   , mMaximum( top )
 {
-  // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() ).arg( QString::number( decimal ) ).arg( QLocale().negativeSign() ).arg( QLocale().exponential() ) );
-  setRegularExpression( reg );
+  setRegularExpression( createExpression( decimal ) );
 }
 
 QgsDoubleValidator::QgsDoubleValidator( int decimal, QObject *parent )
@@ -75,14 +69,12 @@ QgsDoubleValidator::QgsDoubleValidator( int decimal, QObject *parent )
   , mMaximum( std::numeric_limits<qreal>::max() )
 {
   // The regular expression accept double with point as decimal point but also the locale decimal point
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() ).arg( QString::number( decimal ) ).arg( QLocale().negativeSign() ).arg( QLocale().exponential() ) );
-  setRegularExpression( reg );
+  setRegularExpression( createExpression( decimal ) );
 }
 
 void QgsDoubleValidator::setMaxDecimals( int maxDecimals )
 {
-  const QRegularExpression reg( PERMISSIVE_DOUBLE.arg( QLocale().decimalPoint() ).arg( QString::number( maxDecimals ) ).arg( QLocale().negativeSign() ).arg( QLocale().exponential() ) );
-  setRegularExpression( reg );
+  setRegularExpression( createExpression( maxDecimals ) );
 }
 
 QValidator::State QgsDoubleValidator::validate( QString &input, int & ) const
@@ -133,6 +125,19 @@ double QgsDoubleValidator::toDouble( const QString &input )
 {
   bool ok = false;
   return toDouble( input, &ok );
+}
+
+QRegularExpression QgsDoubleValidator::createExpression( int decimals )
+{
+  const QString localeDecimalPoint = QLocale().decimalPoint();
+  const QString localeNegativeSign = QLocale().negativeSign();
+  const QString localeExponential = QLocale().exponential();
+  return QRegularExpression( PERMISSIVE_DOUBLE.arg(
+    localeDecimalPoint == '.' ? QString() : QRegularExpression::escape( localeDecimalPoint ),
+    QString::number( decimals ),
+    localeNegativeSign == '-' ? QString() : QRegularExpression::escape( localeNegativeSign ),
+    localeExponential == 'E' ? QString() : localeExponential
+  ) );
 }
 
 double QgsDoubleValidator::toDouble( const QString &input, bool *ok )

--- a/src/gui/qgsdoublevalidator.h
+++ b/src/gui/qgsdoublevalidator.h
@@ -169,6 +169,11 @@ class GUI_EXPORT QgsDoubleValidator : public QRegularExpressionValidator
      * Top range limit
      */
     double mMaximum;
+
+    /**
+     * Creates the expression with given max \a decimals
+     */
+    static QRegularExpression createExpression( int decimals );
 };
 
 #endif // QGSDOUBLEVALIDATOR_H

--- a/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandgrayrendererwidget.cpp
@@ -124,12 +124,22 @@ void QgsSingleBandGrayRendererWidget::setMapCanvas( QgsMapCanvas *canvas )
 
 void QgsSingleBandGrayRendererWidget::mMinLineEdit_textChanged( const QString & )
 {
-  minMaxModified();
+  QString text = mMinLineEdit->text();
+  int pos = 0;
+  if ( mMinLineEdit->validator()->validate( text, pos ) == QValidator::Acceptable )
+  {
+    minMaxModified();
+  }
 }
 
 void QgsSingleBandGrayRendererWidget::mMaxLineEdit_textChanged( const QString & )
 {
-  minMaxModified();
+  QString text = mMaxLineEdit->text();
+  int pos = 0;
+  if ( mMaxLineEdit->validator()->validate( text, pos ) == QValidator::Acceptable )
+  {
+    minMaxModified();
+  }
 }
 
 void QgsSingleBandGrayRendererWidget::minMaxModified()

--- a/tests/src/gui/testqgsdoublevalidator.cpp
+++ b/tests/src/gui/testqgsdoublevalidator.cpp
@@ -18,6 +18,9 @@
 #include "qgstest.h"
 
 #include <QLineEdit>
+#include <QString>
+
+using namespace Qt::StringLiterals;
 
 class TestQgsDoubleValidator : public QObject
 {
@@ -32,6 +35,8 @@ class TestQgsDoubleValidator : public QObject
     void validate_data();
     void toDouble_data();
     void toDouble();
+
+    void testRegularExpression();
 
   private:
 };
@@ -86,6 +91,10 @@ void TestQgsDoubleValidator::validate_data()
   QTest::newRow( "outside the range + local decimal" ) << QString( "3ld6" ) << int( QValidator::Intermediate ) << false;
   QTest::newRow( "outside the range + c decimal" ) << QString( "3cd6" ) << int( QValidator::Intermediate ) << false;
   QTest::newRow( "string" ) << QString( "string" ) << int( QValidator::Invalid ) << false;
+
+  QTest::newRow( "empty" ) << QString( "" ) << int( QValidator::Intermediate ) << false;
+  QTest::newRow( "only sign" ) << QString( "-" ) << int( QValidator::Intermediate ) << true;
+  QTest::newRow( "only decimal separator" ) << QString( "." ) << int( QValidator::Intermediate ) << false;
 }
 
 void TestQgsDoubleValidator::toDouble_data()
@@ -232,6 +241,28 @@ void TestQgsDoubleValidator::toDouble()
 
     QCOMPARE( QgsDoubleValidator::toDouble( value ), expectedValue );
   }
+}
+
+void TestQgsDoubleValidator::testRegularExpression()
+{
+  // Test that with locales that have '.' as decimal separator and '-' as minus sign the regular expression is correct
+  QLocale::setDefault( QLocale( QLocale::Language::English ) );
+  QgsDoubleValidator validator( nullptr );
+  QString value = u"1.x23"_s;
+  QCOMPARE( validator.validate( value ), QValidator::Invalid );
+  value = u"1.23"_s;
+  QCOMPARE( validator.validate( value ), QValidator::Acceptable );
+  const QRegularExpression re = validator.regularExpression();
+  QCOMPARE( re.pattern(), "^\\s*[+\\-]?[\\d]{0,1000}([\\.][\\d]{0,1000})?([eE][+\\-]?[\\d]{0,1000})?\\s*$" );
+
+  QLocale::setDefault( QLocale( QLocale::Language::Italian ) );
+  validator.setMaxDecimals( 100 );
+  value = u"1,x23"_s;
+  QCOMPARE( validator.validate( value ), QValidator::Invalid );
+  value = u"1,23"_s;
+  QCOMPARE( validator.validate( value ), QValidator::Acceptable );
+  const QRegularExpression re2 = validator.regularExpression();
+  QCOMPARE( re2.pattern(), "^\\s*[+\\-]?[\\d]{0,1000}([\\.\\,][\\d]{0,1000})?([eE][+\\-]?[\\d]{0,100})?\\s*$" );
 }
 
 QGSTEST_MAIN( TestQgsDoubleValidator )


### PR DESCRIPTION
Fix #65566 by not updating the renderer if the values being edited in the widgets are not valid according to the QgsDoubleValidator.

Also fix unreported issues with QgsDoubleValidator not escaping decimal separator and minus sign.
