### PR TITLE
[Customization] Respect item order when applying customization

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -1553,42 +1553,7 @@ bool QgsCustomization::isUserDefined( QWidget *widget )
   return widget && ( widget->property( USER_MENU_PROPERTY ).toBool() || widget->property( USER_TOOLBAR_PROPERTY ).toBool() );
 }
 
-
-template<class WidgetType> void QgsCustomization::updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const
-{
-  // clear all user menu
-  const QList<QAction *> widgetActions = parentWidget->actions();
-  for ( QAction *action : widgetActions )
-  {
-    const QMenu *menu = action->menu();
-    if ( menu && menu->property( USER_MENU_PROPERTY ).toBool() )
-    {
-      parentWidget->removeAction( action );
-    }
-  }
-
-  // add user menu
-  for ( const std::unique_ptr<QgsCustomization::QgsItem> &childItem : parentItem->childItemList() )
-  {
-    if ( !childItem->isVisible() )
-      continue;
-
-    if ( QgsCustomization::QgsUserMenuItem *userMenu = dynamic_cast<QgsCustomization::QgsUserMenuItem *>( childItem.get() ) )
-    {
-      QMenu *menu = new QMenu( userMenu->title(), parentWidget );
-      menu->setProperty( USER_MENU_PROPERTY, true );
-      menu->setObjectName( userMenu->name() );
-      parentWidget->addMenu( menu );
-
-      updateMenuActionVisibility( userMenu, menu );
-    }
-  }
-
-  // update non-user menu visibility
-  updateActionVisibility( parentItem, parentWidget );
-}
-
-void QgsCustomization::updateActionVisibility( QgsCustomization::QgsItem *item, QWidget *widget ) const
+void QgsCustomization::applyItemToWidget( QgsCustomization::QgsItem *item, QWidget *widget ) const
 {
   if ( !item || !widget )
     return;
@@ -1596,7 +1561,12 @@ void QgsCustomization::updateActionVisibility( QgsCustomization::QgsItem *item, 
   QSet<QgsCustomization::QgsItem *> processedChildItems;
   for ( QgsQActionsIterator::Info it : QgsQActionsIterator( widget ) )
   {
-    if ( QgsCustomization::QgsItem *childItem = item->getChild( it.name ) )
+    // remove user menu, would be recreated later
+    if ( it.isMenu && it.widget->property( USER_MENU_PROPERTY ).toBool() )
+    {
+      widget->removeAction( it.action );
+    }
+    else if ( QgsCustomization::QgsItem *childItem = item->getChild( it.name ) )
     {
       processedChildItems << childItem;
 
@@ -1605,10 +1575,7 @@ void QgsCustomization::updateActionVisibility( QgsCustomization::QgsItem *item, 
         widget->removeAction( it.action );
       }
 
-      if ( QMenu *menu = dynamic_cast<QMenu *>( it.widget ) )
-        updateMenuActionVisibility( childItem, menu );
-      else
-        updateActionVisibility( childItem, it.widget );
+      applyItemToWidget( childItem, it.widget );
     }
   }
 
@@ -1655,6 +1622,26 @@ void QgsCustomization::updateActionVisibility( QgsCustomization::QgsItem *item, 
       action->setObjectName( processingAlgorithmRef->name() );
       widget->addAction( action );
     }
+    else if ( QgsCustomization::QgsUserMenuItem *userMenu = dynamic_cast<QgsCustomization::QgsUserMenuItem *>( childItem.get() ) )
+    {
+      QMenu *menu = new QMenu( userMenu->title(), widget );
+      menu->setProperty( USER_MENU_PROPERTY, true );
+      menu->setObjectName( userMenu->name() );
+      if ( QMenu *parentMenu = qobject_cast<QMenu *>( widget ) )
+      {
+        parentMenu->addMenu( menu );
+      }
+      else if ( QMenuBar *parentMenuBar = qobject_cast<QMenuBar *>( widget ) )
+      {
+        parentMenuBar->addMenu( menu );
+      }
+      else
+      {
+        QgsDebugError( u"Trying to add a menu to a '%1'"_s.arg( widget->metaObject()->className() ) );
+      }
+
+      applyItemToWidget( userMenu, menu );
+    }
   }
 }
 
@@ -1664,7 +1651,7 @@ void QgsCustomization::applyToMenus() const
     return;
 
   QMenuBar *menuBar = mQgisApp->menuBar();
-  updateMenuActionVisibility( mMenus.get(), menuBar );
+  applyItemToWidget( mMenus.get(), menuBar );
 }
 
 void QgsCustomization::applyToStatusBarWidgets() const
@@ -1710,7 +1697,7 @@ void QgsCustomization::applyToToolBars() const
     {
       tb->setVisible( t->wasVisible() && t->isVisible() );
       tb->toggleViewAction()->setVisible( t->isVisible() );
-      updateActionVisibility( t, tb );
+      applyItemToWidget( t, tb );
     }
   }
 
@@ -1731,7 +1718,7 @@ void QgsCustomization::applyToToolBars() const
         QgisApp::instance()->addToolBar( toolBar );
       }
 
-      updateActionVisibility( userToolBar, toolBar );
+      applyItemToWidget( userToolBar, toolBar );
     }
   }
 

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -1138,14 +1138,9 @@ class APP_EXPORT QgsCustomization
     void loadOldIniFile( const QString &filePath );
 
     /**
-     * Update action \a widget visibility based on \a item
+     * Apply \a item configuration to \a widget
      */
-    void updateActionVisibility( QgsCustomization::QgsItem *item, QWidget *widget ) const;
-
-    /**
-     * Update menu \a widget visibility based on \a item
-     */
-    template<class WidgetType> void updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const;
+    void applyItemToWidget( QgsCustomization::QgsItem *item, QWidget *widget ) const;
 
     /**
      * Returns QWidget corresponding to \a path. Path is a '/' separated list of

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -54,6 +54,7 @@ class TestQgsCustomization : public QgsTest
     void testModel();
     void testModelProcessing();
     void testToolBarPosition();
+    void testMenuOrder();
 
   private:
     template<class T> T *getItem( QgsCustomization *customization, const QString &path ) const { return dynamic_cast<T *>( getItem( customization, path ) ); }
@@ -1020,6 +1021,54 @@ void TestQgsCustomization::testToolBarPosition()
   QCOMPARE( mySuperToolBarPos, mySuperToolBar->mapToGlobal( QPoint( 0, 0 ) ) );
 }
 
+void TestQgsCustomization::testMenuOrder()
+{
+  // mix action ref and sub menu and check that everything is in the appropriate order
+
+  mQgisApp->customization()->setEnabled( true );
+
+  mQgisApp->customization()->menusItem()->addChild( std::make_unique<QgsCustomization::QgsUserMenuItem>( "MyMenu", "My menu", mQgisApp->customization()->menusItem() ) );
+  QgsCustomization::QgsMenuItem *menuItem = getItem<QgsCustomization::QgsMenuItem>( "Menus/MyMenu" );
+  QVERIFY( menuItem );
+
+  {
+    const QString actionPath = "Menus/mEditMenu/mActionRedo";
+    QgsCustomization::QgsActionItem *actionItem = getItem<QgsCustomization::QgsActionItem>( actionPath );
+    QVERIFY( actionItem );
+    QVERIFY( getItem<QgsCustomization::QgsActionItem>( actionPath )->isVisible() );
+
+    menuItem->addChild( std::make_unique<QgsCustomization::QgsActionRefItem>( mQgisApp->customization()->uniqueActionName( actionItem->name() ), actionItem->title(), actionPath, menuItem ) );
+    QVERIFY( getItem<QgsCustomization::QgsActionRefItem>( "Menus/MyMenu/ActionRef_mActionRedo_1" ) );
+    QVERIFY( getItem<QgsCustomization::QgsActionRefItem>( "Menus/MyMenu/ActionRef_mActionRedo_1" )->isVisible() );
+  }
+
+  menuItem->addChild( std::make_unique<QgsCustomization::QgsUserMenuItem>( "MySubMenu", "My sub menu", menuItem ) );
+  getItem<QgsCustomization::QgsMenuItem>( "Menus/MyMenu/MySubMenu" );
+
+  {
+    const QString actionPath = "Menus/mEditMenu/mActionUndo";
+    QgsCustomization::QgsActionItem *actionItem = getItem<QgsCustomization::QgsActionItem>( actionPath );
+    QVERIFY( actionItem );
+    QVERIFY( getItem<QgsCustomization::QgsActionItem>( actionPath )->isVisible() );
+
+    menuItem->addChild( std::make_unique<QgsCustomization::QgsActionRefItem>( mQgisApp->customization()->uniqueActionName( actionItem->name() ), actionItem->title(), actionPath, menuItem ) );
+    QVERIFY( getItem<QgsCustomization::QgsActionRefItem>( "Menus/MyMenu/ActionRef_mActionUndo_1" ) );
+    QVERIFY( getItem<QgsCustomization::QgsActionRefItem>( "Menus/MyMenu/ActionRef_mActionUndo_1" )->isVisible() );
+  }
+
+  mQgisApp->customization()->apply();
+
+  QMenu *menu = findQWidget<QMenu>( "Menus/MyMenu" );
+  QVERIFY( menu );
+  QCOMPARE( menu->actions().count(), 3 );
+
+  QVERIFY( !menu->actions().at( 0 )->menu() );
+  QCOMPARE( menu->actions().at( 0 )->text(), "&Redo" );
+  QVERIFY( menu->actions().at( 1 )->menu() );
+  QCOMPARE( menu->actions().at( 1 )->text(), "My sub menu" );
+  QVERIFY( !menu->actions().at( 2 )->menu() );
+  QCOMPARE( menu->actions().at( 2 )->text(), "&Undo" );
+}
 
 QGSTEST_MAIN( TestQgsCustomization )
 #include "testqgscustomization.moc"


### PR DESCRIPTION
## Description

Fix the unreported issue "Menu and action order is not respected in user defined menu"

Merge `updateActionVisibility` and `updateMenuActionVisibility` (and rename them to the more meaningful `applyItemToWidget`) to have only one method that restore items (menu and action) in the right order (and avoid to have actions first and then menus for instance).

## AI tool usage

None