### PR TITLE
Fix zooming and temporal navigation with trackpads on macOS

### DIFF
--- a/doc/CONTRIBUTORS
+++ b/doc/CONTRIBUTORS
@@ -61,6 +61,7 @@ Jeremy Palmer
 Jerrit Collord
 José de Paula R. N. Assis
 Julien Cabieces
+Knut Ørland
 Loïc Bartoletti
 Luiz Motta
 Magnus Homann

--- a/src/app/qgstemporalcontrollerdockwidget.cpp
+++ b/src/app/qgstemporalcontrollerdockwidget.cpp
@@ -29,6 +29,7 @@
 #include <QMessageBox>
 #include <QProgressDialog>
 #include <QUrl>
+#include <QWheelEvent>
 
 #include "moc_qgstemporalcontrollerdockwidget.cpp"
 
@@ -53,24 +54,14 @@ QgsTemporalController *QgsTemporalControllerDockWidget::temporalController()
 
 void QgsTemporalControllerDockWidget::setMapCanvas( QgsMapCanvas *canvas )
 {
-  if ( canvas && canvas->viewport() )
-    canvas->viewport()->installEventFilter( this );
-}
+  if ( !canvas )
+    return;
 
-bool QgsTemporalControllerDockWidget::eventFilter( QObject *object, QEvent *event )
-{
-  if ( event->type() == QEvent::Wheel )
-  {
-    QWheelEvent *wheelEvent = qgis::down_cast<QWheelEvent *>( event );
-    // handle horizontal wheel events by scrubbing timeline
-    if ( wheelEvent->angleDelta().x() != 0 )
-    {
-      const int step = -wheelEvent->angleDelta().x() / 120.0;
-      mControllerWidget->temporalController()->setCurrentFrameNumber( mControllerWidget->temporalController()->currentFrameNumber() + step );
-      return true;
-    }
-  }
-  return QgsDockWidget::eventFilter( object, event );
+  disconnect( mHorizontalScrollConnection );
+  mHorizontalScrollConnection = connect( canvas, &QgsMapCanvas::horizontalWheelScrolled, this, [this]( QWheelEvent *event ) {
+    QgsTemporalNavigationObject *controller = mControllerWidget->temporalController();
+    controller->setCurrentFrameNumber( controller->currentFrameNumber() - event->angleDelta().x() / 120 );
+  } );
 }
 
 void QgsTemporalControllerDockWidget::exportAnimation()

--- a/src/app/qgstemporalcontrollerdockwidget.cpp
+++ b/src/app/qgstemporalcontrollerdockwidget.cpp
@@ -68,7 +68,12 @@ void QgsTemporalControllerDockWidget::setMapCanvas( QgsMapCanvas *canvas )
     }
     mScrollGestureTimer.restart();
 
-    mAccumulatedScrollSteps += event->angleDelta().x() / 120.0;
+    int deltaX = event->angleDelta().x();
+    // Make horizontal scrolling actually feel natural with "natural scrolling" turned on in macOS
+    if ( event->inverted() )
+      deltaX = -deltaX;
+
+    mAccumulatedScrollSteps += deltaX / 120.0;
     const int frameSteps = static_cast<int>( mAccumulatedScrollSteps );
     if ( frameSteps != 0 )
     {

--- a/src/app/qgstemporalcontrollerdockwidget.cpp
+++ b/src/app/qgstemporalcontrollerdockwidget.cpp
@@ -59,8 +59,23 @@ void QgsTemporalControllerDockWidget::setMapCanvas( QgsMapCanvas *canvas )
 
   disconnect( mHorizontalScrollConnection );
   mHorizontalScrollConnection = connect( canvas, &QgsMapCanvas::horizontalWheelScrolled, this, [this]( QWheelEvent *event ) {
-    QgsTemporalNavigationObject *controller = mControllerWidget->temporalController();
-    controller->setCurrentFrameNumber( controller->currentFrameNumber() - event->angleDelta().x() / 120 );
+    // Trackpads may send several "short" scroll events compared to mouse wheels that send one "large" scroll event,
+    // so we need to collect enough scroll "steps" before changing frames.
+    constexpr int WHEEL_RESET_TIMEOUT_MS = 200;
+    if ( event->phase() == Qt::ScrollBegin || !mScrollGestureTimer.isValid() || mScrollGestureTimer.elapsed() > WHEEL_RESET_TIMEOUT_MS )
+    {
+      mAccumulatedScrollSteps = 0;
+    }
+    mScrollGestureTimer.restart();
+
+    mAccumulatedScrollSteps += event->angleDelta().x() / 120.0;
+    const int frameSteps = static_cast<int>( mAccumulatedScrollSteps );
+    if ( frameSteps != 0 )
+    {
+      mAccumulatedScrollSteps -= frameSteps;
+      QgsTemporalNavigationObject *controller = mControllerWidget->temporalController();
+      controller->setCurrentFrameNumber( controller->currentFrameNumber() - frameSteps );
+    }
   } );
 }
 

--- a/src/app/qgstemporalcontrollerdockwidget.h
+++ b/src/app/qgstemporalcontrollerdockwidget.h
@@ -21,6 +21,8 @@
 #include "qgis_app.h"
 #include "qgsdockwidget.h"
 
+#include <QElapsedTimer>
+
 class QgsTemporalControllerWidget;
 class QgsTemporalController;
 class QgsMapCanvas;
@@ -55,9 +57,13 @@ class APP_EXPORT QgsTemporalControllerDockWidget : public QgsDockWidget
 
   private:
     QgsTemporalControllerWidget *mControllerWidget = nullptr;
-    
+
     //! Connection to the current canvas' horizontal scroll signal, so repeated setMapCanvas() calls don't stack handlers
     QMetaObject::Connection mHorizontalScrollConnection;
+    //! Accumulated horizontal scroll, in wheel steps, so fine-grained scrolling advances a frame per whole step
+    double mAccumulatedScrollSteps = 0;
+    //! Time since the last horizontal scroll, used to drop stale accumulation when a new gesture starts
+    QElapsedTimer mScrollGestureTimer;
 };
 
 #endif // QGSTEMPORALCONTROLLERDOCKWIDGET_H

--- a/src/app/qgstemporalcontrollerdockwidget.h
+++ b/src/app/qgstemporalcontrollerdockwidget.h
@@ -49,15 +49,15 @@ class APP_EXPORT QgsTemporalControllerDockWidget : public QgsDockWidget
 
     void setMapCanvas( QgsMapCanvas *canvas );
 
-  protected:
-    bool eventFilter( QObject *object, QEvent *event ) override;
-
   private slots:
 
     void exportAnimation();
 
   private:
     QgsTemporalControllerWidget *mControllerWidget = nullptr;
+    
+    //! Connection to the current canvas' horizontal scroll signal, so repeated setMapCanvas() calls don't stack handlers
+    QMetaObject::Connection mHorizontalScrollConnection;
 };
 
 #endif // QGSTEMPORALCONTROLLERDOCKWIDGET_H

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2740,7 +2740,7 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
   // Zoom the map canvas in response to a mouse wheel event. Moving the
   // wheel forward (away) from the user zooms in
 
-  QgsDebugMsgLevel( "Wheel event delta " + QString::number( e->angleDelta().y() ), 2 );
+  QgsDebugMsgLevel( "Wheel event delta " + QString::number( e->angleDelta().x() ) + " / " + QString::number( e->angleDelta().y() ), 2 );
 
   if ( mMapTool )
   {
@@ -2749,9 +2749,49 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
       return;
   }
 
-  // Forward horizontal scroll events (e.g. for temporal navigation)
-  if ( e->angleDelta().x() != 0 )
+  // Classify scroll direction to ONLY do either vertical (zoom) or horizontal (temporal) navigation
+  // (not both at the same time), with quick timeout as fallback for missing phase info.
+  constexpr int WHEEL_RESET_TIMEOUT_MS = 200;
+  if ( e->phase() == Qt::ScrollBegin || !mLastWheelEventTimer.isValid() || mLastWheelEventTimer.elapsed() > WHEEL_RESET_TIMEOUT_MS )
   {
+    mWheelAxisLock = WheelAxis::Undecided;
+  }
+  mLastWheelEventTimer.restart();
+
+  // Hysteresis to allow switching between horizontal and vertical direction mid-scroll.
+  constexpr int WHEEL_AXIS_BREAKOUT_FACTOR = 20;
+  constexpr int WHEEL_AXIS_BREAKOUT_MIN_DELTA = 10;
+
+  const int absX = std::abs( e->angleDelta().x() );
+  const int absY = std::abs( e->angleDelta().y() );
+  switch ( mWheelAxisLock )
+  {
+    case WheelAxis::Undecided:
+      if ( absX > absY )
+        mWheelAxisLock = WheelAxis::Horizontal;
+      else if ( absY > absX )
+        mWheelAxisLock = WheelAxis::Vertical;
+      // else: ambiguous (equal, or no movement yet) - wait for a clearer event
+      break;
+
+    case WheelAxis::Horizontal:
+      if ( absY >= WHEEL_AXIS_BREAKOUT_MIN_DELTA && absY > ( absX * WHEEL_AXIS_BREAKOUT_FACTOR ) )
+      {
+        mWheelAxisLock = WheelAxis::Vertical;
+      }
+      break;
+
+    case WheelAxis::Vertical:
+      if ( absX >= WHEEL_AXIS_BREAKOUT_MIN_DELTA && absX > ( absY * WHEEL_AXIS_BREAKOUT_FACTOR ) )
+      {
+        mWheelAxisLock = WheelAxis::Horizontal;
+      }
+      break;
+  }
+
+  if ( mWheelAxisLock == WheelAxis::Horizontal )
+  {
+    // Forward horizontal scroll events (e.g. for temporal navigation)
     emit horizontalWheelScrolled( e );
     e->accept();
     return;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2749,6 +2749,14 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
       return;
   }
 
+  // Forward horizontal scroll events (e.g. for temporal navigation)
+  if ( e->angleDelta().x() != 0 )
+  {
+    emit horizontalWheelScrolled( e );
+    e->accept();
+    return;
+  }
+
   if ( e->angleDelta().y() == 0 )
   {
     e->accept();

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1224,6 +1224,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     //! Emit key release event
     void keyReleased( QKeyEvent *e );
 
+    //! Emitted when scrolling horizontally over the canvas
+    void horizontalWheelScrolled( QWheelEvent *event ) SIP_SKIP;
+
     /**
      * Emit map tool changed with the old tool
      */

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -35,6 +35,7 @@
 #include "qgsrectangle.h"
 
 #include <QDomDocument>
+#include <QElapsedTimer>
 #include <QGestureEvent>
 #include <QGraphicsView>
 #include <QTimer>
@@ -1576,6 +1577,18 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
 
 
     QPointer<QgsAbstract2DMapController> mMapController;
+
+    //! Axis a wheel action is locked to, so that a diagonal swipe doesn't mix zooming and temporal navigation
+    enum class WheelAxis
+    {
+      Undecided,
+      Horizontal,
+      Vertical
+    };
+    //! Axis the current wheel action is locked to
+    WheelAxis mWheelAxisLock = WheelAxis::Undecided;
+    //! Time since the last wheel event, used to detect the start of a new wheel event
+    QElapsedTimer mLastWheelEventTimer;
 
     QPointer< QgsStatusBar > mStatusBar;
 

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -75,6 +75,7 @@ class TestQgsMapCanvas : public QObject
     void testMagnificationScale();
     void testScaleLockCanvasResize();
     void testZoomByWheel();
+    void testHorizontalWheelScroll();
     void testShiftZoom();
     void testDragDrop();
     void testZoomResolutions();
@@ -397,6 +398,82 @@ void TestQgsMapCanvas::testZoomByWheel()
   mCanvas->wheelEvent( e.get() );
   QGSCOMPARENEAR( mCanvas->extent().width(), originalWidth, 0.1 );
   QGSCOMPARENEAR( mCanvas->extent().height(), originalHeight, 0.1 );
+}
+
+void TestQgsMapCanvas::testHorizontalWheelScroll()
+{
+  mCanvas->setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+
+  int emitted = 0;
+  QPoint lastAngleDelta;
+  bool lastInverted = false;
+  QObject context;
+  connect( mCanvas, &QgsMapCanvas::horizontalWheelScrolled, &context, [&]( QWheelEvent *event ) {
+    emitted++;
+    lastAngleDelta = event->angleDelta();
+    lastInverted = event->inverted();
+  } );
+
+  // A horizontal wheel notch forwards the event unchanged and does not zoom.
+  QgsRectangle before = mCanvas->extent();
+  auto e = std::make_unique<QWheelEvent>( QPointF(), QPointF(), QPoint(), QPoint( QWheelEvent::DefaultDeltasPerStep, 0 ), Qt::NoButton, Qt::NoModifier, Qt::ScrollBegin, false );
+  mCanvas->wheelEvent( e.get() );
+  QCOMPARE( emitted, 1 );
+  QCOMPARE( lastAngleDelta.x(), QWheelEvent::DefaultDeltasPerStep );
+  QGSCOMPARENEAR( mCanvas->extent().width(), before.width(), 0.0001 );
+  QGSCOMPARENEAR( mCanvas->extent().height(), before.height(), 0.0001 );
+
+  // A mostly-vertical diagonal gesture is locked to the vertical axis: it zooms
+  // and forwards nothing.
+  emitted = 0;
+  before = mCanvas->extent();
+  e = std::make_unique<QWheelEvent>( QPointF(), QPointF(), QPoint(), QPoint( QWheelEvent::DefaultDeltasPerStep / 4, QWheelEvent::DefaultDeltasPerStep ), Qt::NoButton, Qt::NoModifier, Qt::ScrollBegin, false );
+  mCanvas->wheelEvent( e.get() );
+  QCOMPARE( emitted, 0 );
+  QVERIFY( std::fabs( mCanvas->extent().width() - before.width() ) > 0.0001 );
+
+  // A mostly-horizontal diagonal gesture is locked to the horizontal axis: it
+  // forwards the event and does not zoom.
+  emitted = 0;
+  before = mCanvas->extent();
+  e = std::make_unique<QWheelEvent>( QPointF(), QPointF(), QPoint(), QPoint( QWheelEvent::DefaultDeltasPerStep, QWheelEvent::DefaultDeltasPerStep / 4 ), Qt::NoButton, Qt::NoModifier, Qt::ScrollBegin, false );
+  mCanvas->wheelEvent( e.get() );
+  QCOMPARE( emitted, 1 );
+  QCOMPARE( lastAngleDelta.x(), QWheelEvent::DefaultDeltasPerStep );
+  QGSCOMPARENEAR( mCanvas->extent().width(), before.width(), 0.0001 );
+
+  // The event is forwarded verbatim, including a small high-resolution sub-notch
+  // delta and the natural-scroll inverted() flag, leaving accumulation and
+  // direction handling to the consumer.
+  emitted = 0;
+  e = std::make_unique<QWheelEvent>( QPointF(), QPointF(), QPoint(), QPoint( QWheelEvent::DefaultDeltasPerStep / 10, 0 ), Qt::NoButton, Qt::NoModifier, Qt::ScrollBegin, true );
+  mCanvas->wheelEvent( e.get() );
+  QCOMPARE( emitted, 1 );
+  QCOMPARE( lastAngleDelta.x(), QWheelEvent::DefaultDeltasPerStep / 10 );
+  QVERIFY( lastInverted );
+
+  // Start scrolling horizontally, then switch to vertical scroll
+  emitted = 0;
+  e = std::make_unique<QWheelEvent>( QPointF(), QPointF(), QPoint(), QPoint( QWheelEvent::DefaultDeltasPerStep, QWheelEvent::DefaultDeltasPerStep - 1 ), Qt::NoButton, Qt::NoModifier, Qt::ScrollBegin, false );
+  mCanvas->wheelEvent( e.get() );
+  QCOMPARE( emitted, 1 ); // locked horizontal, event forwarded
+  before = mCanvas->extent();
+  e = std::make_unique<QWheelEvent>( QPointF(), QPointF(), QPoint(), QPoint( 0, QWheelEvent::DefaultDeltasPerStep ), Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false );
+  mCanvas->wheelEvent( e.get() );
+  QCOMPARE( emitted, 1 );                                                      // broke out to vertical: nothing forwarded
+  QVERIFY( std::fabs( mCanvas->extent().width() - before.width() ) > 0.0001 ); // it zoomed
+
+  // Check hysteresis when moving slightly off axis
+  emitted = 0;
+  e = std::make_unique<QWheelEvent>( QPointF(), QPointF(), QPoint(), QPoint( QWheelEvent::DefaultDeltasPerStep, 0 ), Qt::NoButton, Qt::NoModifier, Qt::ScrollBegin, false );
+  mCanvas->wheelEvent( e.get() );
+  QCOMPARE( emitted, 1 ); // locked horizontal
+  before = mCanvas->extent();
+  e = std::make_unique<
+    QWheelEvent>( QPointF(), QPointF(), QPoint(), QPoint( QWheelEvent::DefaultDeltasPerStep, QWheelEvent::DefaultDeltasPerStep + QWheelEvent::DefaultDeltasPerStep / 5 ), Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false );
+  mCanvas->wheelEvent( e.get() );
+  QCOMPARE( emitted, 2 );                                              // still horizontal: event forwarded, not enough to break out
+  QGSCOMPARENEAR( mCanvas->extent().width(), before.width(), 0.0001 ); // did not zoom
 }
 
 void TestQgsMapCanvas::testShiftZoom()


### PR DESCRIPTION
## Description

Hello!

I've been a happy QGIS user for many years now, but one thing has always frustrated me:
When using QGIS with a trackpad on macOS, zooming in and out on the map has always been very "stuttery" or "choppy" for seemingly no good reason.
To me, it always seemed like it was some kind rendering issue, but it only occurs for trackpads, not with normal scroll wheels.

Also, I am not alone - several others have reported the same over the years in issue #49319, which this PR fixes.

After getting some AI assistance, I managed to track it down to [this change](https://github.com/qgis/QGIS/commit/ad56216f14f61b20914a9d5dea6bd7ad6e591eff) from 2021 (which also correlates with the issue above).

In short, the issue is that the temporal time controller "eats" ANY scroll event that has only a slight vertical component.
This means that if you scroll to zoom in/out on a trackpad, and the direction is not _perfectly_ vertical, the temporal time controller cancels the zoom!
An easy way to replicate the issue is to scroll diagonally. Nothing will happen, but if you try to do it horizontally, most events will go through and zoom in/out.

The fix for that issue in itself could just be a one-liner, but when I started digging into it, I found that temporal navigation with a trackpad doesn't work as intended either, which grew this PR slightly larger.

The temporal controller expects "perfect" horizontal scroll events, e.g. 120 "ticks" per event, but this is also not true for trackpads events, where one event can have e.g. 5 "ticks".
Currently, the only way to use the temporal navigation with a trackpad on macOS is to scroll _really_ fast (so that one event contains >= 120 ticks), which in turn makes the feature somewhat unusable due to scrolling having momentum on macOS.

To fix the issues, I've done a few things:
1. Instead of having the temporal controller "take over" and filter out scroll events, I've inverted the relationship and let the map canvas manage the scroll events.
   I feel this is a "cleaner" way of doing it (and it makes it more "obvious" that something else is going on with scroll events, rather than a somewhat generic filter being attached). 
   This _does_ modify the API, so I am still a bit unsure if this is the preferred approach?
2. After making both temporal navigation and zooming smooth, I noticed that having both change at the same time felt very unnatural. That's why I added the "axis locking".
   The implementation of it somewhat involved, but it makes the user experience much better if you're trying to "look" for something on a map, navigating both zoom levels and temporally.
   It shouldn't cause any problems with regular mouse users, as those events are strictly vertical or horizontal (never diagonal), and immediately "skip over" the axis locking (I have tested both with trackpad and normal scroll wheels)

I don't have a PC running Windows right now, so it would also be interesting to hear if this patch improves (or regresses) things there as well.

I'm not sure what the "policy" for backporting is, but I think it would be great to have this fix backported, as it isn't too large of a change, and I think it would make other macOS users more happy!

Here is also a quick video showing the before (above) and after (below). The overlay on the left is showing the raw scroll events, first with trackpad, then with regular mouse wheel:

https://github.com/user-attachments/assets/96dbd66e-3ecd-40f2-9aa3-c75acf4b9130


This is my first QGIS PR, so I probably got some stuff wrong, so I'm happy to hear feedback on if I should do some things differently. Very excited about finally getting this issue fixed in QGIS though!

Thanks,
Knut Ørland

## AI tool usage

I have used AI tools to find the bug, and generate parts of the code for the fix, but I have also fully understood the code and what it affects. This description is fully written by myself.