### PR TITLE
Fix deletion of first/last point in CompoundCurve rings of a Polygon

### DIFF
--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -1350,10 +1350,45 @@ bool QgsCurvePolygon::deleteVertices( const QSet<QgsVertexId> &positions )
       continue;
     }
 
+    // we cannot make assumptions what happens in deleteVertices() of curves
+    // circularstring can be at the end or start of the compoundcurve, and when its point is deleted, whole arc is deleted, not just that point
+    // let deleteVertices() handle that and then we check if the points are not the same and just sync them
+    if ( QgsWkbTypes::flatType( ring->wkbType() ) == Qgis::WkbType::CompoundCurve )
+    {
+      if ( firstVertexId.vertex == 0 && !vertices.contains( QgsVertexId( 0, 0, n - 1 ) ) )
+      {
+        vertices.emplace_back( 0, 0, n - 1 );
+      }
+      else if ( lastVertexId.vertex == n - 1 && !vertices.contains( QgsVertexId( 0, 0, 0 ) ) )
+      {
+        vertices.emplace_back( 0, 0, 0 );
+      }
+    }
+
     if ( !ring->deleteVertices( QSet<QgsVertexId>( vertices.begin(), vertices.end() ) ) )
     {
       Q_ASSERT( false );
       return false;
+    }
+
+    // safety check
+    // consider a compoundcurve with 2 circularstrings and we are deleting first/last point
+    // in such case, we are removing the whole geometry in that operation
+    if ( ring->numPoints() == 0 )
+    {
+      if ( ringId == 0 )
+      {
+        mExteriorRing.reset();
+        if ( !mInteriorRings.isEmpty() )
+        {
+          mExteriorRing.reset( mInteriorRings.takeFirst() );
+        }
+      }
+      else
+      {
+        removeInteriorRing( ringId - 1 );
+      }
+      continue;
     }
 
     // in case of a compound curve, first/last vertex may have been deleted even if not specified

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -863,6 +863,22 @@ void QgsCurvePolygon::removeInteriorRings( double minimumAllowedArea )
   clearCache();
 }
 
+void QgsCurvePolygon::removeRing( int ringId )
+{
+  if ( ringId == 0 )
+  {
+    mExteriorRing.reset();
+    if ( !mInteriorRings.isEmpty() )
+    {
+      mExteriorRing.reset( mInteriorRings.takeFirst() );
+    }
+  }
+  else
+  {
+    removeInteriorRing( ringId - 1 );
+  }
+}
+
 void QgsCurvePolygon::removeInvalidRings()
 {
   QVector<QgsCurve *> validRings;
@@ -1335,18 +1351,7 @@ bool QgsCurvePolygon::deleteVertices( const QSet<QgsVertexId> &positions )
     if ( vertices.size() > n - 4 )
     {
       // no points will be left in ring, so remove whole ring
-      if ( ringId == 0 )
-      {
-        mExteriorRing.reset();
-        if ( !mInteriorRings.isEmpty() )
-        {
-          mExteriorRing.reset( mInteriorRings.takeFirst() );
-        }
-      }
-      else
-      {
-        removeInteriorRing( ringId - 1 );
-      }
+      removeRing( ringId );
       continue;
     }
 
@@ -1376,18 +1381,7 @@ bool QgsCurvePolygon::deleteVertices( const QSet<QgsVertexId> &positions )
     // in such case, we are removing the whole geometry in that operation
     if ( ring->numPoints() == 0 )
     {
-      if ( ringId == 0 )
-      {
-        mExteriorRing.reset();
-        if ( !mInteriorRings.isEmpty() )
-        {
-          mExteriorRing.reset( mInteriorRings.takeFirst() );
-        }
-      }
-      else
-      {
-        removeInteriorRing( ringId - 1 );
-      }
+      removeRing( ringId );
       continue;
     }
 

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -96,6 +96,15 @@ class CORE_EXPORT QgsCurvePolygon : public QgsSurface
 
       return true;
     }
+
+    /**
+     * Removes the ring with the specified \a ringId
+     *
+     * If \a ringId is 0 the exterior ring is removed, promoting the first
+     * interior ring (if any) to be the new exterior ring. Otherwise the
+     * interior ring at index \a ringId - 1 is removed.
+     */
+    void removeRing( int ringId );
 #endif
   public:
     // clang-format off

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -3359,7 +3359,7 @@ class TestQgsGeometry(QgisTestCase):
 
         curvepolygon = QgsGeometry.fromWkt(curvepolygonwkt)
         assert curvepolygon.deleteVertices([0]), "Delete vertices [0] failed"
-        expwkt = "CurvePolygon( CompoundCurve( CircularString(2 0, 1.5 -0.5, 1 -1), (1 -1, 0 0, 2 0) ) )"
+        expwkt = "CurvePolygon( CompoundCurve( CircularString(2 0, 1.5 -0.5, 1 -1), (1 -1, 2 0) ) )"
         wkt = curvepolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -3371,7 +3371,7 @@ class TestQgsGeometry(QgisTestCase):
 
         curvepolygon = QgsGeometry.fromWkt(curvepolygonwkt)
         assert curvepolygon.deleteVertices([0, 1]), "Delete vertices [0, 1] failed"
-        expwkt = "CurvePolygon( CompoundCurve( CircularString (2 0, 1.5 -0.5, 1 -1), (1 -1, 0 0, 2 0)))"
+        expwkt = "CurvePolygon( CompoundCurve( CircularString (2 0, 1.5 -0.5, 1 -1), (1 -1, 2 0)))"
         wkt = curvepolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -3426,7 +3426,7 @@ class TestQgsGeometry(QgisTestCase):
         assert curvepolygon.deleteVertices([0, 1, 2, 3, 4]), (
             "Delete vertices [0, 1, 2, 3, 4] failed"
         )
-        expwkt = "CurvePolygon (CompoundCurve ((14 20, 19 25),CircularString (19 25, 22 28, 25 25, 28 22, 25 19),(25 19, 20 14, 25 9),CircularString (25 9, 28 6, 25 3, 22 0, 19 3),(19 3, 14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 8 14, 3 19, 14 20)))"
+        expwkt = "CurvePolygon (CompoundCurve ((14 20, 19 25),CircularString (19 25, 22 28, 25 25, 28 22, 25 19),(25 19, 20 14, 25 9),CircularString (25 9, 28 6, 25 3, 22 0, 19 3),(19 3, 14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 8 14, 14 20)))"
         wkt = curvepolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -3435,7 +3435,7 @@ class TestQgsGeometry(QgisTestCase):
         assert curvepolygon.deleteVertices([0, 1, 2, 3, 4, 12, 13, 14, 15, 16]), (
             "Delete vertices [0, 1, 2, 3, 4, 12, 13, 14, 15, 16] failed"
         )
-        expwkt = "CurvePolygon (CompoundCurve ((14 20, 19 25),CircularString (19 25, 22 28, 25 25, 28 22, 25 19),(25 19, 20 14, 14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 8 14, 3 19, 14 20)))"
+        expwkt = "CurvePolygon (CompoundCurve ((14 20, 19 25),CircularString (19 25, 22 28, 25 25, 28 22, 25 19),(25 19, 20 14, 14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 8 14, 14 20)))"
         wkt = curvepolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -3446,7 +3446,7 @@ class TestQgsGeometry(QgisTestCase):
         ), (
             "Delete vertices [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] failed"
         )
-        expwkt = "CurvePolygon (CompoundCurve ((14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 8 14, 3 19, 14 8)))"
+        expwkt = "CurvePolygon (CompoundCurve ((14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 8 14, 14 8)))"
         wkt = curvepolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -3455,7 +3455,7 @@ class TestQgsGeometry(QgisTestCase):
         assert curvepolygon.deleteVertices(
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
         ), "Delete vertices [0, 1, 2, 3, 4, 12, 13, 14, 15, 16] failed"
-        expwkt = "CurvePolygon (CompoundCurve ((14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 8 14, 3 19, 14 8)))"
+        expwkt = "CurvePolygon (CompoundCurve ((14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 8 14, 14 8)))"
         wkt = curvepolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -3481,7 +3481,7 @@ class TestQgsGeometry(QgisTestCase):
         # circularstrings should not merge, but be joined with a line connecting the start/end points
         curvepolygon = QgsGeometry.fromWkt(curvepolygonwkt)
         assert curvepolygon.deleteVertices([24, 23]), "Delete vertices [24, 23] failed"
-        expwkt = "CurvePolygon (CompoundCurve (CircularString (3 19, 0 22, 3 25, 6 28, 9 25),(9 25, 14 20, 19 25),CircularString (19 25, 22 28, 25 25, 28 22, 25 19),(25 19, 20 14, 25 9),CircularString (25 9, 28 6, 25 3, 22 0, 19 3),(19 3, 14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 3 19)))"
+        expwkt = "CurvePolygon (CompoundCurve (CircularString (3 25, 6 28, 9 25),(9 25, 14 20, 19 25),CircularString (19 25, 22 28, 25 25, 28 22, 25 19),(25 19, 20 14, 25 9),CircularString (25 9, 28 6, 25 3, 22 0, 19 3),(19 3, 14 8, 9 3),CircularString (9 3, 6 0, 3 3, 0 6, 3 9),(3 9, 3 25)))"
         wkt = curvepolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 


### PR DESCRIPTION
<img width="1050" height="887" alt="Screenshot_20260628_203046" src="https://github.com/user-attachments/assets/1fcb51e7-865f-4117-b891-ff8b54cfc5f7" />

(red shows the full geometry and selected points are the points which `deleteVertices()` receives, yellow is the current broken state, where that point survives, green is the corrected state from changes in this PR)

If this was a plain `CompoundCurve` and not a ring of a `CurvePolygon`, test cases and the behavior would be correct.
When a user sets to delete the first or the last point of a `Polygon` geometry, we should actually be clearing two points (first and the last, as they are the same point in Polygons).

We already do that when a Polygon has “normal” `LineString` rings, but for the case of `CompoundCurve` rings, we explicitly add the first/last vertex as well, so that we are always deleting both first and the last point in it.

Note that this does not affect the `Vertex Tool`, this change only concerns those using the API calling `deleteVertices( [ 0 ] )` or `deleteVertices( [ noOfPoints – 1 ] )`.

No AI used.