### PR TITLE
Fix raster bin count with float

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2088,9 +2088,6 @@ QgsRasterHistogram QgsGdalProvider::histogram(
   }
 
   const double myScale { bandScale( bandNo ) };
-  // Adjust bin count according to scale
-  // Fix issue GH #59461
-  myHistogram.binCount = static_cast<int>( myHistogram.binCount * myScale );
 
   if ( ( sourceHasNoDataValue( bandNo ) && !useSourceNoDataValue( bandNo ) ) || !userNoDataValues( bandNo ).isEmpty() )
   {

--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -355,24 +355,35 @@ void QgsRasterInterface::initHistogram( QgsRasterHistogram &histogram, int bandN
       // There is no best default value, to display something reasonable in histogram chart,
       // binCount should be small, OTOH, to get precise data for cumulative cut, the number should be big.
       // Because it is easier to define fixed lower value for the chart, we calc optimum binCount
-      // for higher resolution (to avoid calculating that where histogram() is used. In any case,
-      // it does not make sense to use more than width*height;
+      // for higher resolution (to avoid calculating that where histogram() is used.
 
       // for Int16/Int32 make sure bin count <= actual range, because there is no sense in having
       // bins at fractional values
       if ( !mInput && ( mySrcDataType == Qgis::DataType::Int16 || mySrcDataType == Qgis::DataType::Int32 || mySrcDataType == Qgis::DataType::UInt16 || mySrcDataType == Qgis::DataType::UInt32 ) )
       {
-        myBinCount = std::min( static_cast<qint64>( histogram.width ) * histogram.height, static_cast<qint64>( std::ceil( histogram.maximum - histogram.minimum + 1 ) ) );
+        myBinCount = static_cast<qint64>( std::ceil( histogram.maximum - histogram.minimum + 1 ) );
       }
       else
       {
         // This is for not integer types
-        myBinCount = static_cast<qint64>( histogram.width ) * static_cast<qint64>( histogram.height );
+        const QgsRasterBandStats stats = bandStatistics( bandNo, Qgis::RasterBandStatistic::StdDev | Qgis::RasterBandStatistic::Range, boundingBox, sampleSize );
+        // If stats are not available or stdDev is 0, use width*height as binCount
+        // but this could lead to binCount being too large
+        if ( stats.statsGathered.testFlags( Qgis::RasterBandStatistic::StdDev | Qgis::RasterBandStatistic::Range ) )
+        {
+          // Use Scott's Rule to determine bin count: binCount = 3.49 * stdDev / n^(1/3)
+          myBinCount = static_cast<qint64>( stats.range / ( 3.49 * stats.stdDev / std::pow( sampleSize > 0 ? sampleSize : static_cast<double>( histogram.width ) * histogram.height, 1.0 / 3.0 ) ) );
+        }
+        else
+        {
+          // Fallback using the whole histogram size
+          myBinCount = static_cast<qint64>( histogram.width ) * static_cast<qint64>( histogram.height );
+        }
       }
     }
   }
-  // Hard limit 10'000'000
-  histogram.binCount = static_cast<int>( std::min( 10000000LL, myBinCount ) );
+  // Hard limit 10'000'000 and in any case it does not make sense to use more than width*height
+  histogram.binCount = static_cast<int>( std::min( std::min( 10000000LL, static_cast<qint64>( histogram.width ) * histogram.height ), myBinCount ) );
   QgsDebugMsgLevel( u"theHistogram.binCount = %1"_s.arg( histogram.binCount ), 4 );
 }
 

--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -372,7 +372,10 @@ void QgsRasterInterface::initHistogram( QgsRasterHistogram &histogram, int bandN
         if ( stats.statsGathered.testFlags( Qgis::RasterBandStatistic::StdDev | Qgis::RasterBandStatistic::Range ) )
         {
           // Use Scott's Rule to determine bin count: binCount = 3.49 * stdDev / n^(1/3)
-          myBinCount = static_cast<qint64>( stats.range / ( 3.49 * stats.stdDev / std::pow( sampleSize > 0 ? sampleSize : static_cast<double>( histogram.width ) * histogram.height, 1.0 / 3.0 ) ) );
+          // In standard C++ (prior to C++26), std::sqrt is not a constexpr function,
+          // so we precompute the constant value  24 * sqrt( M_PI ) = 42.538892421732385
+          constexpr double SCOTTS_COEFFICIENT = 42.538892421732385;
+          myBinCount = static_cast<qint64>( stats.range / ( stats.stdDev * std::cbrt( SCOTTS_COEFFICIENT / ( sampleSize > 0 ? sampleSize : static_cast<double>( histogram.width ) * histogram.height ) ) ) );
         }
         else
         {

--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -361,7 +361,7 @@ void QgsRasterInterface::initHistogram( QgsRasterHistogram &histogram, int bandN
       // bins at fractional values
       if ( !mInput && ( mySrcDataType == Qgis::DataType::Int16 || mySrcDataType == Qgis::DataType::Int32 || mySrcDataType == Qgis::DataType::UInt16 || mySrcDataType == Qgis::DataType::UInt32 ) )
       {
-        myBinCount = static_cast<qint64>( std::ceil( histogram.maximum - histogram.minimum + 1 ) );
+        myBinCount = std::min( static_cast<qint64>( histogram.width ) * histogram.height, static_cast<qint64>( std::ceil( histogram.maximum - histogram.minimum + 1 ) ) );
       }
       else
       {
@@ -385,8 +385,8 @@ void QgsRasterInterface::initHistogram( QgsRasterHistogram &histogram, int bandN
       }
     }
   }
-  // Hard limit 10'000'000 and in any case it does not make sense to use more than width*height
-  histogram.binCount = static_cast<int>( std::min( std::min( 10000000LL, static_cast<qint64>( histogram.width ) * histogram.height ), myBinCount ) );
+  // Hard limit 10'000'000
+  histogram.binCount = static_cast<int>( std::min( 10000000LL, myBinCount ) );
   QgsDebugMsgLevel( u"theHistogram.binCount = %1"_s.arg( histogram.binCount ), 4 );
 }
 

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -599,28 +599,63 @@ class PyQgsGdalProvider(QgisTestCase, RasterProviderTestCase):
     def testHistogramBinCountWithScale(self):
         """Test issue GH #59461"""
 
-        # Create raster with 2x2 pixels, int type, values 0-10000, scale 0.001
         tmp_dir = QTemporaryDir()
-        tmpfile = os.path.join(tmp_dir.path(), "testBinCountWithScale.tif")
-        ds = gdal.GetDriverByName("GTiff").Create(tmpfile, 2, 2, 1, gdal.GDT_Int32)
-        ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
-        ds.SetProjection("EPSG:4326")
-        ds.WriteRaster(0, 0, 2, 2, struct.pack("i" * 4, 0, 5000, 10000, -10000))
-        # Set band scale
-        band = ds.GetRasterBand(1)
-        band.SetScale(0.001)
-        ds = None
-        rl = QgsRasterLayer(tmpfile, "test")
-        self.assertTrue(rl.isValid())
-        provider = rl.dataProvider()
-        # Data type is changed by QGIS because of the scale
-        self.assertEqual(provider.dataType(1), Qgis.DataType.Float32)
-        self.assertEqual(provider.bandScale(1), 0.001)
 
-        # Create histogram
-        hist = provider.histogram(1, 10000)
-        self.assertIsNotNone(hist)
-        self.assertEqual(hist.binCount, 10)
+        def _test_scale(scale):
+
+            # Test float pixels to make sure we trigger Scott's formula for bin count
+            tmpfile = os.path.join(tmp_dir.path(), "testBinCountWithScaleFloat.tif")
+            ds = gdal.GetDriverByName("GTiff").Create(
+                tmpfile, 10, 10, 1, gdal.GDT_Float32
+            )
+            ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+            ds.SetProjection("EPSG:4326")
+            # Fill with stripes 1 to 10
+            for i in range(10):
+                ds.WriteRaster(0, i, 10, 1, struct.pack("f" * 10, *([i + 1] * 10)))
+            # Set band scale
+            band = ds.GetRasterBand(1)
+            band.SetScale(scale)
+            ds = None
+
+            rl = QgsRasterLayer(tmpfile, "test")
+            self.assertTrue(rl.isValid())
+            provider = rl.dataProvider()
+            # Data type is changed by QGIS because of the scale
+            self.assertEqual(provider.dataType(1), Qgis.DataType.Float32)
+
+            # Create histogram
+            hist = provider.histogram(1)
+            self.assertIsNotNone(hist)
+            self.assertEqual(hist.binCount, 4)
+
+            # Create raster with 2x2 pixels, int type, values 0-10000, scale 0.001
+            tmpfile = os.path.join(tmp_dir.path(), "testBinCountWithScale.tif")
+            ds = gdal.GetDriverByName("GTiff").Create(tmpfile, 2, 2, 1, gdal.GDT_Int32)
+            ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+            ds.SetProjection("EPSG:4326")
+            ds.WriteRaster(0, 0, 2, 2, struct.pack("i" * 4, 0, 5000, 10000, -10000))
+            # Set band scale
+            band = ds.GetRasterBand(1)
+            band.SetScale(scale)
+            ds = None
+            rl = QgsRasterLayer(tmpfile, "test")
+            self.assertTrue(rl.isValid())
+            provider = rl.dataProvider()
+            # Data type is changed by QGIS because of the scale
+            if scale != 1.0:
+                self.assertEqual(provider.dataType(1), Qgis.DataType.Float32)
+
+            # Create histogram
+            hist = provider.histogram(1, 10000)
+            self.assertIsNotNone(hist)
+            # Do not exceed the raster size!
+            self.assertEqual(hist.binCount, 4)
+
+        _test_scale(1.0)
+        _test_scale(0.1)
+        _test_scale(0.01)
+        _test_scale(0.001)
 
     def test_GMF_PER_DATASET_mask_band(self):
         """Test issue GH #64642 - rasters with a GMF_PER_DATASET mask band"""

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -647,10 +647,11 @@ class PyQgsGdalProvider(QgisTestCase, RasterProviderTestCase):
                 self.assertEqual(provider.dataType(1), Qgis.DataType.Float32)
 
             # Create histogram
-            hist = provider.histogram(1, 10000)
+            hist = provider.histogram(1, 5)
             self.assertIsNotNone(hist)
-            # Do not exceed the raster size!
-            self.assertEqual(hist.binCount, 4)
+            # Test requested bin count is respected, even
+            # if it's bigger than the number of pixels
+            self.assertEqual(hist.binCount, 5)
 
         _test_scale(1.0)
         _test_scale(0.1)


### PR DESCRIPTION
Fix #65920 by reverting #63294 (which fixed #59461) and introducing Scott's formula for bin count in case of float rasters.

Also, whatever code path is taken, we now make sure the bin count never exceeds the histogram raster size.

This should fix #59461 without regressing in #65920.

