### PR TITLE
[Oracle] Set browser data item as populated when an error occurs

### DIFF
--- a/src/providers/oracle/qgsoraclecolumntypetask.cpp
+++ b/src/providers/oracle/qgsoraclecolumntypetask.cpp
@@ -36,11 +36,12 @@ QgsOracleColumnTypeTask::QgsOracleColumnTypeTask( const QString &name, const QSt
 
 bool QgsOracleColumnTypeTask::run()
 {
-  QString conninfo = QgsOracleConn::toPoolName( QgsOracleConn::connUri( mName ) );
+  const QString conninfo = QgsOracleConn::toPoolName( QgsOracleConn::connUri( mName ) );
   QgsOracleConn *conn = QgsOracleConnPool::instance()->acquireConnection( conninfo );
   if ( !conn )
   {
-    QgsDebugError( "Connection failed - " + conninfo );
+    mError = tr( "Connection failed" );
+    QgsDebugError( mError );
     return false;
   }
 
@@ -48,6 +49,7 @@ bool QgsOracleColumnTypeTask::run()
   QVector<QgsOracleLayerProperty> layerProperties;
   if ( !conn->supportedLayers( layerProperties, mSchema, QgsOracleConn::geometryColumnsOnly( mName ), QgsOracleConn::userTablesOnly( mName ), mAllowGeometrylessTables ) || layerProperties.isEmpty() )
   {
+    mError = tr( "Failed to retrieve supported layers" );
     return false;
   }
 

--- a/src/providers/oracle/qgsoraclecolumntypetask.h
+++ b/src/providers/oracle/qgsoraclecolumntypetask.h
@@ -49,7 +49,7 @@ class QgsOracleColumnTypeTask : public QgsTask
     /**
      * If the task fails, returns the error which occurred.
      */
-    const QString &error() const { return mError; }
+    QString error() const { return mError; }
 
   signals:
     void setLayerType( const QgsOracleLayerProperty &layerProperty );

--- a/src/providers/oracle/qgsoraclecolumntypetask.h
+++ b/src/providers/oracle/qgsoraclecolumntypetask.h
@@ -47,7 +47,7 @@ class QgsOracleColumnTypeTask : public QgsTask
     bool allowGeometrylessTables() const { return mAllowGeometrylessTables; }
 
     /**
-     * Returns error occurring when the task run
+     * If the task fails, returns the error which occurred.
      */
     const QString &error() const { return mError; }
 

--- a/src/providers/oracle/qgsoraclecolumntypetask.h
+++ b/src/providers/oracle/qgsoraclecolumntypetask.h
@@ -46,6 +46,11 @@ class QgsOracleColumnTypeTask : public QgsTask
     bool useEstimatedMetadata() const { return mUseEstimatedMetadata; }
     bool allowGeometrylessTables() const { return mAllowGeometrylessTables; }
 
+    /**
+     * Returns error occurring when the task run
+     */
+    const QString &error() const { return mError; }
+
   signals:
     void setLayerType( const QgsOracleLayerProperty &layerProperty );
     void progressMessage( const QString &message );
@@ -55,6 +60,7 @@ class QgsOracleColumnTypeTask : public QgsTask
 
     QString mName;
     QString mSchema;
+    QString mError;
     bool mUseEstimatedMetadata = false;
     bool mAllowGeometrylessTables = false;
     QVector<QgsOracleLayerProperty> mLayerProperties;

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -222,10 +222,35 @@ void QgsOracleConnectionItem::taskFinished()
 {
   QgsDebugMsgLevel( u"Entering."_s, 3 );
 
-  if ( mColumnTypeTask->status() == QgsTask::Complete )
-    setAllAsPopulated();
-  else
-    setState( Qgis::BrowserItemState::NotPopulated );
+  switch ( mColumnTypeTask->status() )
+  {
+    case QgsTask::Terminated:
+    {
+      if ( mColumnTypeTask->error().isEmpty() )
+      {
+        // task canceled
+        setState( Qgis::BrowserItemState::NotPopulated );
+      }
+      else
+      {
+        // an error occurred
+        addChildItem( new QgsErrorItem( this, mColumnTypeTask->error(), mPath + "/error" ), true );
+        setAllAsPopulated();
+      }
+      break;
+    }
+
+    case QgsTask::Complete:
+      setIcon( QIcon() );
+      setAllAsPopulated();
+      break;
+
+    case QgsTask::Queued:
+    case QgsTask::OnHold:
+    case QgsTask::Running:
+      QgsDebugError( "Invalid task state" );
+      break;
+  }
 
   mColumnTypeTask = nullptr;
 }

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -241,7 +241,6 @@ void QgsOracleConnectionItem::taskFinished()
     }
 
     case QgsTask::Complete:
-      setIcon( QIcon() );
       setAllAsPopulated();
       break;
 


### PR DESCRIPTION
## Description

This is a partial fix of #58303, works for Oracle only! If we agree on the way to solve it, I'll try top apply the same logic to other providers. 

This PR propose to set browser data item as populated when an error occurs. If we consider it not populated, everytime a sibling will be refreshed or unfolded, QgsBrowserModel::fetchMore() would be called to load every siblings, even the one in error, leading to display an error and eventually to open the connexion dialog (if the last error was 30 seconds later).

It adds also an error item to properly disclose the situation.

<img width="1223" height="835" alt="oracleconn_error" src="https://github.com/user-attachments/assets/29308e8c-b7b0-4b2f-945a-8a04d3503b1e" />



## AI tool usage

None
