### PR TITLE
Remove add layer separator action from user interface

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -227,7 +227,6 @@
      <addaction name="mActionAddVirtualLayer"/>
      <addaction name="mActionAddWmsLayer"/>
      <addaction name="mActionAddXyzLayer"/>
-     <addaction name="mActionAddLayerSeparator"/>
      <addaction name="mActionAddWcsLayer"/>
      <addaction name="mActionAddWfsLayer"/>
      <addaction name="mActionAddAfsLayer"/>
@@ -2099,20 +2098,6 @@ Acts on all layers.</string>
    </property>
    <property name="toolTip">
     <string>Stretch Histogram to Full Dataset</string>
-   </property>
-  </action>
-  <action name="mActionAddLayerSeparator">
-   <property name="text">
-    <string notr="true">More Add Layer actions here</string>
-   </property>
-   <property name="iconText">
-    <string notr="true">More Add Layer actions here</string>
-   </property>
-   <property name="toolTip">
-    <string notr="true">More Add Layer Actions here</string>
-   </property>
-   <property name="visible">
-    <bool>false</bool>
    </property>
   </action>
   <action name="mActionCustomization">


### PR DESCRIPTION
## Description

This PR removes the `mActionAddLayerSeparator`-Action from the QGIS User Interface.

As far as I can tell, this action served as a reference point in the (distant) past for adding other, new or custom *Add Layer …* actions to the *Layer menu* and later to the *Add Layer menu*, at the right position. I noticed the action when searching for something in the shortcut manager:

<img width="454" height="269" alt="image" src="https://github.com/user-attachments/assets/d61178f6-9ff8-4341-9c7d-7eb48d4c1443" />

Currently, it sits between the *Add XYZ Layer…* action and the *Add WCS Layer…* action in the *Layer* ⇝ *Add Layer* submenu of the main window. I haven't found any references to `mActionAddLayerSeparator` in neither the codebase, nor the documentations. Given that, I assume it's safe to remove the action from the GUI.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) were not used in the development of this PR. 