### PR TITLE
Fix QgsLineString SIP code constructing invalid QgsVertexId

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
@@ -546,9 +546,9 @@ point in the line.
 %MethodCode
     const int count = sipCpp->numPoints();
     if ( a0 >= 0 && a0 < count )
-      sipCpp->deleteVertex( QgsVertexId( -1, -1, a0 ) );
+      sipCpp->deleteVertex( QgsVertexId( 0, 0, a0 ) );
     else if ( a0 < 0 && a0 >= -count )
-      sipCpp->deleteVertex( QgsVertexId( -1, -1, count + a0 ) );
+      sipCpp->deleteVertex( QgsVertexId( 0, 0, count + a0 ) );
     else
     {
       PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -592,9 +592,9 @@ class CORE_EXPORT QgsLineString : public QgsSimpleCurve
     % MethodCode
     const int count = sipCpp->numPoints();
     if ( a0 >= 0 && a0 < count )
-      sipCpp->deleteVertex( QgsVertexId( -1, -1, a0 ) );
+      sipCpp->deleteVertex( QgsVertexId( 0, 0, a0 ) );
     else if ( a0 < 0 && a0 >= -count )
-      sipCpp->deleteVertex( QgsVertexId( -1, -1, count + a0 ) );
+      sipCpp->deleteVertex( QgsVertexId( 0, 0, count + a0 ) );
     else
     {
       PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );


### PR DESCRIPTION
Fixes before `deleteVertex` could be removed.

Constructing a `linestring` and calling `del linestring[0]` would call `deleteVertex(0)` on that `linestring`, as introduced in #8542
However, in SIP code, `QgsVertexId` is constructed with both part and ring elements having -1 as values.

Since `deleteVertices` verifies if it actually contains passed vertices before deleting them (check `QgsAbstractGeometry::hasVertex` method), we need to correct this for the part and ring elements to be 0. Valid, in other words.

This doesn’t affect the current code, but will when `deleteVertex` is removed/starts calling `deleteVertices`.

No AI used.