### PR TITLE
Fix removeMenu methods in QgsApp

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14178,6 +14178,7 @@ void QgisApp::removePluginMenu( const QString &name, QAction *action )
   if ( menu->actions().isEmpty() )
   {
     mPluginMenu->removeAction( menu->menuAction() );
+    menu->deleteLater();
   }
   // Remove separator above plugins in Plugin menu if no plugins remain
   QList<QAction *> actions = mPluginMenu->actions();
@@ -14539,6 +14540,7 @@ void QgisApp::removePluginDatabaseMenu( const QString &name, QAction *action )
   if ( menu->actions().isEmpty() )
   {
     mDatabaseMenu->removeAction( menu->menuAction() );
+    menu->deleteLater();
   }
 
   // remove the Database menu from the menuBar if there are no more actions
@@ -14563,6 +14565,7 @@ void QgisApp::removePluginRasterMenu( const QString &name, QAction *action )
   if ( menu->actions().isEmpty() )
   {
     mRasterMenu->removeAction( menu->menuAction() );
+    menu->deleteLater();
   }
 
   // Remove separator above plugins in Raster menu if no plugins remain
@@ -14581,6 +14584,7 @@ void QgisApp::removePluginVectorMenu( const QString &name, QAction *action )
   if ( menu->actions().isEmpty() )
   {
     mVectorMenu->removeAction( menu->menuAction() );
+    menu->deleteLater();
   }
 
   // remove the Vector menu from the menuBar if there are no more actions
@@ -14605,6 +14609,7 @@ void QgisApp::removePluginWebMenu( const QString &name, QAction *action )
   if ( menu->actions().isEmpty() )
   {
     mWebMenu->removeAction( menu->menuAction() );
+    menu->deleteLater();
   }
 
   // remove the Web menu from the menuBar if there are no more actions
@@ -14629,6 +14634,7 @@ void QgisApp::removePluginMeshMenu( const QString &name, QAction *action )
   if ( menu->actions().isEmpty() )
   {
     mMeshMenu->removeAction( menu->menuAction() );
+    menu->deleteLater();
   }
 
   // remove the Mesh menu from the menuBar if there are no more actions

--- a/tests/src/python/test_qgsappstartup.py
+++ b/tests/src/python/test_qgsappstartup.py
@@ -170,6 +170,55 @@ class TestPyQgsAppStartup(unittest.TestCase):
             [testmod + "\n", "--specialScriptArgument's\n", 'a "Quoted" text arg\n'],
         )
 
+    def testIfaceMenuDeletion(self):
+        testfile = "pyqgis_iface_menu_deletion.txt"
+        testfilepath = os.path.join(self.TMP_DIR, testfile).replace("\\", "/")
+        testcode = [
+            f"import sys\nf = open('{testfilepath}', 'a')\n",
+            f"from qgis.utils import iface\n",
+            f"from qgis.PyQt.QtWidgets import QAction, QMenu\n",
+            f"from qgis.PyQt.QtCore import QCoreApplication, QEvent\n",
+            f"menu_name = '&Test Menu'\n"
+            f"action = QAction('Temporary Action', iface.mainWindow())\n"
+            f"iface.removePluginDatabaseMenu(menu_name, action)\n"
+            f"iface.removePluginMenu(menu_name, action)\n"
+            f"iface.removePluginRasterMenu(menu_name, action)\n"
+            f"iface.removePluginVectorMenu(menu_name, action)\n"
+            f"iface.removePluginWebMenu(menu_name, action)\n"
+            f"iface.removePluginMeshMenu(menu_name, action)\n"
+            f"QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)\n"
+            f"QCoreApplication.processEvents()\n"
+            f"menu_count = 0\n"
+            f"for menu in iface.mainWindow().menuBar().findChildren(QMenu):\n"
+            f"    if menu.title() == menu_name:\n"
+            f"        menu_count += 1\n"
+            f"f.write(str(menu_count) + '\\n')\n"
+            f"f.close()\n",
+        ]
+        testmod = os.path.join(self.TMP_DIR, "pyqgis_iface_menu_deletion.py").replace(
+            "\\", "/"
+        )
+        f = open(testmod, "w")
+        f.writelines(testcode)
+        f.close()
+
+        testfile_lines = self.doTestStartup(
+            testFile=testfilepath,
+            timeOut=10,
+            additionalArguments=[
+                "--code",
+                testmod,
+                "--specialScriptArgument's",
+                'a "Quoted" text arg',
+                "--",
+            ],
+        )
+
+        self.assertTrue(
+            int(testfile_lines[0]) == 0,
+            "Menu should have been deleted",
+        )
+
 
 if __name__ == "__main__":
     # look for qgis bin path


### PR DESCRIPTION
## Description
Currently any call to a `removeXMenu` method in QgsApp will create a menu, and not delete it.

This PR calls `menu->deleteLater()` in the respective remove function after `getXMenu()`, which creates an empty menu.

Fixes #66186 and #66407

Supersedes #66440 (unable to reopen)

## AI tool usage

AI was used to do research on methodology and generic syntax. The logic was implemented by hand.

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
