### PR TITLE
Fix crash in drag and drop designer

### DIFF
--- a/src/gui/vector/qgsattributesformmodel.cpp
+++ b/src/gui/vector/qgsattributesformmodel.cpp
@@ -538,6 +538,36 @@ void QgsAttributesFormModel::emitDataChangedRecursively( const QModelIndex &pare
   }
 }
 
+QIcon QgsAttributesFormModel::iconForItemType( QgsAttributesFormData::AttributesFormItemType itemType )
+{
+  switch ( itemType )
+  {
+    case QgsAttributesFormData::Relation:
+      return QgsApplication::getThemeIcon( u"/mEditorWidgetRelationEditor.svg"_s );
+
+    case QgsAttributesFormData::Action:
+      return QgsApplication::getThemeIcon( u"/mEditorWidgetAction.svg"_s );
+
+    case QgsAttributesFormData::QmlWidget:
+      return QgsApplication::getThemeIcon( u"/mEditorWidgetQml.svg"_s );
+
+    case QgsAttributesFormData::HtmlWidget:
+      return QgsApplication::getThemeIcon( u"/mEditorWidgetHtml.svg"_s );
+
+    case QgsAttributesFormData::TextWidget:
+      return QgsApplication::getThemeIcon( u"/mEditorWidgetText.svg"_s );
+
+    case QgsAttributesFormData::SpacerWidget:
+      return QgsApplication::getThemeIcon( u"/mEditorWidgetSpacer.svg"_s );
+
+    case QgsAttributesFormData::Field:
+    case QgsAttributesFormData::Container:
+    case QgsAttributesFormData::WidgetType:
+      break;
+  }
+  return QIcon();
+}
+
 
 QgsAttributesAvailableWidgetsModel::QgsAttributesAvailableWidgetsModel( QgsVectorLayer *layer, QgsProject *project, QObject *parent )
   : QgsAttributesFormModel( layer, project, parent )
@@ -626,7 +656,7 @@ void QgsAttributesAvailableWidgetsModel::populate()
     itemRelation->setData( ItemNameRole, name );
     itemRelation->setData( ItemIdRole, relation.id() );
     itemRelation->setData( ItemDataRole, itemData );
-    itemRelation->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetRelationEditor.svg"_s ) );
+    itemRelation->setIcon( iconForItemType( QgsAttributesFormData::Relation ) );
     itemRelations->addChild( std::move( itemRelation ) );
   }
 
@@ -645,25 +675,25 @@ void QgsAttributesAvailableWidgetsModel::populate()
   QgsAttributesFormData::AttributeFormItemData itemData = QgsAttributesFormData::AttributeFormItemData();
   itemData.setShowLabel( true );
   auto itemQml = std::make_unique< QgsAttributesFormItem >( QgsAttributesFormData::QmlWidget, itemData, u"QML Widget"_s, tr( "QML Widget" ) );
-  itemQml->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetQml.svg"_s ) );
+  itemQml->setIcon( iconForItemType( QgsAttributesFormData::QmlWidget ) );
   itemOtherWidgets->addChild( std::move( itemQml ) );
 
   QgsAttributesFormData::AttributeFormItemData itemHtmlData = QgsAttributesFormData::AttributeFormItemData();
   itemHtmlData.setShowLabel( true );
   auto itemHtml = std::make_unique< QgsAttributesFormItem >( QgsAttributesFormData::HtmlWidget, itemHtmlData, u"HTML Widget"_s, tr( "HTML Widget" ) );
-  itemHtml->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetHtml.svg"_s ) );
+  itemHtml->setIcon( iconForItemType( QgsAttributesFormData::HtmlWidget ) );
   itemOtherWidgets->addChild( std::move( itemHtml ) );
 
   QgsAttributesFormData::AttributeFormItemData itemTextData = QgsAttributesFormData::AttributeFormItemData();
   itemTextData.setShowLabel( true );
   auto itemText = std::make_unique< QgsAttributesFormItem >( QgsAttributesFormData::TextWidget, itemTextData, u"Text Widget"_s, tr( "Text Widget" ) );
-  itemText->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetText.svg"_s ) );
+  itemText->setIcon( iconForItemType( QgsAttributesFormData::TextWidget ) );
   itemOtherWidgets->addChild( std::move( itemText ) );
 
   QgsAttributesFormData::AttributeFormItemData itemSpacerData = QgsAttributesFormData::AttributeFormItemData();
   itemTextData.setShowLabel( false );
   auto itemSpacer = std::make_unique< QgsAttributesFormItem >( QgsAttributesFormData::SpacerWidget, u"Spacer Widget"_s, tr( "Spacer Widget" ) );
-  itemSpacer->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetSpacer.svg"_s ) );
+  itemSpacer->setIcon( iconForItemType( QgsAttributesFormData::SpacerWidget ) );
   itemOtherWidgets->addChild( std::move( itemSpacer ) );
 
   mRootItem->addChild( std::move( itemOtherWidgets ) );
@@ -716,7 +746,7 @@ void QgsAttributesAvailableWidgetsModel::populateActionItems( const QList<QgsAct
       itemAction->setData( ItemTypeRole, QgsAttributesFormData::Action );
       itemAction->setData( ItemNameRole, actionTitle );
       itemAction->setData( ItemDataRole, itemData );
-      itemAction->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetAction.svg"_s ) );
+      itemAction->setIcon( iconForItemType( QgsAttributesFormData::Action ) );
 
       itemActions->addChild( std::move( itemAction ) );
     }
@@ -987,15 +1017,7 @@ void QgsAttributesFormLayoutModel::loadAttributeEditorElementItem( QgsAttributeE
       editorItem->setData( ItemTypeRole, QgsAttributesFormData::Field );
       editorItem->setData( ItemDataRole, itemData );
 
-      const int fieldIndex = mLayer->fields().indexOf( editorElement->name() );
-      if ( fieldIndex != -1 )
-      {
-        editorItem->setData( ItemDisplayRole, mLayer->fields().field( fieldIndex ).alias() );
-
-        QgsAttributesFormData::FieldConfig config( mLayer, fieldIndex );
-        editorItem->setData( ItemFieldConfigRole, config );
-        editorItem->setIcon( QgsGui::instance()->editorWidgetRegistry()->icon( config.mEditorWidgetType ) );
-      }
+      setFieldItemDataFromLayer( editorItem.get() );
 
       break;
     }
@@ -1013,7 +1035,7 @@ void QgsAttributesFormLayoutModel::loadAttributeEditorElementItem( QgsAttributeE
         editorItem->setData( ItemNameRole, action.shortTitle().isEmpty() ? action.name() : action.shortTitle() );
         editorItem->setData( ItemTypeRole, QgsAttributesFormData::Action );
         editorItem->setData( ItemDataRole, itemData );
-        editorItem->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetAction.svg"_s ) );
+        editorItem->setIcon( iconForItemType( QgsAttributesFormData::Action ) );
       }
       else
       {
@@ -1049,7 +1071,7 @@ void QgsAttributesFormLayoutModel::loadAttributeEditorElementItem( QgsAttributeE
       editorItem->setData( ItemDisplayRole, relationEditorConfig.label );
       editorItem->setData( ItemTypeRole, QgsAttributesFormData::Relation );
       editorItem->setData( ItemDataRole, itemData );
-      editorItem->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetRelationEditor.svg"_s ) );
+      editorItem->setIcon( iconForItemType( QgsAttributesFormData::Relation ) );
 
       break;
     }
@@ -1097,7 +1119,7 @@ void QgsAttributesFormLayoutModel::loadAttributeEditorElementItem( QgsAttributeE
       editorItem->setData( ItemNameRole, editorElement->name() );
       editorItem->setData( ItemTypeRole, QgsAttributesFormData::QmlWidget );
       editorItem->setData( ItemDataRole, itemData );
-      editorItem->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetQml.svg"_s ) );
+      editorItem->setIcon( iconForItemType( QgsAttributesFormData::QmlWidget ) );
       break;
     }
 
@@ -1114,7 +1136,7 @@ void QgsAttributesFormLayoutModel::loadAttributeEditorElementItem( QgsAttributeE
       editorItem->setData( ItemNameRole, editorElement->name() );
       editorItem->setData( ItemTypeRole, QgsAttributesFormData::HtmlWidget );
       editorItem->setData( ItemDataRole, itemData );
-      editorItem->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetHtml.svg"_s ) );
+      editorItem->setIcon( iconForItemType( QgsAttributesFormData::HtmlWidget ) );
       break;
     }
 
@@ -1131,7 +1153,7 @@ void QgsAttributesFormLayoutModel::loadAttributeEditorElementItem( QgsAttributeE
       editorItem->setData( ItemNameRole, editorElement->name() );
       editorItem->setData( ItemTypeRole, QgsAttributesFormData::TextWidget );
       editorItem->setData( ItemDataRole, itemData );
-      editorItem->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetText.svg"_s ) );
+      editorItem->setIcon( iconForItemType( QgsAttributesFormData::TextWidget ) );
       break;
     }
 
@@ -1149,7 +1171,7 @@ void QgsAttributesFormLayoutModel::loadAttributeEditorElementItem( QgsAttributeE
       editorItem->setData( ItemNameRole, editorElement->name() );
       editorItem->setData( ItemTypeRole, QgsAttributesFormData::SpacerWidget );
       editorItem->setData( ItemDataRole, itemData );
-      editorItem->setIcon( QgsApplication::getThemeIcon( u"/mEditorWidgetSpacer.svg"_s ) );
+      editorItem->setIcon( iconForItemType( QgsAttributesFormData::SpacerWidget ) );
       break;
     }
 
@@ -1477,6 +1499,7 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
     Q_ASSERT( action == Qt::CopyAction ); // External drop
     QByteArray itemData = data->data( u"application/x-qgsattributesformavailablewidgetsrelement"_s );
     QDataStream stream( &itemData, QIODevice::ReadOnly );
+    QModelIndexList addedIndexes;
 
     while ( !stream.atEnd() )
     {
@@ -1489,12 +1512,13 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
       insertChild( parent, row + rows, itemId, itemType, itemName );
 
       isDropSuccessful = true;
-
-      QModelIndex addedIndex = index( row + rows, 0, parent );
-      emit externalItemDropped( addedIndex );
+      addedIndexes << index( row + rows, 0, parent );
 
       rows++;
     }
+
+    if ( !addedIndexes.isEmpty() )
+      emit externalItemsDropped( addedIndexes );
   }
   else if ( data->hasFormat( u"application/x-qgsattributesformlayoutelement"_s ) )
   {
@@ -1513,6 +1537,7 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
     }
 
     QgsAttributesFormItem *destParentItem = itemForIndex( parent );
+    QList< QPersistentModelIndex > movedIndexes;
     for ( const QPersistentModelIndex &source : draggedIndexes )
     {
       const QModelIndex sourceParent = source.parent();
@@ -1523,6 +1548,7 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
       if ( sourceParent == parent && ( destRow == sourceRow || destRow == sourceRow + 1 ) )
       {
         isDropSuccessful = true;
+        movedIndexes << source;
         rows++;
         continue;
       }
@@ -1541,15 +1567,24 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
       endMoveRows();
 
       isDropSuccessful = true;
-
-      QModelIndex movedIndex = index( insertPosition, 0, parent );
-      emit internalItemDropped( movedIndex );
+      movedIndexes << QPersistentModelIndex( index( insertPosition, 0, parent ) );
 
       // Removing a source row placed above the drop point shifts all rows below
       if ( sourceParentItem == destParentItem && sourceRow < row )
         row--;
 
       rows++;
+    }
+
+    if ( !movedIndexes.isEmpty() )
+    {
+      // Use persistent indexes while moving, since subsequent moves may shift
+      // the rows of items moved earlier
+      QModelIndexList indexes;
+      indexes.reserve( movedIndexes.size() );
+      for ( const QPersistentModelIndex &movedIndex : std::as_const( movedIndexes ) )
+        indexes << movedIndex;
+      emit internalItemsDropped( indexes );
     }
   }
 
@@ -1766,6 +1801,19 @@ void QgsAttributesFormLayoutModel::addContainer( QModelIndex &parent, const QStr
   endInsertRows();
 }
 
+void QgsAttributesFormLayoutModel::setFieldItemDataFromLayer( QgsAttributesFormItem *item )
+{
+  const int fieldIndex = mLayer->fields().indexOf( item->name() );
+  if ( fieldIndex == -1 )
+    return;
+
+  item->setData( ItemDisplayRole, mLayer->fields().field( fieldIndex ).alias() );
+
+  const QgsAttributesFormData::FieldConfig config( mLayer, fieldIndex );
+  item->setData( ItemFieldConfigRole, QVariant::fromValue( config ) );
+  item->setIcon( QgsGui::instance()->editorWidgetRegistry()->icon( config.mEditorWidgetType ) );
+}
+
 void QgsAttributesFormLayoutModel::insertChild( const QModelIndex &parent, int row, const QString &itemId, QgsAttributesFormData::AttributesFormItemType itemType, const QString &itemName )
 {
   if ( row < 0 )
@@ -1777,6 +1825,16 @@ void QgsAttributesFormLayoutModel::insertChild( const QModelIndex &parent, int r
   item->setData( QgsAttributesFormModel::ItemIdRole, itemId );
   item->setData( QgsAttributesFormModel::ItemTypeRole, itemType );
   item->setData( QgsAttributesFormModel::ItemNameRole, itemName );
+
+  // Set the same icon (and, for fields, the same data) the item has in the available widgets tree
+  if ( itemType == QgsAttributesFormData::Field )
+  {
+    setFieldItemDataFromLayer( item.get() );
+  }
+  else
+  {
+    item->setIcon( iconForItemType( itemType ) );
+  }
 
   itemForIndex( parent )->insertChild( row, std::move( item ) );
   endInsertRows();

--- a/src/gui/vector/qgsattributesformmodel.cpp
+++ b/src/gui/vector/qgsattributesformmodel.cpp
@@ -1537,6 +1537,19 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
     }
 
     QgsAttributesFormItem *destParentItem = itemForIndex( parent );
+
+    const QPersistentModelIndex persistentParent( parent );
+
+    // Returns true if ancestor is item itself or one of its ancestors.
+    const auto isSelfOrAncestorOf = []( const QgsAttributesFormItem *ancestor, QgsAttributesFormItem *item ) {
+      for ( QgsAttributesFormItem *walk = item; walk; walk = walk->parent() )
+      {
+        if ( walk == ancestor )
+          return true;
+      }
+      return false;
+    };
+
     QList< QPersistentModelIndex > movedIndexes;
     for ( const QPersistentModelIndex &source : draggedIndexes )
     {
@@ -1544,8 +1557,8 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
       const int sourceRow = source.row();
       const int destRow = row + rows;
 
-      // Moving an item onto its current position is a no-op that beginMoveRows() rejects.
-      if ( sourceParent == parent && ( destRow == sourceRow || destRow == sourceRow + 1 ) )
+      // Moving an item onto its current position is a no-op.
+      if ( sourceParent == persistentParent && ( destRow == sourceRow || destRow == sourceRow + 1 ) )
       {
         isDropSuccessful = true;
         movedIndexes << source;
@@ -1553,21 +1566,29 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
         continue;
       }
 
-      if ( !beginMoveRows( sourceParent, sourceRow, sourceRow, parent, destRow ) )
-        continue; // e.g. attempt to move a container into itself
+      // A container cannot be moved into itself or one of its own descendants.
+      if ( isSelfOrAncestorOf( itemForIndex( source ), destParentItem ) )
+        continue;
 
       QgsAttributesFormItem *sourceParentItem = itemForIndex( sourceParent );
+
+      // It seems that QSortFilterProxyModel mishandles row moves when filtering is enabled
+      // so we use remove + insert instead of move.
+      beginRemoveRows( sourceParent, sourceRow, sourceRow );
       std::unique_ptr< QgsAttributesFormItem > movedItem = sourceParentItem->takeChild( sourceRow );
+      endRemoveRows();
 
       int insertPosition = destRow;
       if ( sourceParentItem == destParentItem && sourceRow < destRow )
         insertPosition = destRow - 1; // account for the just-removed source row
+      insertPosition = std::clamp( insertPosition, 0, destParentItem->childCount() );
 
+      beginInsertRows( persistentParent, insertPosition, insertPosition );
       destParentItem->insertChild( insertPosition, std::move( movedItem ) );
-      endMoveRows();
+      endInsertRows();
 
       isDropSuccessful = true;
-      movedIndexes << QPersistentModelIndex( index( insertPosition, 0, parent ) );
+      movedIndexes << QPersistentModelIndex( index( insertPosition, 0, persistentParent ) );
 
       // Removing a source row placed above the drop point shifts all rows below
       if ( sourceParentItem == destParentItem && sourceRow < row )

--- a/src/gui/vector/qgsattributesformmodel.cpp
+++ b/src/gui/vector/qgsattributesformmodel.cpp
@@ -1545,6 +1545,10 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
       QModelIndex movedIndex = index( insertPosition, 0, parent );
       emit internalItemDropped( movedIndex );
 
+      // Removing a source row placed above the drop point shifts all rows below
+      if ( sourceParentItem == destParentItem && sourceRow < row )
+        row--;
+
       rows++;
     }
   }

--- a/src/gui/vector/qgsattributesformmodel.cpp
+++ b/src/gui/vector/qgsattributesformmodel.cpp
@@ -300,6 +300,23 @@ void QgsAttributesFormItem::deleteChildAtIndex( int index )
     mChildren.erase( mChildren.begin() + index );
 }
 
+std::unique_ptr< QgsAttributesFormItem > QgsAttributesFormItem::takeChild( int index )
+{
+  if ( index < 0 || index >= static_cast< int >( mChildren.size() ) )
+    return nullptr;
+
+  std::unique_ptr< QgsAttributesFormItem > child = std::move( mChildren[index] );
+  mChildren.erase( mChildren.begin() + index );
+
+  if ( child )
+  {
+    disconnect( child.get(), &QgsAttributesFormItem::addedChildren, this, &QgsAttributesFormItem::addedChildren );
+    child->mParent = nullptr;
+  }
+
+  return child;
+}
+
 void QgsAttributesFormItem::deleteChildren()
 {
   mChildren.clear();
@@ -1332,7 +1349,9 @@ bool QgsAttributesFormLayoutModel::removeRow( int row, const QModelIndex &parent
 
 Qt::DropActions QgsAttributesFormLayoutModel::supportedDragActions() const
 {
-  return Qt::MoveAction;
+  // For internal moves, QAbstractItemView::startDrag() will delete the dragged item after a successful drop if we don't support Qt::CopyAction
+  // See QgsAttributesFormLayoutView::dropEvent where we force it to be a CopyAction.
+  return Qt::CopyAction | Qt::MoveAction;
 }
 
 Qt::DropActions QgsAttributesFormLayoutModel::supportedDropActions() const
@@ -1414,6 +1433,12 @@ QMimeData *QgsAttributesFormLayoutModel::mimeData( const QModelIndexList &indexe
   // Sort indexes since their order reflects selection order
   std::sort( curatedIndexes.begin(), curatedIndexes.end(), [this]( const QModelIndex &a, const QModelIndex &b ) { return indexLessThan( a, b ); } );
 
+  // Remember the dragged source items in the same order they are serialized below
+  // so an internal move can be performed without a rebuild of the dragged item subtree
+  mDraggedLayoutIndexes.clear();
+  for ( const QModelIndex &index : std::as_const( curatedIndexes ) )
+    mDraggedLayoutIndexes << QPersistentModelIndex( index );
+
   for ( const QModelIndex &index : std::as_const( curatedIndexes ) )
   {
     if ( index.isValid() )
@@ -1474,32 +1499,51 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
   else if ( data->hasFormat( u"application/x-qgsattributesformlayoutelement"_s ) )
   {
     Q_ASSERT( action == Qt::MoveAction ); // Internal move
-    QByteArray itemData = data->data( u"application/x-qgsattributesformlayoutelement"_s );
-    QDataStream stream( &itemData, QIODevice::ReadOnly );
 
-    while ( !stream.atEnd() )
+    const QList< QPersistentModelIndex > draggedIndexes = mDraggedLayoutIndexes;
+    mDraggedLayoutIndexes.clear();
+
+    if ( draggedIndexes.isEmpty() )
+      return false;
+
+    for ( const QPersistentModelIndex &source : draggedIndexes )
     {
-      QString text;
-      stream >> text;
+      if ( !source.isValid() )
+        return false;
+    }
 
-      QDomDocument doc;
-      if ( !doc.setContent( text ) )
-        continue;
-      const QDomElement rootElem = doc.documentElement();
-      if ( rootElem.tagName() != "form_layout_mime"_L1 || !rootElem.hasChildNodes() )
-        continue;
-      const QDomElement childElem = rootElem.firstChild().toElement();
+    QgsAttributesFormItem *destParentItem = itemForIndex( parent );
+    for ( const QPersistentModelIndex &source : draggedIndexes )
+    {
+      const QModelIndex sourceParent = source.parent();
+      const int sourceRow = source.row();
+      const int destRow = row + rows;
 
-      // Build editor element from XML and add/insert it to parent
-      QgsAttributeEditorElement *editor = QgsAttributeEditorElement::create( childElem, mLayer->id(), mLayer->fields(), QgsReadWriteContext() );
-      beginInsertRows( parent, row + rows, row + rows );
-      loadAttributeEditorElementItem( editor, itemForIndex( parent ), row + rows );
-      endInsertRows();
+      // Moving an item onto its current position is a no-op that beginMoveRows() rejects.
+      if ( sourceParent == parent && ( destRow == sourceRow || destRow == sourceRow + 1 ) )
+      {
+        isDropSuccessful = true;
+        rows++;
+        continue;
+      }
+
+      if ( !beginMoveRows( sourceParent, sourceRow, sourceRow, parent, destRow ) )
+        continue; // e.g. attempt to move a container into itself
+
+      QgsAttributesFormItem *sourceParentItem = itemForIndex( sourceParent );
+      std::unique_ptr< QgsAttributesFormItem > movedItem = sourceParentItem->takeChild( sourceRow );
+
+      int insertPosition = destRow;
+      if ( sourceParentItem == destParentItem && sourceRow < destRow )
+        insertPosition = destRow - 1; // account for the just-removed source row
+
+      destParentItem->insertChild( insertPosition, std::move( movedItem ) );
+      endMoveRows();
 
       isDropSuccessful = true;
 
-      QModelIndex addedIndex = index( row + rows, 0, parent );
-      emit internalItemDropped( addedIndex );
+      QModelIndex movedIndex = index( insertPosition, 0, parent );
+      emit internalItemDropped( movedIndex );
 
       rows++;
     }

--- a/src/gui/vector/qgsattributesformmodel.cpp
+++ b/src/gui/vector/qgsattributesformmodel.cpp
@@ -1536,80 +1536,103 @@ bool QgsAttributesFormLayoutModel::dropMimeData( const QMimeData *data, Qt::Drop
         return false;
     }
 
-    QgsAttributesFormItem *destParentItem = itemForIndex( parent );
-
+    // Defer the actual relocation until after the drag's modal event loop has
+    // exited. Mutating the model while the drag is still in
+    // progress corrupts the proxy's incremental source-to-proxy mapping
     const QPersistentModelIndex persistentParent( parent );
+    QMetaObject::invokeMethod( this, [this, draggedIndexes, persistentParent, row]() { performInternalMove( draggedIndexes, persistentParent, row ); }, Qt::QueuedConnection );
 
-    // Returns true if ancestor is item itself or one of its ancestors.
-    const auto isSelfOrAncestorOf = []( const QgsAttributesFormItem *ancestor, QgsAttributesFormItem *item ) {
-      for ( QgsAttributesFormItem *walk = item; walk; walk = walk->parent() )
-      {
-        if ( walk == ancestor )
-          return true;
-      }
-      return false;
-    };
-
-    QList< QPersistentModelIndex > movedIndexes;
-    for ( const QPersistentModelIndex &source : draggedIndexes )
-    {
-      const QModelIndex sourceParent = source.parent();
-      const int sourceRow = source.row();
-      const int destRow = row + rows;
-
-      // Moving an item onto its current position is a no-op.
-      if ( sourceParent == persistentParent && ( destRow == sourceRow || destRow == sourceRow + 1 ) )
-      {
-        isDropSuccessful = true;
-        movedIndexes << source;
-        rows++;
-        continue;
-      }
-
-      // A container cannot be moved into itself or one of its own descendants.
-      if ( isSelfOrAncestorOf( itemForIndex( source ), destParentItem ) )
-        continue;
-
-      QgsAttributesFormItem *sourceParentItem = itemForIndex( sourceParent );
-
-      // It seems that QSortFilterProxyModel mishandles row moves when filtering is enabled
-      // so we use remove + insert instead of move.
-      beginRemoveRows( sourceParent, sourceRow, sourceRow );
-      std::unique_ptr< QgsAttributesFormItem > movedItem = sourceParentItem->takeChild( sourceRow );
-      endRemoveRows();
-
-      int insertPosition = destRow;
-      if ( sourceParentItem == destParentItem && sourceRow < destRow )
-        insertPosition = destRow - 1; // account for the just-removed source row
-      insertPosition = std::clamp( insertPosition, 0, destParentItem->childCount() );
-
-      beginInsertRows( persistentParent, insertPosition, insertPosition );
-      destParentItem->insertChild( insertPosition, std::move( movedItem ) );
-      endInsertRows();
-
-      isDropSuccessful = true;
-      movedIndexes << QPersistentModelIndex( index( insertPosition, 0, persistentParent ) );
-
-      // Removing a source row placed above the drop point shifts all rows below
-      if ( sourceParentItem == destParentItem && sourceRow < row )
-        row--;
-
-      rows++;
-    }
-
-    if ( !movedIndexes.isEmpty() )
-    {
-      // Use persistent indexes while moving, since subsequent moves may shift
-      // the rows of items moved earlier
-      QModelIndexList indexes;
-      indexes.reserve( movedIndexes.size() );
-      for ( const QPersistentModelIndex &movedIndex : std::as_const( movedIndexes ) )
-        indexes << movedIndex;
-      emit internalItemsDropped( indexes );
-    }
+    isDropSuccessful = true;
   }
 
   return isDropSuccessful;
+}
+
+void QgsAttributesFormLayoutModel::performInternalMove( const QList< QPersistentModelIndex > &draggedIndexes, const QModelIndex &parent, int row )
+{
+  for ( const QPersistentModelIndex &source : draggedIndexes )
+  {
+    if ( !source.isValid() )
+      return;
+  }
+
+  QgsAttributesFormItem *destParentItem = itemForIndex( parent );
+
+  // Capture the dragged items as raw pointers: they survive the move (only the
+  // owning unique_ptr is relocated), so they stay valid across the mutations
+  // below and across the model reset.
+  QList< QgsAttributesFormItem * > draggedItems;
+  draggedItems.reserve( draggedIndexes.size() );
+  for ( const QPersistentModelIndex &source : draggedIndexes )
+    draggedItems << itemForIndex( source );
+
+  // Returns true if ancestor is item itself or one of its ancestors.
+  const auto isSelfOrAncestorOf = []( const QgsAttributesFormItem *ancestor, QgsAttributesFormItem *item ) {
+    for ( QgsAttributesFormItem *walk = item; walk; walk = walk->parent() )
+    {
+      if ( walk == ancestor )
+        return true;
+    }
+    return false;
+  };
+
+  // We signal the move as a full model reset rather than via fine-grained
+  // beginInsertRows() and friends.
+  //  This is safe here because dropMimeData() defers this call out of the drag's modal
+  // loop, so no drag indexes are invalidated. The view restores the
+  // expanded state and selection afterwards (see internalItemsDropped()).
+  beginResetModel();
+
+  int rows = 0;
+  QList< QgsAttributesFormItem * > movedItems;
+  for ( QgsAttributesFormItem *item : std::as_const( draggedItems ) )
+  {
+    QgsAttributesFormItem *sourceParentItem = item->parent();
+    if ( !sourceParentItem )
+      continue;
+
+    const int sourceRow = item->row();
+    const int destRow = row + rows;
+
+    // Moving an item onto its current position is a no-op.
+    if ( sourceParentItem == destParentItem && ( destRow == sourceRow || destRow == sourceRow + 1 ) )
+    {
+      movedItems << item;
+      rows++;
+      continue;
+    }
+
+    // A container cannot be moved into itself or one of its own descendants.
+    if ( isSelfOrAncestorOf( item, destParentItem ) )
+      continue;
+
+    std::unique_ptr< QgsAttributesFormItem > movedItem = sourceParentItem->takeChild( sourceRow );
+
+    int insertPosition = destRow;
+    if ( sourceParentItem == destParentItem && sourceRow < destRow )
+      insertPosition = destRow - 1; // account for the just-removed source row
+    insertPosition = std::clamp( insertPosition, 0, destParentItem->childCount() );
+
+    destParentItem->insertChild( insertPosition, std::move( movedItem ) );
+    movedItems << item;
+
+    // Removing a source row placed above the drop point shifts all rows below
+    if ( sourceParentItem == destParentItem && sourceRow < row )
+      row--;
+
+    rows++;
+  }
+
+  endResetModel();
+
+  if ( !movedItems.isEmpty() )
+  {
+    QModelIndexList indexes;
+    indexes.reserve( movedItems.size() );
+    for ( QgsAttributesFormItem *item : std::as_const( movedItems ) )
+      indexes << createIndex( item->row(), 0, item );
+    emit internalItemsDropped( indexes );
+  }
 }
 
 void QgsAttributesFormLayoutModel::updateFieldConfigForFieldItemsRecursive( QgsAttributesFormItem *parent, const QString &fieldName, const QgsAttributesFormData::FieldConfig &config )

--- a/src/gui/vector/qgsattributesformmodel.h
+++ b/src/gui/vector/qgsattributesformmodel.h
@@ -487,7 +487,7 @@ class GUI_EXPORT QgsAttributesFormItem : public QObject
      * elsewhere in the tree.
      * Returns a NULLPTR if \a index is out of range.
      *
-     * \since QGIS 4.4
+     * \since QGIS 4.2.1
      */
     std::unique_ptr< QgsAttributesFormItem > takeChild( int index );
 
@@ -697,6 +697,17 @@ class GUI_EXPORT QgsAttributesFormModel : public QAbstractItemModel
      */
     void emitDataChangedRecursively( const QModelIndex &parent = QModelIndex(), const QVector<int> &roles = QVector<int>() );
 
+    /**
+     * Returns the icon used for items of the given \a itemType, both in the
+     * available widgets tree and in the form layout tree.
+     *
+     * An invalid icon is returned for item types without a fixed icon (e.g.,
+     * fields, whose icon depends on their editor widget type).
+     *
+     * \since QGIS 4.2.1
+     */
+    static QIcon iconForItemType( QgsAttributesFormData::AttributesFormItemType itemType );
+
     std::unique_ptr< QgsAttributesFormItem > mRootItem;
     QgsVectorLayer *mLayer;
     QgsProject *mProject;
@@ -866,9 +877,9 @@ class GUI_EXPORT QgsAttributesFormLayoutModel : public QgsAttributesFormModel
 
   signals:
     //! Informs that items were inserted (via drop) in the model from another model.
-    void externalItemDropped( QModelIndex &index );
+    void externalItemsDropped( const QModelIndexList &indexes );
     //! Informs that items were moved (via drop) in the model from the same model.
-    void internalItemDropped( QModelIndex &index );
+    void internalItemsDropped( const QModelIndexList &indexes );
 
   private:
     //! Update the field config for all items in the model.
@@ -878,6 +889,14 @@ class GUI_EXPORT QgsAttributesFormLayoutModel : public QgsAttributesFormModel
 
     QList< QgsAddAttributeFormContainerDialog::ContainerPair > recursiveListOfContainers( QgsAttributesFormItem *parent ) const;
     void loadAttributeEditorElementItem( QgsAttributeEditorElement *const editorElement, QgsAttributesFormItem *parent, const int position = -1 );
+
+    /**
+     * Sets the alias, field config and editor widget icon on a field \a item,
+     * taking the data from the corresponding layer field (matched by item name).
+     *
+     * Does nothing if no matching layer field is found.
+     */
+    void setFieldItemDataFromLayer( QgsAttributesFormItem *item );
 
     /**
      * Creates a list of indexes filtering out children whose parents are already included.

--- a/src/gui/vector/qgsattributesformmodel.h
+++ b/src/gui/vector/qgsattributesformmodel.h
@@ -908,6 +908,14 @@ class GUI_EXPORT QgsAttributesFormLayoutModel : public QgsAttributesFormModel
      */
     QModelIndexList curateIndexesForMimeData( const QModelIndexList &indexes ) const;
 
+    /**
+     * Performs the actual relocation of the \a draggedIndexes under \a parent at
+     * \a row. This is invoked (queued) from dropMimeData() after the drag's modal
+     * event loop has exited: mutating the model while the drag is still in
+     * progress corrupts QSortFilterProxyModel's mapping.
+     */
+    void performInternalMove( const QList< QPersistentModelIndex > &draggedIndexes, const QModelIndex &parent, int row );
+
     // Capture source items being dragged in an ongoing internal move.
     mutable QList< QPersistentModelIndex > mDraggedLayoutIndexes;
 };

--- a/src/gui/vector/qgsattributesformmodel.h
+++ b/src/gui/vector/qgsattributesformmodel.h
@@ -478,6 +478,20 @@ class GUI_EXPORT QgsAttributesFormItem : public QObject
     void deleteChildAtIndex( int index );
 
     /**
+     * Removes the child item placed at the given \a index from this item without
+     * deleting it.
+     *
+     * Caller takes ownership of the returned object.
+     *
+     * The returned item is detached from its parent, so it can be re-inserted
+     * elsewhere in the tree.
+     * Returns a NULLPTR if \a index is out of range.
+     *
+     * \since QGIS 4.4
+     */
+    std::unique_ptr< QgsAttributesFormItem > takeChild( int index );
+
+    /**
      * Deletes all child items from this item.
      */
     void deleteChildren();
@@ -766,10 +780,11 @@ class GUI_EXPORT QgsAttributesAvailableWidgetsModel : public QgsAttributesFormMo
 
 
 /**
+ * \ingroup gui
  * \brief Manages form layouts when configuring attributes forms via drag and drop designer.
  *
  * \warning Not part of stable API and may change in future QGIS releases.
- * \ingroup gui
+ *
  * \since QGIS 3.44
  */
 class GUI_EXPORT QgsAttributesFormLayoutModel : public QgsAttributesFormModel
@@ -873,6 +888,9 @@ class GUI_EXPORT QgsAttributesFormLayoutModel : public QgsAttributesFormModel
      * \param indexes Input list of indexes, potentially with redundant indexes.
      */
     QModelIndexList curateIndexesForMimeData( const QModelIndexList &indexes ) const;
+
+    // Capture source items being dragged in an ongoing internal move.
+    mutable QList< QPersistentModelIndex > mDraggedLayoutIndexes;
 };
 
 

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -514,7 +514,10 @@ void QgsAttributesFormProperties::loadAttributeContainerEdit()
 
 void QgsAttributesFormProperties::onAttributeSelectionChanged( const QItemSelection &, const QItemSelection & )
 {
+  // when the selection changes in the main tree, sync the DnD layout
+  // Block both selection handlers while syncing (see onFormLayoutSelectionChanged for rationale).
   disconnect( mFormLayoutView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
+  disconnect( mAvailableWidgetsView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onAttributeSelectionChanged );
 
   QModelIndex index;
   if ( mFormLayoutView->selectionModel()->selectedRows( 0 ).count() == 1 )
@@ -526,12 +529,16 @@ void QgsAttributesFormProperties::onAttributeSelectionChanged( const QItemSelect
 
   loadAttributeSpecificEditor( mAvailableWidgetsView, mFormLayoutView, index );
   connect( mFormLayoutView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
+  connect( mAvailableWidgetsView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onAttributeSelectionChanged );
 }
 
 void QgsAttributesFormProperties::onFormLayoutSelectionChanged( const QItemSelection &, const QItemSelection &deselected )
 {
   // when the selection changes in the DnD layout, sync the main tree
+  // Block both selection handlers while syncing (see onAttributeSelectionChanged for rationale).
+  disconnect( mFormLayoutView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
   disconnect( mAvailableWidgetsView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onAttributeSelectionChanged );
+
   QModelIndex index;
   if ( deselected.indexes().count() == 1 )
   {
@@ -544,6 +551,7 @@ void QgsAttributesFormProperties::onFormLayoutSelectionChanged( const QItemSelec
   }
 
   loadAttributeSpecificEditor( mFormLayoutView, mAvailableWidgetsView, index );
+  connect( mFormLayoutView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
   connect( mAvailableWidgetsView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onAttributeSelectionChanged );
 }
 

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -512,8 +512,14 @@ void QgsAttributesFormProperties::loadAttributeContainerEdit()
   mAttributeTypeFrame->layout()->addWidget( mAttributeContainerEdit );
 }
 
-void QgsAttributesFormProperties::onAttributeSelectionChanged( const QItemSelection &, const QItemSelection & )
+void QgsAttributesFormProperties::onAttributeSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
 {
+  if ( selected.isEmpty() && deselected.isEmpty() )
+  {
+    // No-op notification, emitted e.g. by QItemSelectionModel when rows are inserted
+    return;
+  }
+
   // when the selection changes in the main tree, sync the DnD layout
   // block both selection handlers while syncing
   disconnect( mFormLayoutView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
@@ -532,8 +538,14 @@ void QgsAttributesFormProperties::onAttributeSelectionChanged( const QItemSelect
   connect( mAvailableWidgetsView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onAttributeSelectionChanged );
 }
 
-void QgsAttributesFormProperties::onFormLayoutSelectionChanged( const QItemSelection &, const QItemSelection &deselected )
+void QgsAttributesFormProperties::onFormLayoutSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected )
 {
+  if ( selected.isEmpty() && deselected.isEmpty() )
+  {
+    // No-op notification, emitted e.g. by QItemSelectionModel when rows are inserted
+    return;
+  }
+
   // when the selection changes in the DnD layout, sync the main tree
   // block both selection handlers while syncing
   disconnect( mFormLayoutView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
@@ -718,6 +730,9 @@ void QgsAttributesFormProperties::removeTabOrGroupButton()
   sourceIndexes.reserve( selectedRows.size() );
   for ( const QModelIndex &proxyIndex : selectedRows )
     sourceIndexes << QPersistentModelIndex( mFormLayoutProxyModel->mapToSource( proxyIndex ) );
+
+  // Clear the selection up front so that no selection handler fires while rows are being removed
+  mFormLayoutView->selectionModel()->clearSelection();
 
   for ( const QPersistentModelIndex &sourceIndex : std::as_const( sourceIndexes ) )
   {

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -77,7 +77,7 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
   mAvailableWidgetsView->setItemDelegate( new QgsAttributesFormTreeViewItemDelegate( mAvailableWidgetsView ) );
   mAvailableWidgetsView->setStyle( new QgsAttributesFormTreeViewProxyStyle( mAvailableWidgetsView ) );
 
-  mAvailableWidgetsModel = new QgsAttributesAvailableWidgetsModel( mLayer, QgsProject().instance(), this );
+  mAvailableWidgetsModel = new QgsAttributesAvailableWidgetsModel( mLayer, QgsProject::instance(), this );
   mAvailableWidgetsProxyModel = new QgsAttributesFormProxyModel( this );
   mAvailableWidgetsProxyModel->setAttributesFormSourceModel( mAvailableWidgetsModel );
   mAvailableWidgetsProxyModel->setRecursiveFilteringEnabled( true );
@@ -101,7 +101,7 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
   mFormLayoutView->setItemDelegate( new QgsAttributesFormTreeViewItemDelegate( mFormLayoutView ) );
   mFormLayoutView->setStyle( new QgsAttributesFormTreeViewProxyStyle( mFormLayoutView ) );
 
-  mFormLayoutModel = new QgsAttributesFormLayoutModel( mLayer, QgsProject().instance(), this );
+  mFormLayoutModel = new QgsAttributesFormLayoutModel( mLayer, QgsProject::instance(), this );
   mFormLayoutProxyModel = new QgsAttributesFormProxyModel( this );
   mFormLayoutProxyModel->setAttributesFormSourceModel( mFormLayoutModel );
   mFormLayoutProxyModel->setRecursiveFilteringEnabled( true );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -515,7 +515,7 @@ void QgsAttributesFormProperties::loadAttributeContainerEdit()
 void QgsAttributesFormProperties::onAttributeSelectionChanged( const QItemSelection &, const QItemSelection & )
 {
   // when the selection changes in the main tree, sync the DnD layout
-  // Block both selection handlers while syncing (see onFormLayoutSelectionChanged for rationale).
+  // block both selection handlers while syncing
   disconnect( mFormLayoutView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
   disconnect( mAvailableWidgetsView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onAttributeSelectionChanged );
 
@@ -535,7 +535,7 @@ void QgsAttributesFormProperties::onAttributeSelectionChanged( const QItemSelect
 void QgsAttributesFormProperties::onFormLayoutSelectionChanged( const QItemSelection &, const QItemSelection &deselected )
 {
   // when the selection changes in the DnD layout, sync the main tree
-  // Block both selection handlers while syncing (see onAttributeSelectionChanged for rationale).
+  // block both selection handlers while syncing
   disconnect( mFormLayoutView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
   disconnect( mAvailableWidgetsView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsAttributesFormProperties::onAttributeSelectionChanged );
 
@@ -710,16 +710,19 @@ void QgsAttributesFormProperties::addContainer()
 
 void QgsAttributesFormProperties::removeTabOrGroupButton()
 {
-  // deleting an item may delete any number of nested child items -- so we delete
-  // them one at a time and then see if there's any selection left
-  while ( true )
-  {
-    const QModelIndexList items = mFormLayoutView->selectionModel()->selectedRows();
-    if ( items.empty() )
-      break;
+  // Take a snapshot of the selected rows in the proxy model, and map them to the source model.
+  // This is necessary because removing rows from the source model will invalidate the proxy model's indexes.
+  const QModelIndexList selectedRows = mFormLayoutView->selectionModel()->selectedRows();
 
-    const QModelIndex item = mFormLayoutProxyModel->mapToSource( items.at( 0 ) );
-    mFormLayoutModel->removeRow( item.row(), item.parent() );
+  QList< QPersistentModelIndex > sourceIndexes;
+  sourceIndexes.reserve( selectedRows.size() );
+  for ( const QModelIndex &proxyIndex : selectedRows )
+    sourceIndexes << QPersistentModelIndex( mFormLayoutProxyModel->mapToSource( proxyIndex ) );
+
+  for ( const QPersistentModelIndex &sourceIndex : std::as_const( sourceIndexes ) )
+  {
+    if ( sourceIndex.isValid() )
+      mFormLayoutModel->removeRow( sourceIndex.row(), sourceIndex.parent() );
   }
 }
 

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -484,15 +484,20 @@ void QgsAttributesFormLayoutView::onItemDoubleClicked( const QModelIndex &index 
 
       //update preview on text change
       connect( qmlCode, &QgsCodeEditor::editingTimeout, this, [qmlWrapper, qmlCode, previewFeature, errorFeedbackWidget] {
+        QQuickWidget *qmlWidget = dynamic_cast<QQuickWidget *>( qmlWrapper->widget() );
         if ( qmlCode->text().trimmed().isEmpty() )
         {
           errorFeedbackWidget->setText( QObject::tr( "No QML code" ) );
+          if ( qmlWidget )
+          {
+            qmlWidget->setSource( QUrl() );
+          }
           return;
         }
         qmlWrapper->setQmlCode( qmlCode->text() );
         qmlWrapper->reinitWidget();
         qmlWrapper->setFeature( previewFeature );
-        if ( QQuickWidget *qmlWidget = dynamic_cast<QQuickWidget *>( qmlWrapper->widget() ) )
+        if ( qmlWidget )
         {
           const QList<QQmlError> errors = qmlWidget->errors();
           if ( !errors.isEmpty() )

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -484,6 +484,11 @@ void QgsAttributesFormLayoutView::onItemDoubleClicked( const QModelIndex &index 
 
       //update preview on text change
       connect( qmlCode, &QgsCodeEditor::editingTimeout, this, [qmlWrapper, qmlCode, previewFeature, errorFeedbackWidget] {
+        if ( qmlCode->text().trimmed().isEmpty() )
+        {
+          errorFeedbackWidget->setText( QObject::tr( "No QML code" ) );
+          return;
+        }
         qmlWrapper->setQmlCode( qmlCode->text() );
         qmlWrapper->reinitWidget();
         qmlWrapper->setFeature( previewFeature );

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -215,9 +215,22 @@ void QgsAttributesFormLayoutView::handleExternalDroppedItems( const QModelIndexL
   {
     const auto itemType = static_cast< QgsAttributesFormData::AttributesFormItemType >( index.data( QgsAttributesFormModel::ItemTypeRole ).toInt() );
 
-    if ( itemType == QgsAttributesFormData::QmlWidget || itemType == QgsAttributesFormData::HtmlWidget || itemType == QgsAttributesFormData::TextWidget || itemType == QgsAttributesFormData::SpacerWidget )
+    switch ( itemType )
     {
-      onItemDoubleClicked( mModel->mapFromSource( index ) );
+      case QgsAttributesFormData::QmlWidget:
+      case QgsAttributesFormData::HtmlWidget:
+      case QgsAttributesFormData::TextWidget:
+      case QgsAttributesFormData::SpacerWidget:
+        // These need to be configured right after being dropped
+        onItemDoubleClicked( mModel->mapFromSource( index ) );
+        break;
+
+      case QgsAttributesFormData::Field:
+      case QgsAttributesFormData::Relation:
+      case QgsAttributesFormData::Container:
+      case QgsAttributesFormData::WidgetType:
+      case QgsAttributesFormData::Action:
+        break;
     }
   }
 }

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -184,26 +184,47 @@ void QgsAttributesFormLayoutView::setModel( QAbstractItemModel *model )
   QTreeView::setModel( mModel );
 
   const auto *formLayoutModel = static_cast< QgsAttributesFormLayoutModel * >( mModel->sourceModel() );
-  connect( formLayoutModel, &QgsAttributesFormLayoutModel::externalItemDropped, this, &QgsAttributesFormLayoutView::handleExternalDroppedItem );
-  connect( formLayoutModel, &QgsAttributesFormLayoutModel::internalItemDropped, this, &QgsAttributesFormLayoutView::handleInternalDroppedItem );
+  connect( formLayoutModel, &QgsAttributesFormLayoutModel::externalItemsDropped, this, &QgsAttributesFormLayoutView::handleExternalDroppedItems );
+  connect( formLayoutModel, &QgsAttributesFormLayoutModel::internalItemsDropped, this, &QgsAttributesFormLayoutView::handleInternalDroppedItems );
 }
 
 
-void QgsAttributesFormLayoutView::handleExternalDroppedItem( QModelIndex &index )
+void QgsAttributesFormLayoutView::selectDroppedItems( const QModelIndexList &indexes )
 {
-  selectionModel()->setCurrentIndex( mModel->mapFromSource( index ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  if ( indexes.isEmpty() )
+    return;
 
-  const auto itemType = static_cast< QgsAttributesFormData::AttributesFormItemType >( index.data( QgsAttributesFormModel::ItemTypeRole ).toInt() );
-
-  if ( itemType == QgsAttributesFormData::QmlWidget || itemType == QgsAttributesFormData::HtmlWidget || itemType == QgsAttributesFormData::TextWidget || itemType == QgsAttributesFormData::SpacerWidget )
+  QItemSelection selection;
+  for ( const QModelIndex &index : indexes )
   {
-    onItemDoubleClicked( mModel->mapFromSource( index ) );
+    const QModelIndex proxyIndex = mModel->mapFromSource( index );
+    selection.select( proxyIndex, proxyIndex );
+  }
+
+  // Set the current index first without touching the selection, so that the
+  // selection is changed once, keeping all dropped items selected
+  selectionModel()->setCurrentIndex( mModel->mapFromSource( indexes.constLast() ), QItemSelectionModel::NoUpdate );
+  selectionModel()->select( selection, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+}
+
+void QgsAttributesFormLayoutView::handleExternalDroppedItems( const QModelIndexList &indexes )
+{
+  selectDroppedItems( indexes );
+
+  for ( const QModelIndex &index : indexes )
+  {
+    const auto itemType = static_cast< QgsAttributesFormData::AttributesFormItemType >( index.data( QgsAttributesFormModel::ItemTypeRole ).toInt() );
+
+    if ( itemType == QgsAttributesFormData::QmlWidget || itemType == QgsAttributesFormData::HtmlWidget || itemType == QgsAttributesFormData::TextWidget || itemType == QgsAttributesFormData::SpacerWidget )
+    {
+      onItemDoubleClicked( mModel->mapFromSource( index ) );
+    }
   }
 }
 
-void QgsAttributesFormLayoutView::handleInternalDroppedItem( QModelIndex &index )
+void QgsAttributesFormLayoutView::handleInternalDroppedItems( const QModelIndexList &indexes )
 {
-  selectionModel()->setCurrentIndex( mModel->mapFromSource( index ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  selectDroppedItems( indexes );
 }
 
 void QgsAttributesFormLayoutView::dragEnterEvent( QDragEnterEvent *event )

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -225,6 +225,44 @@ void QgsAttributesFormLayoutView::handleExternalDroppedItems( const QModelIndexL
 void QgsAttributesFormLayoutView::handleInternalDroppedItems( const QModelIndexList &indexes )
 {
   selectDroppedItems( indexes );
+
+  // Restore the state captured in dropEvent() before the move took place.
+  for ( const QModelIndex &index : indexes )
+  {
+    restoreExpandedState( index );
+  }
+  mDraggedExpandedState.clear();
+}
+
+void QgsAttributesFormLayoutView::storeExpandedState( const QModelIndex &sourceIndex )
+{
+  if ( !sourceIndex.isValid() )
+    return;
+
+  if ( auto *item = static_cast< QgsAttributesFormItem * >( sourceIndex.internalPointer() ) )
+    mDraggedExpandedState.insert( item, isExpanded( mModel->mapFromSource( sourceIndex ) ) );
+
+  const int rows = mModel->sourceModel()->rowCount( sourceIndex );
+  for ( int row = 0; row < rows; ++row )
+  {
+    storeExpandedState( mModel->sourceModel()->index( row, 0, sourceIndex ) );
+  }
+}
+
+void QgsAttributesFormLayoutView::restoreExpandedState( const QModelIndex &sourceIndex )
+{
+  if ( !sourceIndex.isValid() )
+    return;
+
+  // Expand parents before children so descendant indexes are correct
+  if ( auto *item = static_cast< QgsAttributesFormItem * >( sourceIndex.internalPointer() ) )
+    setExpanded( mModel->mapFromSource( sourceIndex ), mDraggedExpandedState.value( item, true ) );
+
+  const int rows = mModel->sourceModel()->rowCount( sourceIndex );
+  for ( int row = 0; row < rows; ++row )
+  {
+    restoreExpandedState( mModel->sourceModel()->index( row, 0, sourceIndex ) );
+  }
 }
 
 void QgsAttributesFormLayoutView::dragEnterEvent( QDragEnterEvent *event )
@@ -277,6 +315,18 @@ void QgsAttributesFormLayoutView::dropEvent( QDropEvent *event )
     return;
 
   const bool internalMove = event->source() == this && event->mimeData()->hasFormat( u"application/x-qgsattributesformlayoutelement"_s );
+
+  if ( internalMove )
+  {
+    // Capture the expanded state of the dragged items now, before the move
+    // turns into a removal + insertion that would collapse moved containers.
+    mDraggedExpandedState.clear();
+    const QModelIndexList selectedProxyIndexes = selectionModel()->selectedRows();
+    for ( const QModelIndex &proxyIndex : selectedProxyIndexes )
+    {
+      storeExpandedState( mModel->mapToSource( proxyIndex ) );
+    }
+  }
 
   if ( event->source() == this )
   {

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -203,12 +203,7 @@ void QgsAttributesFormLayoutView::handleExternalDroppedItem( QModelIndex &index 
 
 void QgsAttributesFormLayoutView::handleInternalDroppedItem( QModelIndex &index )
 {
-  selectionModel()->clearCurrentIndex();
-  const auto itemType = static_cast< QgsAttributesFormData::AttributesFormItemType >( index.data( QgsAttributesFormModel::ItemTypeRole ).toInt() );
-  if ( itemType == QgsAttributesFormData::Container )
-  {
-    expandRecursively( mModel->mapFromSource( index ) );
-  }
+  selectionModel()->setCurrentIndex( mModel->mapFromSource( index ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
 }
 
 void QgsAttributesFormLayoutView::dragEnterEvent( QDragEnterEvent *event )
@@ -260,12 +255,21 @@ void QgsAttributesFormLayoutView::dropEvent( QDropEvent *event )
   if ( !( event->mimeData()->hasFormat( u"application/x-qgsattributesformavailablewidgetsrelement"_s ) || event->mimeData()->hasFormat( u"application/x-qgsattributesformlayoutelement"_s ) ) )
     return;
 
+  const bool internalMove = event->source() == this && event->mimeData()->hasFormat( u"application/x-qgsattributesformlayoutelement"_s );
+
   if ( event->source() == this )
   {
     event->setDropAction( Qt::MoveAction );
   }
 
   QTreeView::dropEvent( event );
+
+  if ( internalMove && event->isAccepted() )
+  {
+    // Reporting a CopyAction makes QAbstractItemView::startDrag() skip its clearOrRemove() step.
+    event->setDropAction( Qt::CopyAction );
+    event->accept();
+  }
 }
 
 void QgsAttributesFormLayoutView::onItemDoubleClicked( const QModelIndex &index )

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -226,10 +226,12 @@ void QgsAttributesFormLayoutView::handleInternalDroppedItems( const QModelIndexL
 {
   selectDroppedItems( indexes );
 
-  // Restore the state captured in dropEvent() before the move took place.
-  for ( const QModelIndex &index : indexes )
+  // The move resets the model, collapsing the whole tree, so restore the
+  // expanded state captured in dropEvent() before the move took place.
+  const int topLevelRows = mModel->sourceModel()->rowCount( QModelIndex() );
+  for ( int row = 0; row < topLevelRows; ++row )
   {
-    restoreExpandedState( index );
+    restoreExpandedState( mModel->sourceModel()->index( row, 0, QModelIndex() ) );
   }
   mDraggedExpandedState.clear();
 }
@@ -318,13 +320,14 @@ void QgsAttributesFormLayoutView::dropEvent( QDropEvent *event )
 
   if ( internalMove )
   {
-    // Capture the expanded state of the dragged items now, before the move
-    // turns into a removal + insertion that would collapse moved containers.
+    // Capture the expanded state of the whole tree now, before the (deferred)
+    // move resets the model, which collapses everything. It is restored
+    // afterwards in handleInternalDroppedItems().
     mDraggedExpandedState.clear();
-    const QModelIndexList selectedProxyIndexes = selectionModel()->selectedRows();
-    for ( const QModelIndex &proxyIndex : selectedProxyIndexes )
+    const int topLevelRows = mModel->sourceModel()->rowCount( QModelIndex() );
+    for ( int row = 0; row < topLevelRows; ++row )
     {
-      storeExpandedState( mModel->mapToSource( proxyIndex ) );
+      storeExpandedState( mModel->sourceModel()->index( row, 0, QModelIndex() ) );
     }
   }
 

--- a/src/gui/vector/qgsattributesformview.h
+++ b/src/gui/vector/qgsattributesformview.h
@@ -186,6 +186,14 @@ class GUI_EXPORT QgsAttributesFormLayoutView : public QgsAttributesFormBaseView
   private:
     //! Selects all the given source model \a indexes, making the last one the current index.
     void selectDroppedItems( const QModelIndexList &indexes );
+
+    //! Recursively records the expanded state of the subtree rooted at source model \a sourceIndex.
+    void storeExpandedState( const QModelIndex &sourceIndex );
+
+    //! Recursively restores the expanded state of the subtree rooted at source model \a sourceIndex.
+    void restoreExpandedState( const QModelIndex &sourceIndex );
+
+    QHash< QgsAttributesFormItem *, bool > mDraggedExpandedState;
 };
 
 

--- a/src/gui/vector/qgsattributesformview.h
+++ b/src/gui/vector/qgsattributesformview.h
@@ -180,8 +180,12 @@ class GUI_EXPORT QgsAttributesFormLayoutView : public QgsAttributesFormBaseView
 
   private slots:
     void onItemDoubleClicked( const QModelIndex &index );
-    void handleExternalDroppedItem( QModelIndex &index );
-    void handleInternalDroppedItem( QModelIndex &index );
+    void handleExternalDroppedItems( const QModelIndexList &indexes );
+    void handleInternalDroppedItems( const QModelIndexList &indexes );
+
+  private:
+    //! Selects all the given source model \a indexes, making the last one the current index.
+    void selectDroppedItems( const QModelIndexList &indexes );
 };
 
 

--- a/tests/src/gui/testqgsattributesformmodel.cpp
+++ b/tests/src/gui/testqgsattributesformmodel.cpp
@@ -15,9 +15,13 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsattributeeditorcontainer.h"
+#include "qgsattributeeditorfield.h"
 #include "qgsattributesformmodel.h"
+#include "qgseditformconfig.h"
 #include "qgsproject.h"
 #include "qgstest.h"
+#include "qgsvectorlayer.h"
 
 #include <QString>
 
@@ -44,6 +48,7 @@ class TestQgsAttributesFormModel : public QObject
     void testAvailableWidgetsModelIndexOderInDragAndDrop();
     void testFormLayoutModel();
     void testFormLayoutModelOrphanFields();
+    void testFormLayoutModelInternalMove();
     void testInvalidRelationInAvailableWidgets();
     void testInvalidRelationInFormLayout();
 
@@ -639,6 +644,114 @@ void TestQgsAttributesFormModel::testFormLayoutModelOrphanFields()
 
   const bool discarded = mLayer->rollBack();
   QVERIFY( discarded );
+}
+
+void TestQgsAttributesFormModel::testFormLayoutModelInternalMove()
+{
+  auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer&field=c:integer&field=d:integer"_s, u"test"_s, u"memory"_s );
+
+  // tab
+  //  ├─ a
+  //  ├─ group
+  //  │   ├─ b
+  //  │   └─ c
+  //  └─ d
+  QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
+  tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
+  QgsAttributeEditorContainer *group = new QgsAttributeEditorContainer( u"group"_s, tab );
+  group->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, group ) );
+  group->addChildElement( new QgsAttributeEditorField( u"c"_s, 2, group ) );
+  tab->addChildElement( group );
+  tab->addChildElement( new QgsAttributeEditorField( u"d"_s, 3, tab ) );
+
+  QgsEditFormConfig cfg = layer->editFormConfig();
+  cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+  cfg.clearTabs();
+  cfg.addTab( tab );
+  layer->setEditFormConfig( cfg );
+
+  // Move the "group" container (initially at row 1 under "tab")
+  auto moveGroupAndVerify = [&layer, this]( int targetRow, int expectedFinalRow ) {
+    QgsAttributesFormLayoutModel model( layer.get(), mProject );
+    model.populate();
+
+    const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
+    QCOMPARE( tabIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"tab"_s );
+    QCOMPARE( model.rowCount( tabIndex ), 3 );
+
+    const QModelIndex groupIndex = model.index( 1, 0, tabIndex );
+    QCOMPARE( groupIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"group"_s );
+    QCOMPARE( static_cast< QgsAttributesFormData::AttributesFormItemType >( groupIndex.data( QgsAttributesFormModel::ItemTypeRole ).toInt() ), QgsAttributesFormData::Container );
+    QCOMPARE( model.rowCount( groupIndex ), 2 );
+
+    // mimeData() records the dragged source item, so dropMimeData() performs a
+    // true in-place move: the source is relocated, not copied and left behind.
+    QMimeData *mimeData = model.mimeData( QModelIndexList() << groupIndex );
+    QVERIFY( mimeData );
+
+    const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, targetRow, 0, tabIndex );
+    QVERIFY( dropped );
+    delete mimeData;
+
+    // No duplicate was inserted: the container count is unchanged and the group
+    // ended up where we asked, still holding both children.
+    QCOMPARE( model.rowCount( tabIndex ), 3 );
+    const QModelIndex movedGroup = model.index( expectedFinalRow, 0, tabIndex );
+    QCOMPARE( movedGroup.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"group"_s );
+    QCOMPARE( static_cast< QgsAttributesFormData::AttributesFormItemType >( movedGroup.data( QgsAttributesFormModel::ItemTypeRole ).toInt() ), QgsAttributesFormData::Container );
+    QCOMPARE( movedGroup.parent().data( QgsAttributesFormModel::ItemIdRole ).toString(), u"tab"_s );
+    QCOMPARE( model.rowCount( movedGroup ), 2 );
+    QCOMPARE( model.index( 0, 0, movedGroup ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
+    QCOMPARE( model.index( 1, 0, movedGroup ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"c"_s );
+
+    // The "group" identity must appear exactly once under "tab".
+    int groupCount = 0;
+    for ( int r = 0; r < model.rowCount( tabIndex ); ++r )
+    {
+      if ( model.index( r, 0, tabIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString() == "group"_L1 )
+        groupCount++;
+    }
+    QCOMPARE( groupCount, 1 );
+  };
+
+  // Move up to the top of the container.
+  moveGroupAndVerify( 0, 0 );
+
+  // Move down to the bottom of the container (dropping past the last row appends).
+  moveGroupAndVerify( 3, 2 );
+
+  // Reordering a field within its own group must move it, not drop it. Moving
+  // "b" (row 0) past "c" (row 1) inside "group" should leave the group holding
+  // [c, b] with both fields still present.
+  {
+    QgsAttributesFormLayoutModel model( layer.get(), mProject );
+    model.populate();
+
+    const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
+    const QModelIndex groupIndex = model.index( 1, 0, tabIndex );
+    QCOMPARE( model.rowCount( groupIndex ), 2 );
+
+    const QModelIndex fieldB = model.index( 0, 0, groupIndex );
+    QCOMPARE( fieldB.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
+
+    QMimeData *mimeData = model.mimeData( QModelIndexList() << fieldB );
+    QVERIFY( mimeData );
+    // Drop below "c" (targetRow == 2, i.e. past the last row of the group).
+    const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, 2, 0, groupIndex );
+    QVERIFY( dropped );
+    delete mimeData;
+
+    QCOMPARE( model.rowCount( groupIndex ), 2 );
+    QCOMPARE( model.index( 0, 0, groupIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"c"_s );
+    QCOMPARE( model.index( 1, 0, groupIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
+  }
+
+  // we must use Qt::CopyAction
+  // otherwise QAbstractItemView::startDrag() will delete the dragged item after a successful drop
+  {
+    QgsAttributesFormLayoutModel model( layer.get(), mProject );
+    QVERIFY( model.supportedDragActions() & Qt::CopyAction );
+  }
 }
 
 void TestQgsAttributesFormModel::testInvalidRelationInAvailableWidgets()

--- a/tests/src/gui/testqgsattributesformmodel.cpp
+++ b/tests/src/gui/testqgsattributesformmodel.cpp
@@ -19,6 +19,8 @@
 #include "qgsattributeeditorfield.h"
 #include "qgsattributesformmodel.h"
 #include "qgseditformconfig.h"
+#include "qgseditorwidgetregistry.h"
+#include "qgsgui.h"
 #include "qgsproject.h"
 #include "qgstest.h"
 #include "qgsvectorlayer.h"
@@ -48,8 +50,7 @@ class TestQgsAttributesFormModel : public QObject
     void testAvailableWidgetsModelIndexOderInDragAndDrop();
     void testFormLayoutModel();
     void testFormLayoutModelOrphanFields();
-    void testFormLayoutModelInternalMove();
-    void testFormLayoutModelInternalMultiItemMove();
+    void testFormLayoutModelDragAndDrop();
     void testInvalidRelationInAvailableWidgets();
     void testInvalidRelationInFormLayout();
 
@@ -66,6 +67,7 @@ void TestQgsAttributesFormModel::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  QgsGui::editorWidgetRegistry()->initEditors();
 }
 
 void TestQgsAttributesFormModel::setUpProjectWithRelation()
@@ -647,180 +649,228 @@ void TestQgsAttributesFormModel::testFormLayoutModelOrphanFields()
   QVERIFY( discarded );
 }
 
-void TestQgsAttributesFormModel::testFormLayoutModelInternalMove()
+void TestQgsAttributesFormModel::testFormLayoutModelDragAndDrop()
 {
-  auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer&field=c:integer&field=d:integer"_s, u"test"_s, u"memory"_s );
+  // Covers drag-and-drop behavior of the form layout model:
+  // - internal moves of a single item (container or field) must relocate it,
+  //   not copy it or lose it;
+  // - internal moves of multiple items at once must preserve every item and
+  //   produce the expected order, including when moving downward (the drop
+  //   anchor shifts up each time a source above it is taken out);
+  // - items dropped from the available widgets tree must show the same icon
+  //   they have in that tree.
 
-  // tab
-  //  ├─ a
-  //  ├─ group
-  //  │   ├─ b
-  //  │   └─ c
-  //  └─ d
-  QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
-  tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
-  QgsAttributeEditorContainer *group = new QgsAttributeEditorContainer( u"group"_s, tab );
-  group->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, group ) );
-  group->addChildElement( new QgsAttributeEditorField( u"c"_s, 2, group ) );
-  tab->addChildElement( group );
-  tab->addChildElement( new QgsAttributeEditorField( u"d"_s, 3, tab ) );
+  // Internal moves of a single item
+  {
+    auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer&field=c:integer&field=d:integer"_s, u"test"_s, u"memory"_s );
 
-  QgsEditFormConfig cfg = layer->editFormConfig();
-  cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
-  cfg.clearTabs();
-  cfg.addTab( tab );
-  layer->setEditFormConfig( cfg );
+    // tab
+    //  ├─ a
+    //  ├─ group
+    //  │   ├─ b
+    //  │   └─ c
+    //  └─ d
+    QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
+    tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
+    QgsAttributeEditorContainer *group = new QgsAttributeEditorContainer( u"group"_s, tab );
+    group->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, group ) );
+    group->addChildElement( new QgsAttributeEditorField( u"c"_s, 2, group ) );
+    tab->addChildElement( group );
+    tab->addChildElement( new QgsAttributeEditorField( u"d"_s, 3, tab ) );
 
-  // Move the "group" container (initially at row 1 under "tab")
-  auto moveGroupAndVerify = [&layer, this]( int targetRow, int expectedFinalRow ) {
-    QgsAttributesFormLayoutModel model( layer.get(), mProject );
-    model.populate();
+    QgsEditFormConfig cfg = layer->editFormConfig();
+    cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+    cfg.clearTabs();
+    cfg.addTab( tab );
+    layer->setEditFormConfig( cfg );
 
-    const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
-    QCOMPARE( tabIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"tab"_s );
-    QCOMPARE( model.rowCount( tabIndex ), 3 );
+    // Move the "group" container (initially at row 1 under "tab")
+    auto moveGroupAndVerify = [&layer, this]( int targetRow, int expectedFinalRow ) {
+      QgsAttributesFormLayoutModel model( layer.get(), mProject );
+      model.populate();
 
-    const QModelIndex groupIndex = model.index( 1, 0, tabIndex );
-    QCOMPARE( groupIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"group"_s );
-    QCOMPARE( static_cast< QgsAttributesFormData::AttributesFormItemType >( groupIndex.data( QgsAttributesFormModel::ItemTypeRole ).toInt() ), QgsAttributesFormData::Container );
-    QCOMPARE( model.rowCount( groupIndex ), 2 );
+      const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
+      QCOMPARE( tabIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"tab"_s );
+      QCOMPARE( model.rowCount( tabIndex ), 3 );
 
-    // mimeData() records the dragged source item, so dropMimeData() performs a
-    // true in-place move: the source is relocated, not copied and left behind.
-    QMimeData *mimeData = model.mimeData( QModelIndexList() << groupIndex );
-    QVERIFY( mimeData );
+      const QModelIndex groupIndex = model.index( 1, 0, tabIndex );
+      QCOMPARE( groupIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"group"_s );
+      QCOMPARE( static_cast< QgsAttributesFormData::AttributesFormItemType >( groupIndex.data( QgsAttributesFormModel::ItemTypeRole ).toInt() ), QgsAttributesFormData::Container );
+      QCOMPARE( model.rowCount( groupIndex ), 2 );
 
-    const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, targetRow, 0, tabIndex );
-    QVERIFY( dropped );
-    delete mimeData;
+      // mimeData() records the dragged source item, so dropMimeData() performs a
+      // true in-place move: the source is relocated, not copied and left behind.
+      QMimeData *mimeData = model.mimeData( QModelIndexList() << groupIndex );
+      QVERIFY( mimeData );
 
-    // No duplicate was inserted: the container count is unchanged and the group
-    // ended up where we asked, still holding both children.
-    QCOMPARE( model.rowCount( tabIndex ), 3 );
-    const QModelIndex movedGroup = model.index( expectedFinalRow, 0, tabIndex );
-    QCOMPARE( movedGroup.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"group"_s );
-    QCOMPARE( static_cast< QgsAttributesFormData::AttributesFormItemType >( movedGroup.data( QgsAttributesFormModel::ItemTypeRole ).toInt() ), QgsAttributesFormData::Container );
-    QCOMPARE( movedGroup.parent().data( QgsAttributesFormModel::ItemIdRole ).toString(), u"tab"_s );
-    QCOMPARE( model.rowCount( movedGroup ), 2 );
-    QCOMPARE( model.index( 0, 0, movedGroup ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
-    QCOMPARE( model.index( 1, 0, movedGroup ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"c"_s );
+      const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, targetRow, 0, tabIndex );
+      QVERIFY( dropped );
+      delete mimeData;
 
-    // The "group" identity must appear exactly once under "tab".
-    int groupCount = 0;
-    for ( int r = 0; r < model.rowCount( tabIndex ); ++r )
+      // No duplicate was inserted: the container count is unchanged and the group
+      // ended up where we asked, still holding both children.
+      QCOMPARE( model.rowCount( tabIndex ), 3 );
+      const QModelIndex movedGroup = model.index( expectedFinalRow, 0, tabIndex );
+      QCOMPARE( movedGroup.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"group"_s );
+      QCOMPARE( static_cast< QgsAttributesFormData::AttributesFormItemType >( movedGroup.data( QgsAttributesFormModel::ItemTypeRole ).toInt() ), QgsAttributesFormData::Container );
+      QCOMPARE( movedGroup.parent().data( QgsAttributesFormModel::ItemIdRole ).toString(), u"tab"_s );
+      QCOMPARE( model.rowCount( movedGroup ), 2 );
+      QCOMPARE( model.index( 0, 0, movedGroup ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
+      QCOMPARE( model.index( 1, 0, movedGroup ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"c"_s );
+
+      // The "group" identity must appear exactly once under "tab".
+      int groupCount = 0;
+      for ( int r = 0; r < model.rowCount( tabIndex ); ++r )
+      {
+        if ( model.index( r, 0, tabIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString() == "group"_L1 )
+          groupCount++;
+      }
+      QCOMPARE( groupCount, 1 );
+    };
+
+    // Move up to the top of the container.
+    moveGroupAndVerify( 0, 0 );
+
+    // Move down to the bottom of the container (dropping past the last row appends).
+    moveGroupAndVerify( 3, 2 );
+
+    // Reordering a field within its own group must move it, not drop it. Moving
+    // "b" (row 0) past "c" (row 1) inside "group" should leave the group holding
+    // [c, b] with both fields still present.
     {
-      if ( model.index( r, 0, tabIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString() == "group"_L1 )
-        groupCount++;
+      QgsAttributesFormLayoutModel model( layer.get(), mProject );
+      model.populate();
+
+      const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
+      const QModelIndex groupIndex = model.index( 1, 0, tabIndex );
+      QCOMPARE( model.rowCount( groupIndex ), 2 );
+
+      const QModelIndex fieldB = model.index( 0, 0, groupIndex );
+      QCOMPARE( fieldB.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
+
+      QMimeData *mimeData = model.mimeData( QModelIndexList() << fieldB );
+      QVERIFY( mimeData );
+      // Drop below "c" (targetRow == 2, i.e. past the last row of the group).
+      const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, 2, 0, groupIndex );
+      QVERIFY( dropped );
+      delete mimeData;
+
+      QCOMPARE( model.rowCount( groupIndex ), 2 );
+      QCOMPARE( model.index( 0, 0, groupIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"c"_s );
+      QCOMPARE( model.index( 1, 0, groupIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
     }
-    QCOMPARE( groupCount, 1 );
-  };
 
-  // Move up to the top of the container.
-  moveGroupAndVerify( 0, 0 );
-
-  // Move down to the bottom of the container (dropping past the last row appends).
-  moveGroupAndVerify( 3, 2 );
-
-  // Reordering a field within its own group must move it, not drop it. Moving
-  // "b" (row 0) past "c" (row 1) inside "group" should leave the group holding
-  // [c, b] with both fields still present.
-  {
-    QgsAttributesFormLayoutModel model( layer.get(), mProject );
-    model.populate();
-
-    const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
-    const QModelIndex groupIndex = model.index( 1, 0, tabIndex );
-    QCOMPARE( model.rowCount( groupIndex ), 2 );
-
-    const QModelIndex fieldB = model.index( 0, 0, groupIndex );
-    QCOMPARE( fieldB.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
-
-    QMimeData *mimeData = model.mimeData( QModelIndexList() << fieldB );
-    QVERIFY( mimeData );
-    // Drop below "c" (targetRow == 2, i.e. past the last row of the group).
-    const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, 2, 0, groupIndex );
-    QVERIFY( dropped );
-    delete mimeData;
-
-    QCOMPARE( model.rowCount( groupIndex ), 2 );
-    QCOMPARE( model.index( 0, 0, groupIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"c"_s );
-    QCOMPARE( model.index( 1, 0, groupIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
+    // we must use Qt::CopyAction
+    // otherwise QAbstractItemView::startDrag() will delete the dragged item after a successful drop
+    {
+      QgsAttributesFormLayoutModel model( layer.get(), mProject );
+      QVERIFY( model.supportedDragActions() & Qt::CopyAction );
+    }
   }
 
-  // we must use Qt::CopyAction
-  // otherwise QAbstractItemView::startDrag() will delete the dragged item after a successful drop
+  // Internal moves of multiple items at once
   {
-    QgsAttributesFormLayoutModel model( layer.get(), mProject );
-    QVERIFY( model.supportedDragActions() & Qt::CopyAction );
+    auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer&field=c:integer&field=d:integer"_s, u"test"_s, u"memory"_s );
+
+    // tab
+    //  ├─ a
+    //  ├─ b
+    //  ├─ c
+    //  └─ d
+    QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
+    tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
+    tab->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, tab ) );
+    tab->addChildElement( new QgsAttributeEditorField( u"c"_s, 2, tab ) );
+    tab->addChildElement( new QgsAttributeEditorField( u"d"_s, 3, tab ) );
+
+    QgsEditFormConfig cfg = layer->editFormConfig();
+    cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+    cfg.clearTabs();
+    cfg.addTab( tab );
+    layer->setEditFormConfig( cfg );
+
+    // Drag the fields at the given rows onto targetRow and compare the resulting order
+    auto moveFieldsAndVerify = [&layer, this]( const QList< int > &sourceRows, int targetRow, const QStringList &expectedOrder ) {
+      QgsAttributesFormLayoutModel model( layer.get(), mProject );
+      model.populate();
+
+      const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
+      QCOMPARE( model.rowCount( tabIndex ), 4 );
+
+      QModelIndexList draggedIndexes;
+      for ( const int sourceRow : sourceRows )
+        draggedIndexes << model.index( sourceRow, 0, tabIndex );
+
+      QMimeData *mimeData = model.mimeData( draggedIndexes );
+      QVERIFY( mimeData );
+
+      const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, targetRow, 0, tabIndex );
+      QVERIFY( dropped );
+      delete mimeData;
+
+      // No item may get lost or duplicated by the move
+      QCOMPARE( model.rowCount( tabIndex ), 4 );
+
+      QStringList order;
+      for ( int r = 0; r < model.rowCount( tabIndex ); ++r )
+        order << model.index( r, 0, tabIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString();
+
+      QCOMPARE( order, expectedOrder );
+    };
+
+    // Move "a" and "b" downward past the end (dropping below "d" appends).
+    // The drop anchor shifts up each time a source above it is taken out;
+    // a buggy implementation loses "b" entirely here.
+    moveFieldsAndVerify( { 0, 1 }, 4, { u"c"_s, u"d"_s, u"a"_s, u"b"_s } );
+
+    // Move "a" and "b" downward in between "c" and "d".
+    moveFieldsAndVerify( { 0, 1 }, 3, { u"c"_s, u"a"_s, u"b"_s, u"d"_s } );
+
+    // Move "c" and "d" upward to the top.
+    moveFieldsAndVerify( { 2, 3 }, 0, { u"c"_s, u"d"_s, u"a"_s, u"b"_s } );
+
+    // Move "b" and "d" (non-adjacent) upward to the top.
+    moveFieldsAndVerify( { 1, 3 }, 0, { u"b"_s, u"d"_s, u"a"_s, u"c"_s } );
+
+    // Move "a" and "c" (non-adjacent) downward past the end.
+    moveFieldsAndVerify( { 0, 2 }, 4, { u"b"_s, u"d"_s, u"a"_s, u"c"_s } );
   }
-}
 
-void TestQgsAttributesFormModel::testFormLayoutModelInternalMultiItemMove()
-{
-  auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer&field=c:integer&field=d:integer"_s, u"test"_s, u"memory"_s );
+  // External drops from the available widgets tree: dropped items must show
+  // the same icon they have in that tree
+  {
+    setUpProjectWithRelation();
 
-  // tab
-  //  ├─ a
-  //  ├─ b
-  //  ├─ c
-  //  └─ d
-  QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
-  tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
-  tab->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, tab ) );
-  tab->addChildElement( new QgsAttributeEditorField( u"c"_s, 2, tab ) );
-  tab->addChildElement( new QgsAttributeEditorField( u"d"_s, 3, tab ) );
+    QgsAttributesAvailableWidgetsModel availableWidgetsModel( mLayer, mProject );
+    availableWidgetsModel.populate();
 
-  QgsEditFormConfig cfg = layer->editFormConfig();
-  cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
-  cfg.clearTabs();
-  cfg.addTab( tab );
-  layer->setEditFormConfig( cfg );
+    QgsAttributesFormLayoutModel formLayoutModel( mLayer, mProject );
+    formLayoutModel.populate();
 
-  // Drag the fields at the given rows onto targetRow and compare the resulting order
-  auto moveFieldsAndVerify = [&layer, this]( const QList< int > &sourceRows, int targetRow, const QStringList &expectedOrder ) {
-    QgsAttributesFormLayoutModel model( layer.get(), mProject );
-    model.populate();
-
-    const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
-    QCOMPARE( model.rowCount( tabIndex ), 4 );
-
+    // Collect one index per item type: a field, a relation and all "other" widgets
     QModelIndexList draggedIndexes;
-    for ( const int sourceRow : sourceRows )
-      draggedIndexes << model.index( sourceRow, 0, tabIndex );
+    draggedIndexes << availableWidgetsModel.index( 0, 0, availableWidgetsModel.fieldContainer() );
+    draggedIndexes << availableWidgetsModel.index( 0, 0, availableWidgetsModel.relationContainer() );
+    const QModelIndex otherWidgetsIndex = availableWidgetsModel.index( 3, 0, QModelIndex() );
+    for ( int i = 0; i < availableWidgetsModel.rowCount( otherWidgetsIndex ); i++ )
+      draggedIndexes << availableWidgetsModel.index( i, 0, otherWidgetsIndex );
 
-    QMimeData *mimeData = model.mimeData( draggedIndexes );
+    QMimeData *mimeData = availableWidgetsModel.mimeData( draggedIndexes );
     QVERIFY( mimeData );
 
-    const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, targetRow, 0, tabIndex );
-    QVERIFY( dropped );
+    const int rowCountBeforeDrop = formLayoutModel.rowCount();
+    QVERIFY( formLayoutModel.dropMimeData( mimeData, Qt::CopyAction, -1, -1, QModelIndex() ) );
     delete mimeData;
 
-    // No item may get lost or duplicated by the move
-    QCOMPARE( model.rowCount( tabIndex ), 4 );
+    QCOMPARE( formLayoutModel.rowCount(), rowCountBeforeDrop + draggedIndexes.count() );
 
-    QStringList order;
-    for ( int r = 0; r < model.rowCount( tabIndex ); ++r )
-      order << model.index( r, 0, tabIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString();
-
-    QCOMPARE( order, expectedOrder );
-  };
-
-  // Move "a" and "b" downward past the end (dropping below "d" appends).
-  // The drop anchor shifts up each time a source above it is taken out;
-  // a buggy implementation loses "b" entirely here.
-  moveFieldsAndVerify( { 0, 1 }, 4, { u"c"_s, u"d"_s, u"a"_s, u"b"_s } );
-
-  // Move "a" and "b" downward in between "c" and "d".
-  moveFieldsAndVerify( { 0, 1 }, 3, { u"c"_s, u"a"_s, u"b"_s, u"d"_s } );
-
-  // Move "c" and "d" upward to the top.
-  moveFieldsAndVerify( { 2, 3 }, 0, { u"c"_s, u"d"_s, u"a"_s, u"b"_s } );
-
-  // Move "b" and "d" (non-adjacent) upward to the top.
-  moveFieldsAndVerify( { 1, 3 }, 0, { u"b"_s, u"d"_s, u"a"_s, u"c"_s } );
-
-  // Move "a" and "c" (non-adjacent) downward past the end.
-  moveFieldsAndVerify( { 0, 2 }, 4, { u"b"_s, u"d"_s, u"a"_s, u"c"_s } );
+    for ( int i = 0; i < draggedIndexes.count(); i++ )
+    {
+      const QModelIndex droppedIndex = formLayoutModel.index( rowCountBeforeDrop + i, 0, QModelIndex() );
+      const QIcon icon = droppedIndex.data( Qt::DecorationRole ).value< QIcon >();
+      QVERIFY2( !icon.isNull(), u"Dropped item '%1' has no icon"_s.arg( droppedIndex.data( QgsAttributesFormModel::ItemNameRole ).toString() ).toUtf8().constData() );
+    }
+  }
 }
 
 void TestQgsAttributesFormModel::testInvalidRelationInAvailableWidgets()

--- a/tests/src/gui/testqgsattributesformmodel.cpp
+++ b/tests/src/gui/testqgsattributesformmodel.cpp
@@ -49,6 +49,7 @@ class TestQgsAttributesFormModel : public QObject
     void testFormLayoutModel();
     void testFormLayoutModelOrphanFields();
     void testFormLayoutModelInternalMove();
+    void testFormLayoutModelInternalMultiItemMove();
     void testInvalidRelationInAvailableWidgets();
     void testInvalidRelationInFormLayout();
 
@@ -752,6 +753,74 @@ void TestQgsAttributesFormModel::testFormLayoutModelInternalMove()
     QgsAttributesFormLayoutModel model( layer.get(), mProject );
     QVERIFY( model.supportedDragActions() & Qt::CopyAction );
   }
+}
+
+void TestQgsAttributesFormModel::testFormLayoutModelInternalMultiItemMove()
+{
+  auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer&field=c:integer&field=d:integer"_s, u"test"_s, u"memory"_s );
+
+  // tab
+  //  ├─ a
+  //  ├─ b
+  //  ├─ c
+  //  └─ d
+  QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
+  tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
+  tab->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, tab ) );
+  tab->addChildElement( new QgsAttributeEditorField( u"c"_s, 2, tab ) );
+  tab->addChildElement( new QgsAttributeEditorField( u"d"_s, 3, tab ) );
+
+  QgsEditFormConfig cfg = layer->editFormConfig();
+  cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+  cfg.clearTabs();
+  cfg.addTab( tab );
+  layer->setEditFormConfig( cfg );
+
+  // Drag the fields at the given rows onto targetRow and compare the resulting order
+  auto moveFieldsAndVerify = [&layer, this]( const QList< int > &sourceRows, int targetRow, const QStringList &expectedOrder ) {
+    QgsAttributesFormLayoutModel model( layer.get(), mProject );
+    model.populate();
+
+    const QModelIndex tabIndex = model.index( 0, 0, QModelIndex() );
+    QCOMPARE( model.rowCount( tabIndex ), 4 );
+
+    QModelIndexList draggedIndexes;
+    for ( const int sourceRow : sourceRows )
+      draggedIndexes << model.index( sourceRow, 0, tabIndex );
+
+    QMimeData *mimeData = model.mimeData( draggedIndexes );
+    QVERIFY( mimeData );
+
+    const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, targetRow, 0, tabIndex );
+    QVERIFY( dropped );
+    delete mimeData;
+
+    // No item may get lost or duplicated by the move
+    QCOMPARE( model.rowCount( tabIndex ), 4 );
+
+    QStringList order;
+    for ( int r = 0; r < model.rowCount( tabIndex ); ++r )
+      order << model.index( r, 0, tabIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString();
+
+    QCOMPARE( order, expectedOrder );
+  };
+
+  // Move "a" and "b" downward past the end (dropping below "d" appends).
+  // The drop anchor shifts up each time a source above it is taken out;
+  // a buggy implementation loses "b" entirely here.
+  moveFieldsAndVerify( { 0, 1 }, 4, { u"c"_s, u"d"_s, u"a"_s, u"b"_s } );
+
+  // Move "a" and "b" downward in between "c" and "d".
+  moveFieldsAndVerify( { 0, 1 }, 3, { u"c"_s, u"a"_s, u"b"_s, u"d"_s } );
+
+  // Move "c" and "d" upward to the top.
+  moveFieldsAndVerify( { 2, 3 }, 0, { u"c"_s, u"d"_s, u"a"_s, u"b"_s } );
+
+  // Move "b" and "d" (non-adjacent) upward to the top.
+  moveFieldsAndVerify( { 1, 3 }, 0, { u"b"_s, u"d"_s, u"a"_s, u"c"_s } );
+
+  // Move "a" and "c" (non-adjacent) downward past the end.
+  moveFieldsAndVerify( { 0, 2 }, 4, { u"b"_s, u"d"_s, u"a"_s, u"c"_s } );
 }
 
 void TestQgsAttributesFormModel::testInvalidRelationInAvailableWidgets()

--- a/tests/src/gui/testqgsattributesformmodel.cpp
+++ b/tests/src/gui/testqgsattributesformmodel.cpp
@@ -706,6 +706,8 @@ void TestQgsAttributesFormModel::testFormLayoutModelDragAndDrop()
       const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, targetRow, 0, tabIndex );
       QVERIFY( dropped );
       delete mimeData;
+      // The internal move is performed from a queued call (see dropMimeData)
+      QCoreApplication::processEvents();
 
       // No duplicate was inserted: the container count is unchanged and the group
       // ended up where we asked, still holding both children.
@@ -754,6 +756,8 @@ void TestQgsAttributesFormModel::testFormLayoutModelDragAndDrop()
       const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, 2, 0, groupIndex );
       QVERIFY( dropped );
       delete mimeData;
+      // The internal move is performed from a queued call (see dropMimeData)
+      QCoreApplication::processEvents();
 
       QCOMPARE( model.rowCount( groupIndex ), 2 );
       QCOMPARE( model.index( 0, 0, groupIndex ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"c"_s );
@@ -807,6 +811,8 @@ void TestQgsAttributesFormModel::testFormLayoutModelDragAndDrop()
       const bool dropped = model.dropMimeData( mimeData, Qt::MoveAction, targetRow, 0, tabIndex );
       QVERIFY( dropped );
       delete mimeData;
+      // The internal move is performed from a queued call (see dropMimeData)
+      QCoreApplication::processEvents();
 
       // No item may get lost or duplicated by the move
       QCOMPARE( model.rowCount( tabIndex ), 4 );

--- a/tests/src/gui/testqgsattributesformproperties.cpp
+++ b/tests/src/gui/testqgsattributesformproperties.cpp
@@ -47,6 +47,7 @@ class TestQgsAttributesFormProperties : public QObject
     void testConfigStored();
     void testRemoveDuplicateField();
     void testDropMultipleItems();
+    void testMoveContainerIntoContainer();
 };
 
 void TestQgsAttributesFormProperties::initTestCase()
@@ -298,6 +299,74 @@ void TestQgsAttributesFormProperties::testDropMultipleItems()
   selectedRowsAndNames( selectedRows, selectedNames );
   QCOMPARE( selectedRows, QList< int >() << 4 << 5 );
   QCOMPARE( selectedNames, QStringList() << u"a"_s << u"b"_s );
+}
+
+void TestQgsAttributesFormProperties::testMoveContainerIntoContainer()
+{
+  // Moving a container into another container (through the filter proxy) must
+  // relocate it, not lose it. This is exercised with the source container
+  // sitting above the destination container under the same parent, so that
+  // removing the source shifts the destination's row — a case that a plain
+  // (non-persistent) destination parent index would get wrong.
+
+  auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer"_s, u"test"_s, u"memory"_s );
+
+  // tab
+  //  ├─ groupA
+  //  │   └─ a
+  //  └─ groupB
+  //      └─ b
+  QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
+  QgsAttributeEditorContainer *groupA = new QgsAttributeEditorContainer( u"groupA"_s, tab );
+  groupA->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, groupA ) );
+  tab->addChildElement( groupA );
+  QgsAttributeEditorContainer *groupB = new QgsAttributeEditorContainer( u"groupB"_s, tab );
+  groupB->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, groupB ) );
+  tab->addChildElement( groupB );
+
+  QgsEditFormConfig cfg = layer->editFormConfig();
+  cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+  cfg.clearTabs();
+  cfg.addTab( tab );
+  layer->setEditFormConfig( cfg );
+
+  QgsAttributesFormProperties attributeFormProperties( layer.get() );
+  attributeFormProperties.init();
+
+  QgsAttributesFormProxyModel *layoutProxy = attributeFormProperties.mFormLayoutProxyModel;
+  QgsAttributesFormLayoutModel *layoutModel = attributeFormProperties.mFormLayoutModel;
+
+  const QModelIndex tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 2 );
+  const QModelIndex groupAProxyIndex = layoutProxy->index( 0, 0, tabProxyIndex );
+  const QModelIndex groupBProxyIndex = layoutProxy->index( 1, 0, tabProxyIndex );
+  QCOMPARE( groupAProxyIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"groupA"_s );
+  QCOMPARE( groupBProxyIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"groupB"_s );
+
+  // Move groupA into groupB (append)
+  QMimeData *mimeData = layoutProxy->mimeData( QModelIndexList() << groupAProxyIndex );
+  QVERIFY( mimeData );
+  QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::MoveAction, -1, -1, groupBProxyIndex ) );
+  delete mimeData;
+
+  // The tab now holds only groupB, which in turn holds [b, groupA]; groupA still holds a.
+  const QModelIndex tabSourceIndex = layoutModel->index( 0, 0, QModelIndex() );
+  QCOMPARE( layoutModel->rowCount( tabSourceIndex ), 1 );
+  const QModelIndex movedGroupB = layoutModel->index( 0, 0, tabSourceIndex );
+  QCOMPARE( movedGroupB.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"groupB"_s );
+  QCOMPARE( layoutModel->rowCount( movedGroupB ), 2 );
+  QCOMPARE( layoutModel->index( 0, 0, movedGroupB ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"b"_s );
+  const QModelIndex movedGroupA = layoutModel->index( 1, 0, movedGroupB );
+  QCOMPARE( movedGroupA.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"groupA"_s );
+  QCOMPARE( layoutModel->rowCount( movedGroupA ), 1 );
+  QCOMPARE( layoutModel->index( 0, 0, movedGroupA ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"a"_s );
+
+  // The proxy must stay consistent with the source model
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 1 );
+  const QModelIndex groupBProxyAfter = layoutProxy->index( 0, 0, tabProxyIndex );
+  QCOMPARE( groupBProxyAfter.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"groupB"_s );
+  QCOMPARE( layoutProxy->rowCount( groupBProxyAfter ), 2 );
+  QCOMPARE( layoutProxy->index( 1, 0, groupBProxyAfter ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"groupA"_s );
 }
 
 QGSTEST_MAIN( TestQgsAttributesFormProperties )

--- a/tests/src/gui/testqgsattributesformproperties.cpp
+++ b/tests/src/gui/testqgsattributesformproperties.cpp
@@ -14,13 +14,17 @@
  ***************************************************************************/
 
 
+#include "qgsattributeeditorcontainer.h"
+#include "qgsattributeeditorfield.h"
 #include "qgsattributesformmodel.h"
 #include "qgsattributesformproperties.h"
 #include "qgsattributesformview.h"
 #include "qgsattributetypedialog.h"
+#include "qgseditformconfig.h"
 #include "qgstest.h"
 #include "qgsvectorlayer.h"
 
+#include <QItemSelectionModel>
 #include <QString>
 
 using namespace Qt::StringLiterals;
@@ -38,6 +42,7 @@ class TestQgsAttributesFormProperties : public QObject
     void cleanup();         // will be called after every testfunction.
 
     void testConfigStored();
+    void testRemoveDuplicateField();
 };
 
 void TestQgsAttributesFormProperties::initTestCase()
@@ -88,6 +93,49 @@ void TestQgsAttributesFormProperties::testConfigStored()
   attributeFormProperties.mAvailableWidgetsView->setCurrentIndex( attributeFormProperties.mAvailableWidgetsProxyModel->mapFromSource( availableWidgetsModel->index( 1, 0, fieldContainer ) ) );
   QVERIFY( attributeFormProperties.mAttributeTypeDialog );
   QCOMPARE( attributeFormProperties.mAttributeTypeDialog->alias(), u"alias1"_s );
+}
+
+void TestQgsAttributesFormProperties::testRemoveDuplicateField()
+{
+  // Regression test for the "removing a duplicate field deletes every copy" bug:
+  // add the same field several times to a tab, select one copy and trigger the
+  // real trash-button slot. Exactly that copy must be removed.
+
+  auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer"_s, u"test"_s, u"memory"_s );
+
+  // tab
+  //  ├─ a   (row 0)
+  //  ├─ a   (row 1)
+  //  └─ a   (row 2)
+  QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
+  tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
+  tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
+  tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
+
+  QgsEditFormConfig cfg = layer->editFormConfig();
+  cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+  cfg.clearTabs();
+  cfg.addTab( tab );
+  layer->setEditFormConfig( cfg );
+
+  QgsAttributesFormProperties attributeFormProperties( layer.get() );
+  attributeFormProperties.init();
+
+  QgsAttributesFormProxyModel *proxy = attributeFormProperties.mFormLayoutProxyModel;
+  const QModelIndex tabProxyIndex = proxy->index( 0, 0, QModelIndex() );
+  QCOMPARE( proxy->rowCount( tabProxyIndex ), 3 );
+
+  // Select the middle duplicate (row 1) in the form layout view, then trigger
+  // the same slot the trash button is connected to.
+  const QModelIndex middle = proxy->index( 1, 0, tabProxyIndex );
+  attributeFormProperties.mFormLayoutView->selectionModel()->setCurrentIndex( middle, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  QCOMPARE( attributeFormProperties.mFormLayoutView->selectionModel()->selectedRows( 0 ).count(), 1 );
+
+  attributeFormProperties.removeTabOrGroupButton();
+
+  // Exactly one copy must have been removed, leaving two behind.
+  QgsAttributesFormLayoutModel *layoutModel = attributeFormProperties.mFormLayoutModel;
+  QCOMPARE( layoutModel->rowCount( layoutModel->index( 0, 0, QModelIndex() ) ), 2 );
 }
 
 QGSTEST_MAIN( TestQgsAttributesFormProperties )

--- a/tests/src/gui/testqgsattributesformproperties.cpp
+++ b/tests/src/gui/testqgsattributesformproperties.cpp
@@ -48,6 +48,7 @@ class TestQgsAttributesFormProperties : public QObject
     void testRemoveDuplicateField();
     void testDropMultipleItems();
     void testMoveContainerIntoContainer();
+    void testMoveTab();
 };
 
 void TestQgsAttributesFormProperties::initTestCase()
@@ -251,7 +252,7 @@ void TestQgsAttributesFormProperties::testDropMultipleItems()
   attributeFormProperties.init();
 
   QgsAttributesFormProxyModel *layoutProxy = attributeFormProperties.mFormLayoutProxyModel;
-  const QModelIndex tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
+  QModelIndex tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
   QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 4 );
 
   // Returns the sorted rows and the names of the currently selected layout items
@@ -272,6 +273,10 @@ void TestQgsAttributesFormProperties::testDropMultipleItems()
   QVERIFY( mimeData );
   QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::MoveAction, 4, 0, tabProxyIndex ) );
   delete mimeData;
+  // The internal move is performed from a queued call (see dropMimeData)
+  QCoreApplication::processEvents();
+  // The move resets the model, so proxy indexes captured earlier are invalid
+  tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
 
   // Resulting order is [c, d, a, b]; both moved items must remain selected
   QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 4 );
@@ -336,7 +341,7 @@ void TestQgsAttributesFormProperties::testMoveContainerIntoContainer()
   QgsAttributesFormProxyModel *layoutProxy = attributeFormProperties.mFormLayoutProxyModel;
   QgsAttributesFormLayoutModel *layoutModel = attributeFormProperties.mFormLayoutModel;
 
-  const QModelIndex tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
+  QModelIndex tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
   QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 2 );
   const QModelIndex groupAProxyIndex = layoutProxy->index( 0, 0, tabProxyIndex );
   const QModelIndex groupBProxyIndex = layoutProxy->index( 1, 0, tabProxyIndex );
@@ -348,6 +353,10 @@ void TestQgsAttributesFormProperties::testMoveContainerIntoContainer()
   QVERIFY( mimeData );
   QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::MoveAction, -1, -1, groupBProxyIndex ) );
   delete mimeData;
+  // The internal move is performed from a queued call (see dropMimeData)
+  QCoreApplication::processEvents();
+  // The move resets the model, so proxy indexes captured earlier are invalid
+  tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
 
   // The tab now holds only groupB, which in turn holds [b, groupA]; groupA still holds a.
   const QModelIndex tabSourceIndex = layoutModel->index( 0, 0, QModelIndex() );
@@ -367,6 +376,74 @@ void TestQgsAttributesFormProperties::testMoveContainerIntoContainer()
   QCOMPARE( groupBProxyAfter.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"groupB"_s );
   QCOMPARE( layoutProxy->rowCount( groupBProxyAfter ), 2 );
   QCOMPARE( layoutProxy->index( 1, 0, groupBProxyAfter ).data( QgsAttributesFormModel::ItemIdRole ).toString(), u"groupA"_s );
+}
+void TestQgsAttributesFormProperties::testMoveTab()
+{
+  // Moving a top-level tab container to another position (a same-parent reorder
+  // at the root level, with each tab holding children) must not crash the
+  // filter proxy and must produce the expected order.
+
+  auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer&field=c:integer&field=d:integer"_s, u"test"_s, u"memory"_s );
+
+  // tab1{a}  tab2{b}  tab3{c}  tab4{d}
+  auto makeTab = []( const QString &name, const QString &field, int fieldIdx ) {
+    QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( name, nullptr );
+    tab->addChildElement( new QgsAttributeEditorField( field, fieldIdx, tab ) );
+    return tab;
+  };
+
+  QgsEditFormConfig cfg = layer->editFormConfig();
+  cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+  cfg.clearTabs();
+  cfg.addTab( makeTab( u"tab1"_s, u"a"_s, 0 ) );
+  cfg.addTab( makeTab( u"tab2"_s, u"b"_s, 1 ) );
+  cfg.addTab( makeTab( u"tab3"_s, u"c"_s, 2 ) );
+  cfg.addTab( makeTab( u"tab4"_s, u"d"_s, 3 ) );
+  layer->setEditFormConfig( cfg );
+
+  QgsAttributesFormProperties attributeFormProperties( layer.get() );
+  attributeFormProperties.init();
+
+  QgsAttributesFormProxyModel *layoutProxy = attributeFormProperties.mFormLayoutProxyModel;
+  QgsAttributesFormLayoutModel *layoutModel = attributeFormProperties.mFormLayoutModel;
+  QCOMPARE( layoutProxy->rowCount( QModelIndex() ), 4 );
+
+  // Build the proxy child mappings for every tab (as an expanded view would)
+  for ( int row = 0; row < 4; ++row )
+  {
+    const QModelIndex tabProxy = layoutProxy->index( row, 0, QModelIndex() );
+    QCOMPARE( layoutProxy->rowCount( tabProxy ), 1 );
+    ( void ) layoutProxy->index( 0, 0, tabProxy );
+  }
+
+  // Move tab3 (row 2) to the front (drop at row 0 among the tabs)
+  const QModelIndex tab3ProxyIndex = layoutProxy->index( 2, 0, QModelIndex() );
+  QCOMPARE( tab3ProxyIndex.data( QgsAttributesFormModel::ItemIdRole ).toString(), u"tab3"_s );
+  QMimeData *mimeData = layoutProxy->mimeData( QModelIndexList() << tab3ProxyIndex );
+  QVERIFY( mimeData );
+  QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::MoveAction, 0, 0, QModelIndex() ) );
+  delete mimeData;
+  // The internal move is performed from a queued call (see dropMimeData)
+  QCoreApplication::processEvents();
+
+  // Order is now tab3, tab1, tab2, tab4 (each keeping its child)
+  QCOMPARE( layoutModel->rowCount( QModelIndex() ), 4 );
+  const QStringList expected { u"tab3"_s, u"tab1"_s, u"tab2"_s, u"tab4"_s };
+  for ( int row = 0; row < 4; ++row )
+  {
+    const QModelIndex tabSource = layoutModel->index( row, 0, QModelIndex() );
+    QCOMPARE( tabSource.data( QgsAttributesFormModel::ItemIdRole ).toString(), expected.at( row ) );
+    QCOMPARE( layoutModel->rowCount( tabSource ), 1 );
+  }
+
+  // The proxy must agree
+  QCOMPARE( layoutProxy->rowCount( QModelIndex() ), 4 );
+  for ( int row = 0; row < 4; ++row )
+  {
+    const QModelIndex tabProxy = layoutProxy->index( row, 0, QModelIndex() );
+    QCOMPARE( tabProxy.data( QgsAttributesFormModel::ItemIdRole ).toString(), expected.at( row ) );
+    QCOMPARE( layoutProxy->rowCount( tabProxy ), 1 );
+  }
 }
 
 QGSTEST_MAIN( TestQgsAttributesFormProperties )

--- a/tests/src/gui/testqgsattributesformproperties.cpp
+++ b/tests/src/gui/testqgsattributesformproperties.cpp
@@ -21,10 +21,13 @@
 #include "qgsattributesformview.h"
 #include "qgsattributetypedialog.h"
 #include "qgseditformconfig.h"
+#include "qgseditorwidgetregistry.h"
+#include "qgsgui.h"
 #include "qgstest.h"
 #include "qgsvectorlayer.h"
 
 #include <QItemSelectionModel>
+#include <QMimeData>
 #include <QString>
 
 using namespace Qt::StringLiterals;
@@ -43,12 +46,14 @@ class TestQgsAttributesFormProperties : public QObject
 
     void testConfigStored();
     void testRemoveDuplicateField();
+    void testDropMultipleItems();
 };
 
 void TestQgsAttributesFormProperties::initTestCase()
 {
   QgsApplication::init();
   QgsApplication::initQgis();
+  QgsGui::editorWidgetRegistry()->initEditors();
 }
 
 void TestQgsAttributesFormProperties::cleanupTestCase()
@@ -97,17 +102,30 @@ void TestQgsAttributesFormProperties::testConfigStored()
 
 void TestQgsAttributesFormProperties::testRemoveDuplicateField()
 {
-  // Regression test for the "removing a duplicate field deletes every copy" bug:
-  // add the same field several times to a tab, select one copy and trigger the
-  // real trash-button slot. Exactly that copy must be removed.
+  /*
+    - removing a copy of a duplicated field must remove exactly that copy
+
+    - dropping a duplicate at or above the currently selected row makes
+      QItemSelectionModel emit a no-op selectionChanged() signal from within
+      rowsAboutToBeInserted(). If the selection-changed handlers react to it
+      by writing to the source model, the proxy model mapping gets corrupted:
+      it gains a phantom row and all subsequent proxy indexes are shifted,
+      leading to wrong items being removed and "QSortFilterProxyModel:
+      inconsistent changes reported by source model" warnings
+
+    - the drop-then-remove flow must also work when appending below the
+      selection and when the selection is changed before removing.
+  */
 
   auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer"_s, u"test"_s, u"memory"_s );
 
   // tab
-  //  ├─ a   (row 0)
+  //  ├─ b   (row 0)
   //  ├─ a   (row 1)
-  //  └─ a   (row 2)
+  //  ├─ a   (row 2)
+  //  └─ a   (row 3)
   QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
+  tab->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, tab ) );
   tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
   tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
   tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
@@ -121,21 +139,165 @@ void TestQgsAttributesFormProperties::testRemoveDuplicateField()
   QgsAttributesFormProperties attributeFormProperties( layer.get() );
   attributeFormProperties.init();
 
-  QgsAttributesFormProxyModel *proxy = attributeFormProperties.mFormLayoutProxyModel;
-  const QModelIndex tabProxyIndex = proxy->index( 0, 0, QModelIndex() );
-  QCOMPARE( proxy->rowCount( tabProxyIndex ), 3 );
+  // Mutating the model from selection-changed handlers while rows are being
+  // inserted or removed corrupts the proxy model mapping
+  QTest::failOnWarning( QRegularExpression( u".*inconsistent changes.*"_s ) );
 
-  // Select the middle duplicate (row 1) in the form layout view, then trigger
-  // the same slot the trash button is connected to.
-  const QModelIndex middle = proxy->index( 1, 0, tabProxyIndex );
-  attributeFormProperties.mFormLayoutView->selectionModel()->setCurrentIndex( middle, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  QgsAttributesFormProxyModel *layoutProxy = attributeFormProperties.mFormLayoutProxyModel;
+  QgsAttributesFormLayoutModel *layoutModel = attributeFormProperties.mFormLayoutModel;
+  const QModelIndex tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
+  const QModelIndex tabSourceIndex = layoutModel->index( 0, 0, QModelIndex() );
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 4 );
+
+  // Select the middle duplicate (row 2) in the form layout view, then trigger
+  // the same slot the trash button is connected to. Exactly that copy must be
+  // removed.
+  attributeFormProperties.mFormLayoutView->selectionModel()->setCurrentIndex( layoutProxy->index( 2, 0, tabProxyIndex ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  QCOMPARE( attributeFormProperties.mFormLayoutView->selectionModel()->selectedRows( 0 ).count(), 1 );
+  attributeFormProperties.removeTabOrGroupButton();
+  QCOMPARE( layoutModel->rowCount( tabSourceIndex ), 3 );
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 3 );
+
+  // Remove the remaining duplicate the same way, leaving [b, a]
+  attributeFormProperties.mFormLayoutView->selectionModel()->setCurrentIndex( layoutProxy->index( 2, 0, tabProxyIndex ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  attributeFormProperties.removeTabOrGroupButton();
+  QCOMPARE( layoutModel->rowCount( tabSourceIndex ), 2 );
+  QCOMPARE( layoutModel->index( 0, 0, tabSourceIndex ).data( QgsAttributesFormModel::ItemNameRole ).toString(), u"b"_s );
+  QCOMPARE( layoutModel->index( 1, 0, tabSourceIndex ).data( QgsAttributesFormModel::ItemNameRole ).toString(), u"a"_s );
+
+  // Select field "a" in the available widgets view, like a user would do before
+  // dragging it. This auto-selects the matching layout item (row 1) and loads
+  // the attribute type dialog.
+  const QgsAttributesAvailableWidgetsModel *availableWidgetsModel = static_cast<QgsAttributesAvailableWidgetsView *>( attributeFormProperties.mAvailableWidgetsView )->availableWidgetsModel();
+  const QModelIndex fieldContainer = availableWidgetsModel->fieldContainer();
+  const QModelIndex fieldAProxyIndex = attributeFormProperties.mAvailableWidgetsProxyModel->mapFromSource( availableWidgetsModel->index( 0, 0, fieldContainer ) );
+  QCOMPARE( fieldAProxyIndex.data( QgsAttributesFormModel::ItemNameRole ).toString(), u"a"_s );
+  attributeFormProperties.mAvailableWidgetsView->selectionModel()->setCurrentIndex( fieldAProxyIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
   QCOMPARE( attributeFormProperties.mFormLayoutView->selectionModel()->selectedRows( 0 ).count(), 1 );
 
-  attributeFormProperties.removeTabOrGroupButton();
+  // Drop a duplicate of field "a" at row 0, i.e. above the selected row
+  QMimeData *mimeData = attributeFormProperties.mAvailableWidgetsProxyModel->mimeData( QModelIndexList() << fieldAProxyIndex );
+  QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::CopyAction, 0, 0, tabProxyIndex ) );
+  delete mimeData;
 
-  // Exactly one copy must have been removed, leaving two behind.
-  QgsAttributesFormLayoutModel *layoutModel = attributeFormProperties.mFormLayoutModel;
-  QCOMPARE( layoutModel->rowCount( layoutModel->index( 0, 0, QModelIndex() ) ), 2 );
+  // The proxy model must stay in sync with the source model
+  QCOMPARE( layoutModel->rowCount( tabSourceIndex ), 3 );
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 3 );
+  for ( int row = 0; row < 3; row++ )
+  {
+    QCOMPARE( layoutProxy->mapToSource( layoutProxy->index( row, 0, tabProxyIndex ) ).row(), row );
+  }
+
+  // The freshly dropped copy (row 0) gets auto-selected; the trash button must
+  // remove exactly that copy
+  QCOMPARE( attributeFormProperties.mFormLayoutView->selectionModel()->selectedRows( 0 ).count(), 1 );
+  attributeFormProperties.removeTabOrGroupButton();
+  QCOMPARE( layoutModel->rowCount( tabSourceIndex ), 2 );
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 2 );
+  QCOMPARE( layoutModel->index( 0, 0, tabSourceIndex ).data( QgsAttributesFormModel::ItemNameRole ).toString(), u"b"_s );
+  QCOMPARE( layoutModel->index( 1, 0, tabSourceIndex ).data( QgsAttributesFormModel::ItemNameRole ).toString(), u"a"_s );
+
+  // Drop the duplicate once more, this time appending it below the selection;
+  // the fresh copy is auto-selected and must be the one removed
+  mimeData = attributeFormProperties.mAvailableWidgetsProxyModel->mimeData( QModelIndexList() << fieldAProxyIndex );
+  QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::CopyAction, -1, -1, tabProxyIndex ) );
+  delete mimeData;
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 3 );
+  QCOMPARE( attributeFormProperties.mFormLayoutView->selectionModel()->selectedRows( 0 ).count(), 1 );
+  attributeFormProperties.removeTabOrGroupButton();
+  QCOMPARE( layoutModel->rowCount( tabSourceIndex ), 2 );
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 2 );
+
+  // Drop it yet again, but this time change the selection to the first copy
+  // before removing. Again, exactly one copy must be removed.
+  mimeData = attributeFormProperties.mAvailableWidgetsProxyModel->mimeData( QModelIndexList() << fieldAProxyIndex );
+  QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::CopyAction, -1, -1, tabProxyIndex ) );
+  delete mimeData;
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 3 );
+
+  attributeFormProperties.mFormLayoutView->selectionModel()->setCurrentIndex( layoutProxy->index( 1, 0, tabProxyIndex ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  attributeFormProperties.removeTabOrGroupButton();
+  QCOMPARE( layoutModel->rowCount( tabSourceIndex ), 2 );
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 2 );
+}
+
+void TestQgsAttributesFormProperties::testDropMultipleItems()
+{
+  // Dropping several items at once onto the form layout tree must leave all
+  // dropped items selected, not only the last one. This holds both for
+  // internal moves and for items dragged from the available widgets tree.
+
+  auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=a:integer&field=b:integer&field=c:integer&field=d:integer"_s, u"test"_s, u"memory"_s );
+
+  // tab
+  //  ├─ a
+  //  ├─ b
+  //  ├─ c
+  //  └─ d
+  QgsAttributeEditorContainer *tab = new QgsAttributeEditorContainer( u"tab"_s, nullptr );
+  tab->addChildElement( new QgsAttributeEditorField( u"a"_s, 0, tab ) );
+  tab->addChildElement( new QgsAttributeEditorField( u"b"_s, 1, tab ) );
+  tab->addChildElement( new QgsAttributeEditorField( u"c"_s, 2, tab ) );
+  tab->addChildElement( new QgsAttributeEditorField( u"d"_s, 3, tab ) );
+
+  QgsEditFormConfig cfg = layer->editFormConfig();
+  cfg.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+  cfg.clearTabs();
+  cfg.addTab( tab );
+  layer->setEditFormConfig( cfg );
+
+  QgsAttributesFormProperties attributeFormProperties( layer.get() );
+  attributeFormProperties.init();
+
+  QgsAttributesFormProxyModel *layoutProxy = attributeFormProperties.mFormLayoutProxyModel;
+  const QModelIndex tabProxyIndex = layoutProxy->index( 0, 0, QModelIndex() );
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 4 );
+
+  // Returns the sorted rows and the names of the currently selected layout items
+  auto selectedRowsAndNames = [&attributeFormProperties]( QList< int > &rows, QStringList &names ) {
+    rows.clear();
+    names.clear();
+    const QModelIndexList selectedIndexes = attributeFormProperties.mFormLayoutView->selectionModel()->selectedRows( 0 );
+    for ( const QModelIndex &index : selectedIndexes )
+      rows << index.row();
+    std::sort( rows.begin(), rows.end() );
+    const QModelIndex parent = selectedIndexes.isEmpty() ? QModelIndex() : selectedIndexes.at( 0 ).parent();
+    for ( const int row : std::as_const( rows ) )
+      names << attributeFormProperties.mFormLayoutView->model()->index( row, 0, parent ).data( QgsAttributesFormModel::ItemNameRole ).toString();
+  };
+
+  // Internal move: drag "a" and "b" (rows 0 and 1) past the end of the tab
+  QMimeData *mimeData = layoutProxy->mimeData( QModelIndexList() << layoutProxy->index( 0, 0, tabProxyIndex ) << layoutProxy->index( 1, 0, tabProxyIndex ) );
+  QVERIFY( mimeData );
+  QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::MoveAction, 4, 0, tabProxyIndex ) );
+  delete mimeData;
+
+  // Resulting order is [c, d, a, b]; both moved items must remain selected
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 4 );
+  QList< int > selectedRows;
+  QStringList selectedNames;
+  selectedRowsAndNames( selectedRows, selectedNames );
+  QCOMPARE( selectedRows, QList< int >() << 2 << 3 );
+  QCOMPARE( selectedNames, QStringList() << u"a"_s << u"b"_s );
+
+  // External drop: drag fields "a" and "b" from the available widgets tree
+  const QgsAttributesAvailableWidgetsModel *availableWidgetsModel = static_cast<QgsAttributesAvailableWidgetsView *>( attributeFormProperties.mAvailableWidgetsView )->availableWidgetsModel();
+  const QModelIndex fieldContainer = availableWidgetsModel->fieldContainer();
+  QModelIndexList availableWidgetsIndexes;
+  availableWidgetsIndexes
+    << attributeFormProperties.mAvailableWidgetsProxyModel->mapFromSource( availableWidgetsModel->index( 0, 0, fieldContainer ) )
+    << attributeFormProperties.mAvailableWidgetsProxyModel->mapFromSource( availableWidgetsModel->index( 1, 0, fieldContainer ) );
+
+  mimeData = attributeFormProperties.mAvailableWidgetsProxyModel->mimeData( availableWidgetsIndexes );
+  QVERIFY( mimeData );
+  QVERIFY( layoutProxy->dropMimeData( mimeData, Qt::CopyAction, -1, -1, tabProxyIndex ) );
+  delete mimeData;
+
+  // Both dropped copies (appended at rows 4 and 5) must be selected
+  QCOMPARE( layoutProxy->rowCount( tabProxyIndex ), 6 );
+  selectedRowsAndNames( selectedRows, selectedNames );
+  QCOMPARE( selectedRows, QList< int >() << 4 << 5 );
+  QCOMPARE( selectedNames, QStringList() << u"a"_s << u"b"_s );
 }
 
 QGSTEST_MAIN( TestQgsAttributesFormProperties )


### PR DESCRIPTION
## Description

This fixes the crash when reordering fields in the from properties tab. #65352  (see first commit).

Second commit is changing the way internal moves are handled. Instead of relying on XML parsing + complete reload of the model (which was causing flickering in the view + the need to restore collapsing state), we rely on moving rows.
One trick is that QAbstractItemView::startDrag actually deletes the source of a successful drop.
see https://github.com/qt/qtbase/blob/3062b68bb821eecde374c832a2ca396cb48fa670/src/widgets/itemviews/qabstractitemview.cpp#L3892-L3894
So, we rely on CopyAction to avoid the deletion.

Fixes #65352

Also fixes an issue that removing an attribute having duplicated widgets was not behaving correctly (multiple deletes).

## AI tool usage

 - [x] AI tool(s) used to spot the 2 issues, assisted in coding, and to write the tests. I assume full responsibility of the code.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
