### PR TITLE
fix(qgs3dmapcanvas): Allow key events to be sent to maptools

### DIFF
--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -328,7 +328,6 @@ bool Qgs3DMapCanvas::eventFilter( QObject *watched, QEvent *event )
       event->accept();
       return true;
     }
-    return false;
   }
 
   if ( !mMapTool )


### PR DESCRIPTION
## Description

This ensures that `KeyPress` and `KeyRelease` events can be reached if a map tool is activated.

## AI tool usage

 No AI Tool used