### PR TITLE
Fix topocentric filtering logic, remove "no projection" form the base CRS combobox

### DIFF
--- a/src/gui/proj/qgsprojectionselectiondialog.cpp
+++ b/src/gui/proj/qgsprojectionselectiondialog.cpp
@@ -234,8 +234,7 @@ bool QgsCrsSelectionWidget::hasValidSelection() const
       case QgsCrsSelectionWidget::CrsType::Topocentric:
       {
         const QgsCoordinateReferenceSystem baseCrs = mTopocentricBaseSelector->crs();
-        double tmpLat = 0.0, tmpLon = 0.0;
-        return baseCrs.isValid() && ( baseCrs.horizontalCrs().type() == Qgis::CrsType::Geocentric || baseCrs.type() == Qgis::CrsType::Geographic3d || baseCrs.topocentricOrigin( tmpLat, tmpLon ) );
+        return baseCrs.isValid();
       }
     }
     BUILTIN_UNREACHABLE
@@ -280,10 +279,6 @@ QgsCoordinateReferenceSystem QgsCrsSelectionWidget::crs() const
       case QgsCrsSelectionWidget::CrsType::Topocentric:
       {
         const QgsCoordinateReferenceSystem base = mTopocentricBaseSelector->crs();
-        double tmpLat = 0.0, tmpLon = 0.0;
-        const bool canConvert = base.horizontalCrs().type() == Qgis::CrsType::Geocentric || base.type() == Qgis::CrsType::Geographic3d || base.topocentricOrigin( tmpLat, tmpLon );
-        if ( !base.isValid() || !canConvert )
-          return QgsCoordinateReferenceSystem(); // we shouldn't be reaching this through the GUI
         return base.toTopocentricCrs( mSpinBoxTopoLat->value(), mSpinBoxTopoLon->value() );
       }
     }

--- a/src/gui/proj/qgsprojectionselectionwidget.cpp
+++ b/src/gui/proj/qgsprojectionselectionwidget.cpp
@@ -346,6 +346,9 @@ bool CombinedCoordinateReferenceSystemsProxyModel::filterAcceptsRow( int sourceR
           return crs.isValid();
 
         case QgsProjectionSelectionWidget::CurrentCrs:
+          // prevent adding "no projection"/invalid entry in the base crs widget of topocentric crs
+          if ( mFilters.testFlag( QgsCoordinateReferenceSystemProxyModel::FilterTopocentricCompatible ) )
+            return crs.isValid();
           // hide invalid current CRS value option only if "not set" option is shown
           return crs.isValid() || !mVisibleOptions.testFlag( QgsProjectionSelectionWidget::CrsNotSet );
 


### PR DESCRIPTION
Remove unnecessary filtering logic (leftover from the first test implementations), and just let the widget, which is filtered for only topocentricCompatible CRSes handle that.

Second fix is to avoid adding "no projection" entry when we first select the Topocentric CRS from the combobox. Topocentric CRS wouldn't have been created either way, but we keep the widget "cleaner".

No AI used.