### PR TITLE
fix __geo_interface__ additions to python wrappers for QgsFeature & QgsGeometry

### DIFF
--- a/python/PyQt6/core/additions/qgsfeature.py
+++ b/python/PyQt6/core/additions/qgsfeature.py
@@ -18,8 +18,7 @@
 
 def _mapping_feature(feature):
     geom = feature.geometry()
-    fields = [field.name() for field in feature.fields()]
-    properties = dict(list(zip(fields, feature.attributes())))
+    properties = feature.attributeMap()
     return {
         "type": "Feature",
         "properties": properties,

--- a/python/PyQt6/core/additions/qgsgeometry.py
+++ b/python/PyQt6/core/additions/qgsgeometry.py
@@ -14,7 +14,9 @@
 *                                                                         *
 ***************************************************************************
 """
+
 import json
+
 
 def _geometryNonZero(self):
     return not self.isEmpty()

--- a/python/PyQt6/core/additions/qgsgeometry.py
+++ b/python/PyQt6/core/additions/qgsgeometry.py
@@ -14,7 +14,7 @@
 *                                                                         *
 ***************************************************************************
 """
-
+import json
 
 def _geometryNonZero(self):
     return not self.isEmpty()
@@ -22,6 +22,6 @@ def _geometryNonZero(self):
 
 def _mapping_geometry(geometry):
     geo = geometry.asJson()
-    # We have to use eval because exportToGeoJSON() gives us
+    # We have to use loads because exportToGeoJSON() gives us
     # back a string that looks like a dictionary.
-    return eval(geo)
+    return json.loads(geo)

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -419,6 +419,16 @@ class TestQgsFeature(QgisTestCase):
             },
         )
 
+        feat.setGeometry(None)
+        self.assertEqual(
+            feat.__geo_interface__,
+            {
+                "geometry": None,
+                "properties": {"my_field": None, "my_field2": None, "my_field3": None},
+                "type": "Feature",
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

The python wrappers for `QgsFeature` and `QgsGeometry` add `__geo_interface__` properties for interoperability with other python tools that support this protocol (e.g. GeoPandas). This PR improves performance, functionality, and safety in those implementations by 

1) replacing a double loop (to create a list of field names, and then to zip field values into a dict) with the native `attributeMap` method of `QgsFeature`, which produces an identical dict
2) using `json.loads` instead of `eval` to convert the geometry json string into a python dict for safety
3) using `json.loads` also has the benefit of avoiding an exception for empty geometries. Empty geometries have a json `null` value for the `geometry` property of the json object. `eval` can't handle that because the string "null" is valid json, but not valid python code. `json.loads` correctly converts the `null` value to `None`, avoiding an `eval` exception.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.