### PR TITLE
VertexTool: return empty when removing all vertices instead of NULL

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1488,17 +1488,7 @@ bool QgsVectorLayer::moveVertex( const QgsPoint &p, QgsFeatureId atFeatureId, in
 
 Qgis::VectorEditResult QgsVectorLayer::deleteVertex( QgsFeatureId featureId, int vertex )
 {
-  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
-
-  if ( !isValid() || !mEditBuffer || !mDataProvider )
-    return Qgis::VectorEditResult::InvalidLayer;
-
-  QgsVectorLayerEditUtils utils( this );
-  Qgis::VectorEditResult result = utils.deleteVertex( featureId, vertex );
-
-  if ( result == Qgis::VectorEditResult::Success )
-    updateExtents();
-  return result;
+  return deleteVertices( featureId, { vertex } );
 }
 
 Qgis::VectorEditResult QgsVectorLayer::deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices )

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -127,12 +127,12 @@ Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertex( QgsFeatureId featu
 
   if ( geometry.constGet() && geometry.constGet()->nCoordinates() == 0 )
   {
-    //last vertex deleted, set geometry to null
-    geometry.set( nullptr );
+    //last vertex deleted, set geometry to empty
+    geometry.set( geometry.constGet()->createEmptyWithSameType() );
   }
 
   mLayer->changeGeometry( featureId, geometry );
-  return !geometry.isNull() ? Qgis::VectorEditResult::Success : Qgis::VectorEditResult::EmptyGeometry;
+  return !geometry.isEmpty() ? Qgis::VectorEditResult::Success : Qgis::VectorEditResult::EmptyGeometry;
 }
 
 Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices )
@@ -151,12 +151,12 @@ Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertices( QgsFeatureId fea
 
   if ( geometry.constGet() && geometry.constGet()->nCoordinates() == 0 )
   {
-    // Last vertex deleted, set geometry to null
-    geometry.set( nullptr );
+    // Last vertex deleted, set geometry to empty
+    geometry.set( geometry.constGet()->createEmptyWithSameType() );
   }
 
   mLayer->changeGeometry( featureId, geometry );
-  return !geometry.isNull() ? Qgis::VectorEditResult::Success : Qgis::VectorEditResult::EmptyGeometry;
+  return !geometry.isEmpty() ? Qgis::VectorEditResult::Success : Qgis::VectorEditResult::EmptyGeometry;
 }
 
 static Qgis::GeometryOperationResult staticAddRing( QgsVectorLayer *layer, std::unique_ptr< QgsCurve > &ring, const QgsFeatureIds &targetFeatureIds, QgsFeatureIds *modifiedFeatureIds, bool firstOne = true )

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -113,26 +113,7 @@ bool QgsVectorLayerEditUtils::moveVertex( const QgsPoint &p, QgsFeatureId atFeat
 
 Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertex( QgsFeatureId featureId, int vertex )
 {
-  if ( !mLayer->isSpatial() )
-    return Qgis::VectorEditResult::InvalidLayer;
-
-  QgsFeature f;
-  if ( !mLayer->getFeatures( QgsFeatureRequest().setFilterFid( featureId ).setNoAttributes() ).nextFeature( f ) || !f.hasGeometry() )
-    return Qgis::VectorEditResult::FetchFeatureFailed; // geometry not found
-
-  QgsGeometry geometry = f.geometry();
-
-  if ( !geometry.deleteVertex( vertex ) )
-    return Qgis::VectorEditResult::EditFailed;
-
-  if ( geometry.constGet() && geometry.constGet()->nCoordinates() == 0 )
-  {
-    //last vertex deleted, set geometry to empty
-    geometry.set( geometry.constGet()->createEmptyWithSameType() );
-  }
-
-  mLayer->changeGeometry( featureId, geometry );
-  return !geometry.isEmpty() ? Qgis::VectorEditResult::Success : Qgis::VectorEditResult::EmptyGeometry;
+  return deleteVertices( featureId, { vertex } );
 }
 
 Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices )

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -1174,6 +1174,51 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
         self.assertEqual(joinLayer.featureCount(), 3)  # deleteCascade activated
         self.assertEqual(joinLayer2.featureCount(), 4)  # deleteCascade deactivated
 
+    def test_DeleteAllVertices(self):
+        """Deleting all vertices must leave an empty (not NULL) geometry.
+
+        This keeps the vertex tool consistent with the "delete part" tool,
+        which leaves an empty geometry when its last part is removed (see
+        is_empty(@geometry) vs @geometry IS NULL).
+        Fixes: https://github.com/qgis/QGIS/issues/65453
+        """
+
+        layer = QgsVectorLayer("LineString?field=f:int", "addfeat", "memory")
+        f = QgsFeature()
+        f.setAttributes([1])
+        f.setGeometry(
+            QgsGeometry.fromPolylineXY(
+                [QgsPointXY(0, 0), QgsPointXY(1, 0), QgsPointXY(2, 0)]
+            )
+        )
+        self.assertTrue(layer.dataProvider().addFeatures([f]))
+        layer.startEditing()
+        res = layer.deleteVertices(1, [0, 1, 2])
+        self.assertEqual(res, Qgis.VectorEditResult.EmptyGeometry)
+        g = layer.getGeometry(1)
+        self.assertFalse(g.isNull())
+        self.assertTrue(g.isEmpty())
+        layer.rollBack()
+
+    def test_DeleteSomeVertices(self):
+        """Deleting some vertices must leave a non empty geometry."""
+
+        layer = QgsVectorLayer("LineString?field=f:int", "addfeat", "memory")
+        f = QgsFeature()
+        f.setAttributes([1])
+        f.setGeometry(
+            QgsGeometry.fromPolylineXY(
+                [QgsPointXY(0, 0), QgsPointXY(1, 0), QgsPointXY(2, 0)]
+            )
+        )
+        self.assertTrue(layer.dataProvider().addFeatures([f]))
+        layer.startEditing()
+        res = layer.deleteVertices(1, [0])
+        self.assertEqual(res, Qgis.VectorEditResult.Success)
+        self.assertFalse(layer.getGeometry(1).isNull())
+        self.assertFalse(layer.getGeometry(1).isEmpty())
+        layer.rollBack()
+
     # CHANGE ATTRIBUTE
 
     def test_ChangeAttribute(self):

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -1219,6 +1219,25 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
         self.assertFalse(layer.getGeometry(1).isEmpty())
         layer.rollBack()
 
+    def test_DeleteSomeVertices(self):
+        """Deleting some vertices must leave a non empty geometry."""
+
+        layer = QgsVectorLayer("LineString?field=f:int", "addfeat", "memory")
+        f = QgsFeature()
+        f.setAttributes([1])
+        f.setGeometry(
+            QgsGeometry.fromPolylineXY(
+                [QgsPointXY(0, 0), QgsPointXY(1, 0), QgsPointXY(2, 0)]
+            )
+        )
+        self.assertTrue(layer.dataProvider().addFeatures([f]))
+        layer.startEditing()
+        res = layer.deleteVertex(1, 0)
+        self.assertEqual(res, Qgis.VectorEditResult.Success)
+        self.assertFalse(layer.getGeometry(1).isNull())
+        self.assertFalse(layer.getGeometry(1).isEmpty())
+        layer.rollBack()
+
     # CHANGE ATTRIBUTE
 
     def test_ChangeAttribute(self):


### PR DESCRIPTION
## Description

Rationalize deleteVertices to return empty like delete part

Fixes https://github.com/qgis/QGIS/issues/65453 cc @tudorbarascu 

## AI tool usage

 - [X] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
- bootstrap test + docstring

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
