### PR TITLE
Use custom QFontComboBox to avoid display issues with ESRI font names

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -78,6 +78,16 @@ jobs:
       - name: Run QgsScrollArea check
         run: ./tests/code_layout/test_qgsscrollarea.sh
 
+  qgsfontcombobox_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run QgsFontComboBox check
+        run: ./tests/code_layout/test_qgsfontcombobox.sh
+
   qvariant_no_brace_init:
     runs-on: ubuntu-latest
     steps:

--- a/python/PyQt6/gui/auto_generated/qgsfontcombobox.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfontcombobox.sip.in
@@ -1,0 +1,42 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsfontcombobox.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+
+
+class QgsFontComboBox : QFontComboBox
+{
+%Docstring(signature="appended")
+A QFontComboBox with improved usability.
+
+.. versionadded:: 4.2
+%End
+
+%TypeHeaderCode
+#include "qgsfontcombobox.h"
+%End
+%ConvertToSubClassCode
+    if ( qobject_cast<QgsFontComboBox *>( sipCpp ) )
+      sipType = sipType_QgsFontComboBox;
+    else
+      sipType = NULL;
+%End
+  public:
+    explicit QgsFontComboBox( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsFontComboBox, with the specified ``parent`` widget.
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsfontcombobox.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/PyQt6/gui/gui_auto.sip
+++ b/python/PyQt6/gui/gui_auto.sip
@@ -92,6 +92,7 @@
 %Include auto_generated/qgsfloatingwidget.sip
 %Include auto_generated/qgsfocuswatcher.sip
 %Include auto_generated/qgsfontbutton.sip
+%Include auto_generated/qgsfontcombobox.sip
 %Include auto_generated/qgsformannotation.sip
 %Include auto_generated/qgsgeocoderlocatorfilter.sip
 %Include auto_generated/qgsgeometryrubberband.sip

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -676,6 +676,7 @@ set(QGIS_GUI_SRCS
   qgsfocuswatcher.cpp
   qgsformlabelformatwidget.cpp
   qgsfontbutton.cpp
+  qgsfontcombobox.cpp
   qgsformannotation.cpp
   qgsgeocoderlocatorfilter.cpp
   qgsgeometryrubberband.cpp
@@ -949,6 +950,7 @@ set(QGIS_GUI_HDRS
   qgsfocuskeeper.h
   qgsfocuswatcher.h
   qgsfontbutton.h
+  qgsfontcombobox.h
   qgsformannotation.h
   qgsformlabelformatwidget.h
   qgsgeocoderlocatorfilter.h

--- a/src/gui/qgsfontcombobox.cpp
+++ b/src/gui/qgsfontcombobox.cpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+    qgsfontcombobox.cpp
+     --------------------------------------
+    Date                 : July 2026
+    Copyright            : (C) 2026 Nyall Dawson
+    Email                : nyall.dawson@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsfontcombobox.h"
+
+#include <QString>
+
+#include "moc_qgsfontcombobox.cpp"
+
+using namespace Qt::StringLiterals;
+
+QgsFontComboBox::QgsFontComboBox( QWidget *parent )
+  : QFontComboBox( parent )
+{
+  QFont f = font();
+  // set font size to match QFontComboBox default:
+  // https://github.com/openwebos/qt/blob/master/src/gui/widgets/qfontcombobox.cpp#L134C1-L135C1
+  // yep, ¯\(°_o)/¯
+  f.setPointSize( static_cast< int >( 3 / 2.0 * f.pointSize() ) );
+
+  // these fonts have broken metadata -- they aren't correctly tagged as symbol fonts,
+  // so QFontComboBox happily renders the font name in undecipherable symbol characters.
+  // Yes, it's the fonts themselves which are broken, but given that these particular fonts
+  // are used heavily in spatial contexts, its worth working around this!
+  for ( const QString &family : {
+          u"D050000L [urw]"_s,
+          u"D050000L [URW ]"_s,
+          u"D050000L"_s,
+          u"ESRI AMFM Electric"_s,
+          u"ESRI Cartography"_s,
+          u"ESRI Caves 1"_s,
+          u"ESRI Caves 2"_s,
+          u"ESRI Caves 3"_s,
+          u"ESRI Environmental & Icons"_s,
+          u"ESRI Geology"_s,
+          u"ESRI Geology USGS 95-525"_s,
+          u"ESRI Geometric Symbols"_s,
+          u"ESRI Hazardous Materials"_s,
+          u"ESRI MilMod 01"_s,
+          u"ESRI MilSym 04"_s,
+          u"ESRI NIMA DNC PT"_s,
+          u"ESRI Oil, Gas, & Water"_s,
+          u"ESRI Pipeline US 1"_s,
+          u"ESRI Public1"_s,
+          u"ESRI SDS 1.95 1"_s,
+          u"ESRI SDS 2.00 1"_s,
+          u"ESRI Transportation & Civic"_s,
+          u"ESRI US Forestry 1"_s,
+          u"ESRI US MUTCD 1"_s,
+          u"ESRI US MUTCD 2"_s,
+          u"ESRI US MUTCD 3"_s,
+          u"ESRI Weather"_s,
+        } )
+  {
+    setDisplayFont( family, f );
+  }
+}

--- a/src/gui/qgsfontcombobox.h
+++ b/src/gui/qgsfontcombobox.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+    qgsfontcombobox.h
+     --------------------------------------
+    Date                 : July 2026
+    Copyright            : (C) 2026 Nyall Dawson
+    Email                : nyall.dawson@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSFONTCOMBOBOX_H
+#define QGSFONTCOMBOBOX_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+
+#include <QFontComboBox>
+
+/**
+ * \ingroup gui
+ * \brief A QFontComboBox with improved usability.
+ *
+ * \since QGIS 4.2
+ */
+class GUI_EXPORT QgsFontComboBox : public QFontComboBox
+{
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( qobject_cast<QgsFontComboBox *>( sipCpp ) )
+      sipType = sipType_QgsFontComboBox;
+    else
+      sipType = NULL;
+    SIP_END
+#endif
+
+    Q_OBJECT
+
+  public:
+    /**
+     * Constructor for QgsFontComboBox, with the specified \a parent widget.
+     */
+    explicit QgsFontComboBox( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+};
+
+#endif // QGSFONTCOMBOBOX_H

--- a/src/ui/labeling/qgslabelpropertydialogbase.ui
+++ b/src/ui/labeling/qgslabelpropertydialogbase.ui
@@ -128,7 +128,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0" colspan="3">
-           <widget class="QFontComboBox" name="mFontFamilyCmbBx"/>
+           <widget class="QgsFontComboBox" name="mFontFamilyCmbBx"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_3">
@@ -705,6 +705,11 @@
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontComboBox</class>
+   <extends>QFontComboBox</extends>
+   <header>qgsfontcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgscodeditorsettings.ui
+++ b/src/ui/qgscodeditorsettings.ui
@@ -278,7 +278,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QFontComboBox" name="mFontComboBox">
+            <widget class="QgsFontComboBox" name="mFontComboBox">
              <property name="insertPolicy">
               <enum>QComboBox::NoInsert</enum>
              </property>
@@ -861,6 +861,11 @@
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontComboBox</class>
+   <extends>QFontComboBox</extends>
+   <header>qgsfontcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSpinBox</class>

--- a/src/ui/qgseditconditionalformatrulewidget.ui
+++ b/src/ui/qgseditconditionalformatrulewidget.ui
@@ -442,7 +442,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QFontComboBox" name="mFontFamilyCmbBx"/>
+         <widget class="QgsFontComboBox" name="mFontFamilyCmbBx"/>
         </item>
        </layout>
       </item>
@@ -453,15 +453,20 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontComboBox</class>
+   <extends>QFontComboBox</extends>
+   <header>qgsfontcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsformlabelformatwidget.ui
+++ b/src/ui/qgsformlabelformatwidget.ui
@@ -235,7 +235,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QFontComboBox" name="mFontFamilyCmbBx"/>
+       <widget class="QgsFontComboBox" name="mFontFamilyCmbBx"/>
       </item>
      </layout>
     </widget>
@@ -260,16 +260,21 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsFontComboBox</class>
+   <extends>QFontComboBox</extends>
+   <header>qgsfontcombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -416,7 +416,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QFontComboBox" name="mFontFamilyComboBox">
+                     <widget class="QgsFontComboBox" name="mFontFamilyComboBox">
                       <property name="sizeAdjustPolicy">
                        <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
                       </property>
@@ -4629,7 +4629,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </widget>
                   </item>
                   <item row="2" column="1">
-                   <widget class="QFontComboBox" name="mComposerFontComboBox"/>
+                   <widget class="QgsFontComboBox" name="mComposerFontComboBox"/>
                   </item>
                  </layout>
                 </widget>
@@ -5556,15 +5556,32 @@ li.checked::marker { content: &quot;\2612&quot;; }
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsFontComboBox</class>
+   <extends>QFontComboBox</extends>
+   <header>qgsfontcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
@@ -5578,21 +5595,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsAuthSettingsWidget</class>
    <extends>QWidget</extends>
    <header>qgsauthsettingswidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/qgstextannotationdialogbase.ui
+++ b/src/ui/qgstextannotationdialogbase.ui
@@ -39,7 +39,7 @@
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QFontComboBox" name="mFontComboBox"/>
+      <widget class="QgsFontComboBox" name="mFontComboBox"/>
      </item>
      <item>
       <spacer name="horizontalSpacer">
@@ -127,11 +127,18 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontComboBox</class>
+   <extends>QFontComboBox</extends>
+   <header>qgsfontcombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -1010,7 +1010,7 @@ font-style: italic;</string>
                           </widget>
                          </item>
                          <item row="1" column="1">
-                          <widget class="QFontComboBox" name="mFontFamilyCmbBx">
+                          <widget class="QgsFontComboBox" name="mFontFamilyCmbBx">
                            <property name="sizeAdjustPolicy">
                             <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
                            </property>
@@ -7101,14 +7101,59 @@ This limit is inclusive, that means the label will be displayed on this scale.</
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFontComboBox</class>
+   <extends>QFontComboBox</extends>
+   <header>qgsfontcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCodeEditorExpression</class>
+   <extends>QWidget</extends>
+   <header>qgscodeeditorexpression.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -7123,54 +7168,15 @@ This limit is inclusive, that means the label will be displayed on this scale.</
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsPenJoinStyleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCodeEditorExpression</class>
-   <extends>QWidget</extends>
-   <header>qgscodeeditorexpression.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -204,7 +204,7 @@
     </layout>
    </item>
    <item row="0" column="2">
-    <widget class="QFontComboBox" name="cboFont">
+    <widget class="QgsFontComboBox" name="cboFont">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
@@ -518,20 +518,31 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsFontComboBox</class>
+   <extends>QFontComboBox</extends>
+   <header>qgsfontcombobox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsPropertyOverrideButton</class>
    <extends>QToolButton</extends>
    <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -543,12 +554,6 @@
    <class>QgsPenJoinStyleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgspenstylecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/code_layout/test_qgsfontcombobox.sh
+++ b/tests/code_layout/test_qgsfontcombobox.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This test checks for use of QFontComboBox in .ui files and suggests using QgsFontComboBox instead
+
+RES=
+DIR=$(git rev-parse --show-toplevel)
+
+pushd "${DIR}" > /dev/null || exit
+
+FOUND=$(git grep "class=\"QFontComboBox\"" -- 'src/*.ui' | grep --invert-match skip-keyword-check)
+
+if [[  ${FOUND} ]]; then
+  echo "Base QFontComboBox class used in .ui file!"
+  echo " -> Use QgsFontComboBox class instead"
+  echo
+  echo "${FOUND}"
+  echo
+  RES=1
+fi
+
+FOUND=$(git grep "new QFontComboBox" -- 'src' | grep --invert-match skip-keyword-check)
+
+if [[  ${FOUND} ]]; then
+  echo "Base QFontComboBox class used in file!"
+  echo " -> Use QgsFontComboBox class instead"
+  echo "    or mark with // skip-keyword-check"  echo
+  echo "${FOUND}"
+  echo
+  RES=1
+fi
+
+
+popd > /dev/null || exit
+
+if [ $RES ]; then
+  echo " *** Found QFontComboBox use in ui files"
+  exit 1
+fi
+


### PR DESCRIPTION
## Description

Specifically, this subclass fixes the display of some known symbol fonts with incorrect metadata which do not correctly
identify the font as a symbol font. This means that QFontComboBox would display the font name using illegible symbol characters.

While it's the fonts themselves that are broken, their widespread use in the geospatial world warrant us working around the broken metadata to ensure that QGIS is as user-friendly as it can be.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
