### PR TITLE
Handle missing optional STAC collection and asset titles

### DIFF
--- a/src/gui/stac/qgsstacsearchparametersdialog.cpp
+++ b/src/gui/stac/qgsstacsearchparametersdialog.cpp
@@ -193,7 +193,8 @@ void QgsStacSearchParametersDialog::appendCollections( const QVector<QgsStacColl
   {
     descr.setMarkdown( c->description() );
 
-    QStandardItem *i = new QStandardItem( c->title() );
+    // While title() is more human readable, it is not required by the stac spec, so if missing we fall back to using id()
+    QStandardItem *i = new QStandardItem( c->title().isEmpty() ? c->id() : c->title() );
     i->setData( c->id(), Qt::UserRole );
     i->setData( descr.toHtml(), Qt::ToolTipRole );
     i->setCheckable( true );

--- a/src/gui/stac/qgsstacsourceselect.cpp
+++ b/src/gui/stac/qgsstacsourceselect.cpp
@@ -524,7 +524,7 @@ void QgsStacSourceSelect::showItemsContextMenu( QPoint point )
     {
       if ( asset.isCloudOptimized() )
       {
-        QAction *loadAssetAction = new QAction( asset.title(), assetsMenu );
+        QAction *loadAssetAction = new QAction( asset.title().isEmpty() ? QUrl( asset.href() ).fileName() : asset.title(), assetsMenu );
         connect( loadAssetAction, &QAction::triggered, this, [this, uri = asset.uri()] {
           QgsTemporaryCursorOverride cursorOverride( Qt::WaitCursor );
           loadUri( uri );


### PR DESCRIPTION
## Description
STAC collection `title` and asset `title` is human readable but not required by the STAC spec.
If it is not set, we fall back to `id` for collections and url filename for assets.

In other places we are already using `id` when `title` are not available

Fixes #66588

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
