### PR TITLE
[Dxf] Include highligths when calling GetMap with DXF output

### DIFF
--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -33,6 +33,7 @@ namespace QgsWms
     context.setFlag( QgsWmsRenderContext::UseOpacity );
     context.setFlag( QgsWmsRenderContext::UseFilter );
     context.setFlag( QgsWmsRenderContext::SetAccessControl );
+    context.setFlag( QgsWmsRenderContext::AddHighlightLayers );
     context.setParameters( request.wmsParameters() );
     context.setSocketFeedback( response.feedback() );
 


### PR DESCRIPTION
## Description

Fix partially #62921

This produces this for instance (once DXF load in QGIS)

<img width="717" height="461" alt="dxf_highlight" src="https://github.com/user-attachments/assets/a3ab8ca3-e91c-481b-b470-83ae1e56022c" />

I'm not sure if HIGHLIGHT should be included or not in DXF. I don't know enough the format to figure out if some visual indication as HIGHLIGHT should be part of the file, or if this is a data format only.

On the other side, if the user add the option in the url, it doesn't hurt to add it :shrug: and some users seems to ask for it (see #62921)


## AI tool usage

None