### PR TITLE
fix sip warning

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -200,7 +200,8 @@ name = \"QGIS\"
 version = \"${COMPLETE_VERSION}\"
 description = \"Python bindings for QGIS\"
 authors = [ \{name = \"The QGIS Community\"\} ]
-license = \{file = \"${CMAKE_SOURCE_DIR}/COPYING\"\}
+license = \"GPL-2.0-Only\"
+license-files = [\"${CMAKE_SOURCE_DIR}/COPYING\"]
 dependencies = [\"${pyqtdist}\"]
 
 [project.urls]


### PR DESCRIPTION
Fixes:
```
pyproject.toml: line 16: the legacy use of 'license' is deprecated and will be removed in SIP v7.0.0, use an SPDX license expression and 'license-files' instead
```