### PR TITLE
"fix" every entry in relation reference widget is shown in italic

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsfeaturefiltermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturefiltermodel.sip.in
@@ -15,6 +15,11 @@ class QgsFeatureFilterModel : QgsFeaturePickerModelBase
 Provides a list of features based on filter conditions.
 
 Features are fetched asynchronously.
+
+Entries are identified by the values of one or more identifier fields
+(e.g. to store a foreign key in a relation reference widget). To
+identify features by their feature id instead, use
+:py:class:`QgsFeaturePickerModel`.
 %End
 
 %TypeHeaderCode

--- a/python/PyQt6/core/auto_generated/qgsfeaturepickermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturepickermodel.sip.in
@@ -14,6 +14,10 @@ class QgsFeaturePickerModel : QgsFeaturePickerModelBase
 Provides a list of features based on filter conditions.
 
 Features are fetched asynchronously.
+
+Entries are identified by their feature id. To identify features by
+attribute values (e.g. a foreign key) instead, use
+:py:class:`QgsFeatureFilterModel`.
 %End
 
 %TypeHeaderCode

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -80,7 +80,7 @@ QSet<QString> QgsFeatureFilterModel::requestedAttributes() const
 
 QVariant QgsFeatureFilterModel::entryIdentifier( const QgsFeatureExpressionValuesGatherer::Entry &entry ) const
 {
-  return entry.featureId;
+  return entry.identifierFields;
 }
 
 QgsFeatureExpressionValuesGatherer::Entry QgsFeatureFilterModel::createEntry( const QVariant &identifier ) const

--- a/src/core/qgsfeaturefiltermodel.h
+++ b/src/core/qgsfeaturefiltermodel.h
@@ -25,6 +25,10 @@ class QgsSettingsEntryInteger;
  * \brief Provides a list of features based on filter conditions.
  *
  * Features are fetched asynchronously.
+ *
+ * Entries are identified by the values of one or more identifier fields
+ * (e.g. to store a foreign key in a relation reference widget).
+ * To identify features by their feature id instead, use QgsFeaturePickerModel.
  */
 class CORE_EXPORT QgsFeatureFilterModel : public QgsFeaturePickerModelBase
 {

--- a/src/core/qgsfeaturepickermodel.cpp
+++ b/src/core/qgsfeaturepickermodel.cpp
@@ -42,7 +42,7 @@ void QgsFeaturePickerModel::requestToReloadCurrentFeature( QgsFeatureRequest &re
 
 QVariant QgsFeaturePickerModel::entryIdentifier( const QgsFeatureExpressionValuesGatherer::Entry &entry ) const
 {
-  return entry.identifierFields;
+  return entry.featureId;
 }
 
 QgsFeatureExpressionValuesGatherer::Entry QgsFeaturePickerModel::createEntry( const QVariant &identifier ) const

--- a/src/core/qgsfeaturepickermodel.h
+++ b/src/core/qgsfeaturepickermodel.h
@@ -26,6 +26,10 @@
  * \brief Provides a list of features based on filter conditions.
  *
  * Features are fetched asynchronously.
+ *
+ * Entries are identified by their feature id.
+ * To identify features by attribute values (e.g. a foreign key) instead,
+ * use QgsFeatureFilterModel.
  */
 class CORE_EXPORT QgsFeaturePickerModel : public QgsFeaturePickerModelBase
 {

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -220,6 +220,9 @@ QVariant QgsFeaturePickerModelBase::data( const QModelIndex &index, int role ) c
     case Qt::DecorationRole:
     case Qt::FontRole:
     {
+      // this code is completely broken -- identifierIsNull will always return true for QgsFeatureFilterModel,
+      // and the fix is not trivial. Just disable the broken formatting for now.
+#if 0
       const bool isNull = identifierIsNull( entryIdentifier( mEntries.value( index.row() ) ) );
       if ( isNull )
       {
@@ -239,6 +242,7 @@ QVariant QgsFeaturePickerModelBase::data( const QModelIndex &index, int role ) c
         }
       }
       else
+#endif
       {
         // Respect conditional style
         const QgsConditionalStyle style = featureStyle( mEntries.value( index.row() ).feature );

--- a/src/core/qgsfeaturepickermodelbase.cpp
+++ b/src/core/qgsfeaturepickermodelbase.cpp
@@ -220,9 +220,6 @@ QVariant QgsFeaturePickerModelBase::data( const QModelIndex &index, int role ) c
     case Qt::DecorationRole:
     case Qt::FontRole:
     {
-      // this code is completely broken -- identifierIsNull will always return true for QgsFeatureFilterModel,
-      // and the fix is not trivial. Just disable the broken formatting for now.
-#if 0
       const bool isNull = identifierIsNull( entryIdentifier( mEntries.value( index.row() ) ) );
       if ( isNull )
       {
@@ -242,7 +239,6 @@ QVariant QgsFeaturePickerModelBase::data( const QModelIndex &index, int role ) c
         }
       }
       else
-#endif
       {
         // Respect conditional style
         const QgsConditionalStyle style = featureStyle( mEntries.value( index.row() ).feature );

--- a/tests/src/gui/testqgsfeaturelistcombobox.cpp
+++ b/tests/src/gui/testqgsfeaturelistcombobox.cpp
@@ -24,6 +24,7 @@
 #include "qgstest.h"
 #include "qgsvectorlayer.h"
 
+#include <QBrush>
 #include <QLineEdit>
 #include <QSignalSpy>
 #include <QString>
@@ -328,23 +329,32 @@ void TestQgsFeatureListComboBox::testNullFormatting()
 
   layer->commitChanges();
 
-  QSignalSpy spy( cb.get(), &QgsFeatureListComboBox::identifierValueChanged );
+  QgsApplication::setNullRepresentation( u"nope"_s );
+
+  QgsFeatureFilterModel *model = qobject_cast<QgsFeatureFilterModel *>( cb->model() );
+  QSignalSpy spy( model, &QgsFeatureFilterModel::filterJobCompleted );
 
   cb->setAllowNull( true );
   cb->setSourceLayer( layer.get() );
+  cb->setIdentifierFields( { u"pk"_s } );
   cb->setDisplayExpression( u"\"material\""_s );
 
   //check if everything is fine:
   spy.wait();
 
-  QgsFeatureFilterModel *model = qobject_cast<QgsFeatureFilterModel *>( cb->model() );
-  QCOMPARE( model->data( model->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), u"nope"_s );
+  QCOMPARE( model->rowCount( QModelIndex() ), 3 );
 
-  // should not be italic formatted, these aren't null entries
+  // the null entry should be formatted as null (gray)
+  QCOMPARE( model->data( model->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), u"nope"_s );
+  QCOMPARE( model->data( model->index( 0, 0, QModelIndex() ), Qt::ForegroundRole ).value<QBrush>().color(), QColor( Qt::gray ) );
+
+  // real features must not be formatted as null, even if their display value is NULL
   QCOMPARE( model->data( model->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), QString() );
-  QVERIFY( !model->data( model->index( 1, 0, QModelIndex() ), Qt::FontRole ).value< QFont >().italic() );
+  QVERIFY( !model->data( model->index( 1, 0, QModelIndex() ), Qt::FontRole ).value<QFont>().italic() );
+  QVERIFY( !model->data( model->index( 1, 0, QModelIndex() ), Qt::ForegroundRole ).isValid() );
   QCOMPARE( model->data( model->index( 2, 0, QModelIndex() ), Qt::DisplayRole ).toString(), u"iron"_s );
-  QVERIFY( !model->data( model->index( 2, 0, QModelIndex() ), Qt::FontRole ).value< QFont >().italic() );
+  QVERIFY( !model->data( model->index( 2, 0, QModelIndex() ), Qt::FontRole ).value<QFont>().italic() );
+  QVERIFY( !model->data( model->index( 2, 0, QModelIndex() ), Qt::ForegroundRole ).isValid() );
 }
 
 QGSTEST_MAIN( TestQgsFeatureListComboBox )

--- a/tests/src/gui/testqgsfeaturelistcombobox.cpp
+++ b/tests/src/gui/testqgsfeaturelistcombobox.cpp
@@ -53,6 +53,7 @@ class TestQgsFeatureListComboBox : public QObject
     void nullRepresentation();
     void testNotExistingYetFeature();
     void testFeatureFurtherThanFetchLimit();
+    void testNullFormatting();
 
   private:
     std::unique_ptr<QgsVectorLayer> mLayer;
@@ -305,6 +306,45 @@ void TestQgsFeatureListComboBox::testFeatureFurtherThanFetchLimit()
   QCOMPARE( cb->lineEdit()->text(), u"33"_s );
   QCOMPARE( model->mEntries.count(), 21 );
   QCOMPARE( model->mEntries.at( 0 ).identifierFields.at( 0 ).toInt(), 33 );
+}
+
+void TestQgsFeatureListComboBox::testNullFormatting()
+{
+  auto cb = std::make_unique<QgsFeatureListComboBox>();
+
+  auto layer = std::make_unique<QgsVectorLayer>( u"LineString?field=pk:int&field=material:string"_s, u"vl2"_s, u"memory"_s );
+  layer->setDisplayExpression( u"pk"_s );
+  layer->startEditing();
+
+  QgsFeature ft1( layer->fields() );
+  ft1.setAttribute( u"pk"_s, 10 );
+  ft1.setAttribute( u"material"_s, "iron" );
+  layer->addFeature( ft1 );
+
+  QgsFeature ft2( layer->fields() );
+  ft2.setAttribute( u"pk"_s, 20 );
+  ft2.setAttribute( u"material"_s, QVariant() );
+  layer->addFeature( ft2 );
+
+  layer->commitChanges();
+
+  QSignalSpy spy( cb.get(), &QgsFeatureListComboBox::identifierValueChanged );
+
+  cb->setAllowNull( true );
+  cb->setSourceLayer( layer.get() );
+  cb->setDisplayExpression( u"\"material\""_s );
+
+  //check if everything is fine:
+  spy.wait();
+
+  QgsFeatureFilterModel *model = qobject_cast<QgsFeatureFilterModel *>( cb->model() );
+  QCOMPARE( model->data( model->index( 0, 0, QModelIndex() ), Qt::DisplayRole ).toString(), u"nope"_s );
+
+  // should not be italic formatted, these aren't null entries
+  QCOMPARE( model->data( model->index( 1, 0, QModelIndex() ), Qt::DisplayRole ).toString(), QString() );
+  QVERIFY( !model->data( model->index( 1, 0, QModelIndex() ), Qt::FontRole ).value< QFont >().italic() );
+  QCOMPARE( model->data( model->index( 2, 0, QModelIndex() ), Qt::DisplayRole ).toString(), u"iron"_s );
+  QVERIFY( !model->data( model->index( 2, 0, QModelIndex() ), Qt::FontRole ).value< QFont >().italic() );
 }
 
 QGSTEST_MAIN( TestQgsFeatureListComboBox )


### PR DESCRIPTION
This reveals a deeper underlying issue in QgsFeatureFilterModel. QgsFeatureFilterModel will ALWAYS return true identifierIsNull, since the values returned by its entryIdentifier override aren't lists.

This means that every entry in the QgsFeatureListComboBox is incorrectly flagged as a null value, and shown in the italic greyed out state.

If we actually fix identifierIsNull to handle non-list values, then many other tests fail, which hints that there is deeper breakage elsewhere in these classes.

Just disable the formatting for now as a result.

(The regression was likely introduced by https://github.com/qgis/QGIS/pull/31355)

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
