### PR TITLE
[fix] Make sure we only set text/mimeData to the Selection Clipboard, if the system explicitly supports it

### DIFF
--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -293,9 +293,10 @@ void QgsClipboard::setSystemClipboard()
   // the Windows clipboard (which seems contrary to the Qt
   // docs). With a Linux X server, ::Clipboard was required.
   // The simple solution was to put the text into both clipboards.
-#ifdef Q_OS_LINUX
-  cb->setMimeData( m, QClipboard::Selection );
-#endif
+  if ( cb->supportsSelection() )
+  {
+    cb->setMimeData( m, QClipboard::Selection );
+  }
   cb->setMimeData( m, QClipboard::Clipboard );
 
   QgsDebugMsgLevel( u"replaced system clipboard with: %1."_s.arg( textCopy ), 4 );
@@ -404,11 +405,15 @@ QgsFields QgsClipboard::retrieveFields() const
 {
   QClipboard *cb = QApplication::clipboard();
 
-#ifdef Q_OS_LINUX
-  const QString string = cb->text( QClipboard::Selection );
-#else
-  QString string = cb->text( QClipboard::Clipboard );
-#endif
+  QString string;
+  if ( cb->supportsSelection() )
+  {
+    string = cb->text( QClipboard::Selection );
+  }
+  else
+  {
+    string = cb->text( QClipboard::Clipboard );
+  }
 
   QgsFields f = QgsOgrUtils::stringToFields( string, QTextCodec::codecForName( "System" ) );
   if ( f.size() < 1 )
@@ -452,11 +457,15 @@ QgsFeatureList QgsClipboard::copyOf( const QgsFields &fields ) const
 
   QClipboard *cb = QApplication::clipboard();
 
-#ifdef Q_OS_LINUX
-  QString text = cb->text( QClipboard::Selection );
-#else
-  QString text = cb->text( QClipboard::Clipboard );
-#endif
+  QString text;
+  if ( cb->supportsSelection() )
+  {
+    text = cb->text( QClipboard::Selection );
+  }
+  else
+  {
+    text = cb->text( QClipboard::Clipboard );
+  }
 
   if ( text.endsWith( '\n' ) )
   {
@@ -491,11 +500,16 @@ void QgsClipboard::insert( const QgsFeature &feature )
 bool QgsClipboard::isEmpty() const
 {
   QClipboard *cb = QApplication::clipboard();
-#ifdef Q_OS_LINUX
-  const QString text = cb->text( QClipboard::Selection );
-#else
-  QString text = cb->text( QClipboard::Clipboard );
-#endif
+  QString text;
+  if ( cb->supportsSelection() )
+  {
+    text = cb->text( QClipboard::Selection );
+  }
+  else
+  {
+    text = cb->text( QClipboard::Clipboard );
+  }
+
   return text.isEmpty() && mFeatureClipboard.empty();
 }
 
@@ -532,17 +546,19 @@ void QgsClipboard::setData( const QString &mimeType, const QByteArray &data, con
     mdata->setText( text );
   }
   // Transfers ownership to the clipboard object
-#ifdef Q_OS_LINUX
-  QApplication::clipboard()->setMimeData( mdata, QClipboard::Selection );
-#endif
+  if ( QApplication::clipboard()->supportsSelection() )
+  {
+    QApplication::clipboard()->setMimeData( mdata, QClipboard::Selection );
+  }
   QApplication::clipboard()->setMimeData( mdata, QClipboard::Clipboard );
 }
 
 void QgsClipboard::setText( const QString &text )
 {
-#ifdef Q_OS_LINUX
-  QApplication::clipboard()->setText( text, QClipboard::Selection );
-#endif
+  if ( QApplication::clipboard()->supportsSelection() )
+  {
+    QApplication::clipboard()->setText( text, QClipboard::Selection );
+  }
   QApplication::clipboard()->setText( text, QClipboard::Clipboard );
 }
 

--- a/src/gui/processing/qgsprocessingalgorithmwidgetbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmwidgetbase.cpp
@@ -179,9 +179,10 @@ QgsProcessingAlgorithmWidgetBase::QgsProcessingAlgorithmWidgetBase(
           m->setText( command );
           QClipboard *cb = QApplication::clipboard();
 
-#ifdef Q_OS_LINUX
-          cb->setMimeData( m, QClipboard::Selection );
-#endif
+          if ( cb->supportsSelection() )
+          {
+            cb->setMimeData( m, QClipboard::Selection );
+          }
           cb->setMimeData( m, QClipboard::Clipboard );
         }
       } );
@@ -209,9 +210,10 @@ QgsProcessingAlgorithmWidgetBase::QgsProcessingAlgorithmWidgetBase(
             m->setText( command );
             QClipboard *cb = QApplication::clipboard();
 
-#ifdef Q_OS_LINUX
-            cb->setMimeData( m, QClipboard::Selection );
-#endif
+            if ( cb->supportsSelection() )
+            {
+              cb->setMimeData( m, QClipboard::Selection );
+            }
             cb->setMimeData( m, QClipboard::Clipboard );
           }
         }
@@ -237,9 +239,10 @@ QgsProcessingAlgorithmWidgetBase::QgsProcessingAlgorithmWidgetBase(
           m->setText( json );
           QClipboard *cb = QApplication::clipboard();
 
-#ifdef Q_OS_LINUX
-          cb->setMimeData( m, QClipboard::Selection );
-#endif
+          if ( cb->supportsSelection() )
+          {
+            cb->setMimeData( m, QClipboard::Selection );
+          }
           cb->setMimeData( m, QClipboard::Clipboard );
         }
       } );
@@ -734,9 +737,10 @@ void QgsProcessingAlgorithmWidgetBase::copyLogToClipboard()
   m->setHtml( txtLog->toHtml() );
   QClipboard *cb = QApplication::clipboard();
 
-#ifdef Q_OS_LINUX
-  cb->setMimeData( m, QClipboard::Selection );
-#endif
+  if ( cb->supportsSelection() )
+  {
+    cb->setMimeData( m, QClipboard::Selection );
+  }
   cb->setMimeData( m, QClipboard::Clipboard );
 }
 

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -568,9 +568,10 @@ void QgsQueryResultPanelWidget::copyResults( int fromRow, int toRow, int fromCol
       mdata->setText( text );
     }
     // Transfers ownership to the clipboard object
-#ifdef Q_OS_LINUX
-    QApplication::clipboard()->setMimeData( mdata, QClipboard::Selection );
-#endif
+    if ( QApplication::clipboard()->supportsSelection() )
+    {
+      QApplication::clipboard()->setMimeData( mdata, QClipboard::Selection );
+    }
     QApplication::clipboard()->setMimeData( mdata, QClipboard::Clipboard );
   }
 }


### PR DESCRIPTION
Potentially fixes #66298 and #66299.

We now ask explicitly whether the system supports selection before using the corresponding clipboard.
This will return false on Windows and macOS, and will prevent users from obtaining ugly warnings like this:

`Data set on unsupported clipboard mode. QMimeData object will be deleted.`

(This fix was borrowed from other projects.)

-----------------

_No AI was used._