### PR TITLE
[server][ogcapi] Expose JSON-FG and time to QGIS server OAPIF

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -172,9 +172,11 @@ set if geometries are to be correctly automatically reprojected to WGS
 
     void setTransformGeometries( bool activate );
 %Docstring
-Sets whether geometries should be transformed in EPSG 4326 (default
+Sets whether geometries should be transformed in CRS84 (default
 behavior) or just keep as it is. This is only effective if the JSON
-profile is different than "Legacy" (which is the default value).
+profile is "Legacy" (which is the default value) because for the other
+profiles the required transformations are done automatically provided
+that source and destination CRS are sets correctly.
 
 .. versionadded:: 3.12
 %End

--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -173,7 +173,8 @@ set if geometries are to be correctly automatically reprojected to WGS
     void setTransformGeometries( bool activate );
 %Docstring
 Sets whether geometries should be transformed in EPSG 4326 (default
-behavior) or just keep as it is.
+behavior) or just keep as it is. This is only effective if the JSON
+profile is different than "Legacy" (which is the default value).
 
 .. versionadded:: 3.12
 %End

--- a/python/PyQt6/server/auto_additions/qgsserverogcapi.py
+++ b/python/PyQt6/server/auto_additions/qgsserverogcapi.py
@@ -26,6 +26,8 @@ QgsServerOgcApi.ContentType.baseClass = QgsServerOgcApi
 # monkey patching scoped based enum
 QgsServerOgcApi.Profile.Unset.__doc__ = "No profile"
 QgsServerOgcApi.Profile.Rfc7946.__doc__ = "GeoJSON profile according to RFC7946"
+QgsServerOgcApi.Profile.JsonFg.__doc__ = "JSON Feature Geometry profile according to OGC API - Features 1.0"
+QgsServerOgcApi.Profile.JsonFgPlus.__doc__ = "JSON Feature Geometry profile with GeoJSON compatibility extensions"
 QgsServerOgcApi.Profile.RelAsLink.__doc__ = "JSON responses that include links for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-link"
 QgsServerOgcApi.Profile.RelAsKey.__doc__ = "JSON responses that include key for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-key"
 QgsServerOgcApi.Profile.RelAsUri.__doc__ = "JSON responses that include URI for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-uri"
@@ -33,6 +35,8 @@ QgsServerOgcApi.Profile.__doc__ = """JSON profile
 
 * ``Unset``: No profile
 * ``Rfc7946``: GeoJSON profile according to RFC7946
+* ``JsonFg``: JSON Feature Geometry profile according to OGC API - Features 1.0
+* ``JsonFgPlus``: JSON Feature Geometry profile with GeoJSON compatibility extensions
 * ``RelAsLink``: JSON responses that include links for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-link
 * ``RelAsKey``: JSON responses that include key for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-key
 * ``RelAsUri``: JSON responses that include URI for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-uri

--- a/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
@@ -75,10 +75,8 @@ as instances of :py:class:`QgsServerOgcApiHandler`.
     {
       Unset,
       Rfc7946,
-      // This not supported yet but I am leaving it here because
-      // I am very optimistic that it will be supported soon!
-      //  JsonFg,     //!< JSON Feature Geometry profile according to OGC API - Features 1.0
-      //  JsonFgPlus //!< JSON Feature Geometry profile with GeoJSON compatibility extensions
+      JsonFg,
+      JsonFgPlus,
       RelAsLink,
       RelAsKey,
       RelAsUri

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -117,7 +117,11 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
 
   const bool destinationCrsIsRfc7946Compliant = mDestinationCrs.authid() == "OGC:CRS84" || mDestinationCrs.authid() == "EPSG:4326" || mDestinationCrs.authid() == "CRS:84";
   const bool sourceCrsIsRfc7946Compliant = ( mCrs.authid() == "OGC:CRS84" || mCrs.authid() == "CRS:84" || mCrs.authid() == "EPSG:4326" );
-  const bool requiresCRS84geom = mGeoJsonProfile == Qgis::GeoJsonProfile::Rfc7946 || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus;
+  // Output requires CRS84 coordinates if the GeoJSON profile is RFC7946 or JSON-FG+ (which requires RFC7946 compliance for geometries) or if the requested CRS is CRS84
+  const bool requiresCRS84geom = ( mGeoJsonProfile == Qgis::GeoJsonProfile::Rfc7946 || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus ) || destinationCrsIsRfc7946Compliant;
+
+  // Already transformed
+  const bool geomRequiresTransformToDestinationCrs = mCrs != mDestinationCrs;
 
   QgsGeometry geom = feature.geometry();
 
@@ -187,9 +191,14 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
   {
     // If it is JSON-FG plus we need both CRS84 and the requested CRS
     QgsGeometry transformedCRS84Geom = geom;
-    if ( mTransformGeometries )
+
+    if ( requiresCRS84geom )
     {
-      if ( mCrs.isValid() && !sourceCrsIsRfc7946Compliant && ( requiresCRS84geom || destinationCrsIsRfc7946Compliant ) )
+      if ( sourceCrsIsRfc7946Compliant )
+      {
+        transformedCRS84Geom = geom;
+      }
+      else
       {
         try
         {
@@ -200,26 +209,28 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
           Q_UNUSED( cse )
         }
       }
-      // Do we need to transform the main geometry to the destination CRS?
-      if ( mGeoJsonProfile != Qgis::GeoJsonProfile::Rfc7946 )
+    }
+
+    // Do we need to transform the main geometry to the destination CRS?
+    if ( mGeoJsonProfile != Qgis::GeoJsonProfile::Rfc7946 && geomRequiresTransformToDestinationCrs )
+    {
+      if ( destinationCrsIsRfc7946Compliant )
       {
-        if ( destinationCrsIsRfc7946Compliant )
+        geom = transformedCRS84Geom;
+      }
+      else if ( mCrs.isValid() )
+      {
+        try
         {
-          geom = transformedCRS84Geom;
+          geom.transform( mTransform );
         }
-        else if ( mCrs.isValid() && mTransformGeometries )
+        catch ( QgsCsException &cse )
         {
-          try
-          {
-            geom.transform( mTransform );
-          }
-          catch ( QgsCsException &cse )
-          {
-            Q_UNUSED( cse )
-          }
+          Q_UNUSED( cse )
         }
       }
     }
+
 
     std::function<void( json & )> invertCoords;
     invertCoords = [&invertCoords]( json &geometry ) {

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -118,7 +118,8 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
   const bool destinationCrsIsRfc7946Compliant = mDestinationCrs.authid() == "OGC:CRS84" || mDestinationCrs.authid() == "EPSG:4326" || mDestinationCrs.authid() == "CRS:84";
   const bool sourceCrsIsRfc7946Compliant = ( mCrs.authid() == "OGC:CRS84" || mCrs.authid() == "CRS:84" || mCrs.authid() == "EPSG:4326" );
   // Output requires CRS84 coordinates if the GeoJSON profile is RFC7946 or JSON-FG+ (which requires RFC7946 compliance for geometries) or if the requested CRS is CRS84
-  const bool requiresCRS84geom = ( mGeoJsonProfile == Qgis::GeoJsonProfile::Rfc7946 || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus ) || destinationCrsIsRfc7946Compliant;
+  const bool requiresCRS84geom = ( mGeoJsonProfile == Qgis::GeoJsonProfile::Rfc7946 || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus )
+                                 || ( mTransformGeometries && destinationCrsIsRfc7946Compliant );
 
   // Already transformed
   const bool geomRequiresTransformToDestinationCrs = mCrs != mDestinationCrs;

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -154,6 +154,7 @@ class CORE_EXPORT QgsJsonExporter
     /**
      * Sets whether geometries should be transformed in EPSG 4326 (default
      * behavior) or just keep as it is.
+     * This is only effective if the JSON profile is different than "Legacy" (which is the default value).
      * \since QGIS 3.12
      */
     void setTransformGeometries( bool activate ) { mTransformGeometries = activate; }

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -152,9 +152,11 @@ class CORE_EXPORT QgsJsonExporter
     QgsCoordinateReferenceSystem sourceCrs() const;
 
     /**
-     * Sets whether geometries should be transformed in EPSG 4326 (default
+     * Sets whether geometries should be transformed in CRS84 (default
      * behavior) or just keep as it is.
-     * This is only effective if the JSON profile is different than "Legacy" (which is the default value).
+     * This is only effective if the JSON profile is "Legacy" (which is the default value)
+     * because for the other profiles the required transformations are done automatically
+     * provided that source and destination CRS are sets correctly.
      * \since QGIS 3.12
      */
     void setTransformGeometries( bool activate ) { mTransformGeometries = activate; }

--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -132,14 +132,10 @@ QString QgsServerOgcApi::profileToString( const Profile &profile )
   {
     case Profile::Rfc7946:
       return u"json"_s;
-#if 0
-    // This not supported yet but I am leaving it here because
-    // I am very optimistic that it will be supported soon!
     case Profile::JsonFg:
       return u"jsonfg"_s;
     case Profile::JsonFgPlus:
       return u"jsonfg-plus"_s;
-#endif
     case Profile::Unset:
       return QString();
     case Profile::RelAsKey:
@@ -159,20 +155,16 @@ QString QgsServerOgcApi::profileToUri( const Profile &profile )
   {
     case Profile::Rfc7946:
       return u"http://www.opengis.net/def/profile/OGC/0/rfc7946"_s;
-#if 0
-    // This not supported yet but I am leaving it here because
-    // I am very optimistic that it will be supported soon!
     case Profile::JsonFg:
       return u"http://www.opengis.net/def/profile/OGC/0/jsonfg"_s;
     case Profile::JsonFgPlus:
       return u"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus"_s;
-#endif
     case Profile::RelAsKey:
-      return u"http://www.opengis.net/def/profile/ogc/0/rel-as-key"_s;
+      return u"http://www.opengis.net/def/profile/OGC/0/rel-as-key"_s;
     case Profile::RelAsUri:
-      return u"http://www.opengis.net/def/profile/ogc/0/rel-as-uri"_s;
+      return u"http://www.opengis.net/def/profile/OGC/0/rel-as-uri"_s;
     case Profile::RelAsLink:
-      return u"http://www.opengis.net/def/profile/ogc/0/rel-as-link"_s;
+      return u"http://www.opengis.net/def/profile/OGC/0/rel-as-link"_s;
     case Profile::Unset:
       return QString();
   }

--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -154,17 +154,17 @@ QString QgsServerOgcApi::profileToUri( const Profile &profile )
   switch ( profile )
   {
     case Profile::Rfc7946:
-      return u"http://www.opengis.net/def/profile/OGC/0/rfc7946"_s;
+      return u"http://www.opengis.net/def/profile/ogc/0/rfc7946"_s;
     case Profile::JsonFg:
-      return u"http://www.opengis.net/def/profile/OGC/0/jsonfg"_s;
+      return u"http://www.opengis.net/def/profile/ogc/0/jsonfg"_s;
     case Profile::JsonFgPlus:
-      return u"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus"_s;
+      return u"http://www.opengis.net/def/profile/ogc/0/jsonfg-plus"_s;
     case Profile::RelAsKey:
-      return u"http://www.opengis.net/def/profile/OGC/0/rel-as-key"_s;
+      return u"http://www.opengis.net/def/profile/ogc/0/rel-as-key"_s;
     case Profile::RelAsUri:
-      return u"http://www.opengis.net/def/profile/OGC/0/rel-as-uri"_s;
+      return u"http://www.opengis.net/def/profile/ogc/0/rel-as-uri"_s;
     case Profile::RelAsLink:
-      return u"http://www.opengis.net/def/profile/OGC/0/rel-as-link"_s;
+      return u"http://www.opengis.net/def/profile/ogc/0/rel-as-link"_s;
     case Profile::Unset:
       return QString();
   }

--- a/src/server/qgsserverogcapi.h
+++ b/src/server/qgsserverogcapi.h
@@ -94,15 +94,13 @@ class SERVER_EXPORT QgsServerOgcApi : public QgsServerApi
     //! JSON profile
     enum class Profile
     {
-      Unset,   //!< No profile
-      Rfc7946, //!< GeoJSON profile according to RFC7946
-      // This not supported yet but I am leaving it here because
-      // I am very optimistic that it will be supported soon!
-      //  JsonFg,     //!< JSON Feature Geometry profile according to OGC API - Features 1.0
-      //  JsonFgPlus //!< JSON Feature Geometry profile with GeoJSON compatibility extensions
-      RelAsLink, //!< JSON responses that include links for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-link
-      RelAsKey,  //!< JSON responses that include key for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-key
-      RelAsUri   //!< JSON responses that include URI for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-uri
+      Unset,      //!< No profile
+      Rfc7946,    //!< GeoJSON profile according to RFC7946
+      JsonFg,     //!< JSON Feature Geometry profile according to OGC API - Features 1.0
+      JsonFgPlus, //!< JSON Feature Geometry profile with GeoJSON compatibility extensions
+      RelAsLink,  //!< JSON responses that include links for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-link
+      RelAsKey,   //!< JSON responses that include key for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-key
+      RelAsUri    //!< JSON responses that include URI for referenced resources http://www.opengis.net/def/profile/ogc/0/rel-as-uri
     };
     Q_ENUM( Profile )
 

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -579,6 +579,16 @@ QgsServerOgcApi::Profile QgsServerOgcApiHandler::profileFromString( const QStrin
     ok = true;
     return QgsServerOgcApi::Profile::Rfc7946;
   }
+  else if ( profile.compare( "JSON-FG"_L1, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+  {
+    ok = true;
+    return QgsServerOgcApi::Profile::JsonFg;
+  }
+  else if ( profile.compare( "JSON-FG-PLUS"_L1, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+  {
+    ok = true;
+    return QgsServerOgcApi::Profile::JsonFgPlus;
+  }
   else if ( profile.compare( "REL-AS-KEY"_L1, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
   {
     ok = true;

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -448,8 +448,6 @@ void QgsWfs3AbstractItemsHandler::gatherLayerFieldsInfo( json &data, const QgsVe
       {
         fInfo.format = "date-time";
         fInfo.type = "string";
-        // TODO: connect with temporal properties
-        // fInfo.role = "primary-instant";
         break;
       }
       case QMetaType::Type::QTime:
@@ -501,13 +499,23 @@ void QgsWfs3AbstractItemsHandler::gatherLayerFieldsInfo( json &data, const QgsVe
   }
 
   QList<QString> publishedFieldNames;
+  QgsAttributeList publishedAttributeIds;
   for ( const QgsField &f : std::as_const( constPublishedFields ) )
   {
     publishedFieldNames.push_back( f.name() );
+    publishedAttributeIds.push_back( mapLayer->fields().lookupField( f.name() ) );
   }
 
   // Cannot be const :/
   QgsEditFormConfig config { mapLayer->editFormConfig() };
+
+  // See: https://docs.ogc.org/is/21-045r1/21-045r1.html#_temporal_information
+  QString temporalInstantField;
+  QString temporalStartField;
+  QString temporalEndField;
+  bool isDateTimeField = false;
+
+  exposedTimeDimensions( temporalInstantField, temporalStartField, temporalEndField, isDateTimeField, mapLayer, publishedAttributeIds );
 
   std::function< void( QgsAttributeEditorElement * )> traverseTab;
   traverseTab = [&]( QgsAttributeEditorElement *element ) -> void {
@@ -682,7 +690,7 @@ void QgsWfs3AbstractItemsHandler::gatherLayerFieldsInfo( json &data, const QgsVe
         }
         else
         {
-          // FIXME: if the widget type is unknown, should we skip the field or include it with best effort?
+          // TODO: if the widget type is unknown, should we skip the field or include it with best effort?
           //         For instance, if a relation is set, we could still include the reference information even
           //         if the widget type is unknown.
           //         For now, we skip and warn (info level) assuming that if the widget is not set this is intentional.
@@ -744,6 +752,25 @@ void QgsWfs3AbstractItemsHandler::gatherLayerFieldsInfo( json &data, const QgsVe
         if ( const QString suffix = widgetConfig.value( u"Suffix"_s ).toString(); !suffix.isEmpty() )
         {
           fInfo.unit = suffix.toStdString();
+        }
+
+        // Time dimension
+        // FIXME: It isn't clear if a date can be used as an instant or as a start/end of an interval.
+        // For now, we assume it doesn't
+        if ( isDateTimeField )
+        {
+          if ( field.name() == temporalInstantField )
+          {
+            fInfo.role = "primary-instant";
+          }
+          else if ( field.name() == temporalStartField )
+          {
+            fInfo.role = "primary-interval-start";
+          }
+          else if ( field.name() == temporalEndField )
+          {
+            fInfo.role = "primary-interval-end";
+          }
         }
 
         availableFieldInformation.push_back( fInfo );
@@ -2807,6 +2834,9 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
   // Retrieve feature from storage
   const QString featureId { match.captured( u"featureId"_s ) };
   QgsFeatureRequest featureRequest = filteredRequest( mapLayer, context );
+
+  // Set destination CRS
+  featureRequest.setDestinationCrs( requestedCrs, context.project()->transformContext() );
 
   const QString fidExpression { QgsServerFeatureId::getExpressionFromServerFid( featureId, mapLayer->dataProvider() ) };
   if ( !fidExpression.isEmpty() )

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -43,6 +43,7 @@
 #include "qgsvaluemapfieldformatter.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectorlayertemporalproperties.h"
 #include "qgsvectorlayerutils.h"
 
 #include <QString>
@@ -1763,6 +1764,20 @@ void QgsWfs3CollectionsItemsHandler::writeJsonOutput( const QgsVectorLayer *mapL
   exporter.setAttributes( featureRequest.subsetOfAttributes() );
   exporter.setAttributeDisplayName( true );
   exporter.setTransformGeometries( false );
+  if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFg ) )
+  {
+    exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::JsonFg );
+  }
+  else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFgPlus ) )
+  {
+    exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::JsonFgPlus );
+  }
+  else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::Rfc7946 ) )
+  {
+    // This is the default anyways but better explicit than implicit
+    exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::Rfc7946 );
+  }
+
   QgsFeatureList featureList;
   QgsFeatureIterator features { mapLayer->getFeatures( featureRequest ) };
   QgsFeature feat;
@@ -1815,13 +1830,81 @@ void QgsWfs3CollectionsItemsHandler::writeJsonOutput( const QgsVectorLayer *mapL
     }
   }
 
-  // Patch feature
+  // See: https://docs.ogc.org/is/21-045r1/21-045r1.html#_temporal_information
+  QString temporalInstantField;
+  QString temporalStartField;
+  QString temporalEndField;
+  const QgsVectorLayerTemporalProperties *temporalProperties = static_cast<QgsVectorLayerTemporalProperties *>( const_cast<QgsVectorLayer *>( mapLayer )->temporalProperties() );
+  if ( temporalProperties && temporalProperties->isActive() )
+  {
+    switch ( temporalProperties->mode() )
+    {
+      case Qgis::VectorTemporalMode::FeatureDateTimeInstantFromField:
+      {
+        temporalInstantField = temporalProperties->startField();
+        break;
+      }
+      case Qgis::VectorTemporalMode::FeatureDateTimeStartAndEndFromFields:
+
+      {
+        temporalStartField = temporalProperties->startField();
+        temporalEndField = temporalProperties->endField();
+        break;
+      }
+      default:
+      {
+        // Not supported for now.
+      }
+    }
+  }
+
+  // Patch features
   //  - IDs with server feature IDs
   //  - add references
   //  - format extra geometries
+  //  - add "time" if needed
+
   for ( int i = 0; i < featureList.length(); i++ )
   {
     data["features"][i]["id"] = fidMap.value( data["features"][i]["id"] ).toStdString();
+
+    if ( !temporalInstantField.isEmpty() )
+    {
+      const int instantField = mapLayer->fields().lookupField( temporalInstantField );
+      if ( requestedAttributes.contains( instantField ) )
+      {
+        if ( mapLayer->fields().at( instantField ).type() == QMetaType::QDateTime )
+        {
+          const QDateTime instant = featureList[i].attribute( instantField ).toDateTime();
+          data["features"][i]["time"] = { { "timestamp", instant.toString( Qt::ISODate ).toStdString() } };
+        }
+        else if ( mapLayer->fields().at( instantField ).type() == QMetaType::QDate )
+        {
+          data["features"][i]["time"] = { { "date", featureList[i].attribute( instantField ).toDate().toString( Qt::ISODate ).toStdString() } };
+        }
+      }
+    }
+    else if ( !temporalStartField.isEmpty() && !temporalEndField.isEmpty() )
+    {
+      const int startField = mapLayer->fields().lookupField( temporalStartField );
+      const int endField = mapLayer->fields().lookupField( temporalEndField );
+      if ( requestedAttributes.contains( startField ) && requestedAttributes.contains( endField ) )
+      {
+        if ( mapLayer->fields().at( startField ).type() == QMetaType::QDateTime && mapLayer->fields().at( endField ).type() == QMetaType::QDateTime )
+        {
+          const QDateTime start = featureList[i].attribute( startField ).toDateTime();
+          const QDateTime end = featureList[i].attribute( endField ).toDateTime();
+          data["features"][i]["time"] = { { "interval", { start.toString( Qt::ISODate ).toStdString(), "..", end.toString( Qt::ISODate ).toStdString() } } };
+        }
+        else if ( mapLayer->fields().at( startField ).type() == QMetaType::QDate && mapLayer->fields().at( endField ).type() == QMetaType::QDate )
+        {
+          data["features"][i]["time"] = {
+            { "interval",
+              { featureList[i].attribute( startField ).toDate().toString( Qt::ISODate ).toStdString(), "..", featureList[i].attribute( endField ).toDate().toString( Qt::ISODate ).toStdString() } }
+          };
+        }
+      }
+    }
 
     // Add referenced objects
     if ( hasReferencedObjects && relAs != QgsServerOgcApi::Profile::Unset )
@@ -2175,13 +2258,9 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
   // Add alternate links
   apiContext.response()->addHeader( u"Link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::Rfc7946, u"This document as GEOJSON"_s ) );
   apiContext.response()->addHeader( u"Link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::HTML, QgsServerOgcApi::Profile::Unset, u"This document as HTML"_s ) );
-#if 0
-    // This not supported yet but I am leaving it here because
-    // I am very optimistic that it will be supported soon!
-  context.response()->setHeader( u"link"_s, headerLink( context, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::JSONFG, u"This document as JSONFG"_s ) );
-  context.response()
-    ->setHeader( u"link"_s, headerLink( context, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::JSONFG_PLUS, u"This document as JSONFG-PLUS"_s ) );
-#endif
+  apiContext.response()->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::JsonFg, u"This document as JSONFG"_s ) );
+  apiContext.response()
+    ->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::JsonFgPlus, u"This document as JSONFG-PLUS"_s ) );
 
   // Add next link
   if ( exportContext.limit + exportContext.offset < matchedFeaturesCount )
@@ -2701,6 +2780,20 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
     exporter.setSourceCrs( mapLayer->crs() );
     exporter.setDestinationCrs( requestedCrs );
 
+    if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFg ) )
+    {
+      exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::JsonFg );
+    }
+    else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFgPlus ) )
+    {
+      exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::JsonFgPlus );
+    }
+    else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::Rfc7946 ) )
+    {
+      // This is the default anyways but better explicit than implicit
+      exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::Rfc7946 );
+    }
+
     QMap<int, ReferencedLayerInfo> referencedInfo = gatherReferencedLayerInfo( mapLayer, context );
     // remove if attributes are not requested
     referencedInfo.erase(
@@ -2710,6 +2803,32 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
     QgsServerOgcApi::Profile relAs = QgsServerOgcApi::Profile::Unset;
     bool hasReferencedObjects = !referencedInfo.isEmpty();
 
+    QString temporalInstantField;
+    QString temporalStartField;
+    QString temporalEndField;
+    const QgsVectorLayerTemporalProperties *temporalProperties = static_cast<QgsVectorLayerTemporalProperties *>( const_cast<QgsVectorLayer *>( mapLayer )->temporalProperties() );
+    if ( temporalProperties && temporalProperties->isActive() )
+    {
+      switch ( temporalProperties->mode() )
+      {
+        case Qgis::VectorTemporalMode::FeatureDateTimeInstantFromField:
+        {
+          temporalInstantField = temporalProperties->startField();
+          break;
+        }
+        case Qgis::VectorTemporalMode::FeatureDateTimeStartAndEndFromFields:
+
+        {
+          temporalStartField = temporalProperties->startField();
+          temporalEndField = temporalProperties->endField();
+          break;
+        }
+        default:
+        {
+          // Not supported for now.
+        }
+      }
+    }
     json data = exporter.exportFeatureToJsonObject( feature );
 
     // Patch feature
@@ -2717,6 +2836,26 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
     //  - add references
     //  - format extra geometries
     data["id"] = featureId.toStdString();
+
+    if ( !temporalInstantField.isEmpty() )
+    {
+      data["time"] = { { "timestamp", feature.attribute( temporalInstantField ).toDateTime().toString( Qt::ISODate ).toStdString() } };
+    }
+    else if ( !temporalStartField.isEmpty() && !temporalEndField.isEmpty() )
+    {
+      data["time"] = {
+        { "interval",
+          { feature.attribute( temporalStartField ).toDateTime().toString( Qt::ISODate ).toStdString(), "..", feature.attribute( temporalEndField ).toDateTime().toString( Qt::ISODate ).toStdString() } }
+      };
+    }
+    else if ( !temporalStartField.isEmpty() )
+    {
+      data["time"] = { { "interval", { feature.attribute( temporalStartField ).toDateTime().toString( Qt::ISODate ).toStdString(), ".." } } };
+    }
+    else if ( !temporalEndField.isEmpty() )
+    {
+      data["time"] = { { "interval", { "..", feature.attribute( temporalEndField ).toDateTime().toString( Qt::ISODate ).toStdString() } } };
+    }
 
     if ( hasReferencedObjects )
     {

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1690,6 +1690,121 @@ json QgsWfs3CollectionsItemsHandler::schema( const QgsServerApiContext &context 
   return data;
 }
 
+void QgsWfs3AbstractItemsHandler::exposedTimeDimensions(
+  QString &temporalInstantField, QString &temporalStartField, QString &temporalEndField, bool &isDateTime, const QgsVectorLayer *mapLayer, const QgsAttributeList &requestedAttributes
+) const
+{
+  const QgsMapLayerServerProperties *serverProperties = mapLayer->serverProperties();
+  QList<QgsMapLayerServerProperties::WmsDimensionInfo> dimensions { serverProperties->wmsDimensions() };
+  isDateTime = false;
+
+  for ( const QgsMapLayerServerProperties::WmsDimensionInfo &dimension : std::as_const( dimensions ) )
+  {
+    if ( dimension.name == "time" || dimension.name == "date" )
+    {
+      if ( dimension.fieldName.isEmpty() )
+      {
+        continue;
+      }
+      else if ( dimension.endFieldName.isEmpty() )
+      {
+        if ( !requestedAttributes.contains( mapLayer->fields().indexOf( dimension.fieldName ) ) )
+        {
+          continue;
+        }
+        temporalInstantField = dimension.fieldName;
+      }
+      else
+      {
+        if ( !requestedAttributes.contains( mapLayer->fields().indexOf( dimension.fieldName ) ) || !requestedAttributes.contains( mapLayer->fields().indexOf( dimension.endFieldName ) ) )
+        {
+          continue;
+        }
+        temporalStartField = dimension.fieldName;
+        temporalEndField = dimension.endFieldName;
+      }
+      isDateTime = dimension.name == "time";
+    }
+  }
+}
+
+json QgsWfs3AbstractItemsHandler::timeDimensionInfo( const QgsFeature &feature, const QString &temporalInstantField, const QString &temporalStartField, const QString &temporalEndField, bool isDateTime ) const
+{
+  json data = json::object();
+
+  if ( !temporalInstantField.isEmpty() )
+  {
+    if ( isDateTime )
+    {
+      data["time"] = { { "timestamp", feature.attribute( temporalInstantField ).toDateTime().toUTC().toString( Qt::ISODate ).toStdString() } };
+    }
+    else
+    {
+      data["time"] = { { "date", feature.attribute( temporalInstantField ).toDate().toString( Qt::ISODate ).toStdString() } };
+    }
+  }
+  else if ( !temporalStartField.isEmpty() && !temporalEndField.isEmpty() )
+  {
+    if ( isDateTime )
+    {
+      data["time"] = {
+        { "interval",
+          { feature.attribute( temporalStartField ).toDateTime().toUTC().toString( Qt::ISODate ).toStdString(),
+            feature.attribute( temporalEndField ).toDateTime().toUTC().toString( Qt::ISODate ).toStdString() } }
+      };
+    }
+    else
+    {
+      data["time"] = {
+        { "interval", { feature.attribute( temporalStartField ).toDate().toString( Qt::ISODate ).toStdString(), feature.attribute( temporalEndField ).toDate().toString( Qt::ISODate ).toStdString() } }
+      };
+    }
+  }
+  else if ( !temporalStartField.isEmpty() )
+  {
+    if ( isDateTime )
+    {
+      data["time"] = { { "interval", { feature.attribute( temporalStartField ).toDateTime().toUTC().toString( Qt::ISODate ).toStdString(), ".." } } };
+    }
+    else
+    {
+      data["time"] = { { "interval", { feature.attribute( temporalStartField ).toDate().toString( Qt::ISODate ).toStdString(), ".." } } };
+    }
+  }
+  else if ( !temporalEndField.isEmpty() )
+  {
+    if ( isDateTime )
+    {
+      data["time"] = { { "interval", { "..", feature.attribute( temporalEndField ).toDateTime().toUTC().toString( Qt::ISODate ).toStdString() } } };
+    }
+    else
+    {
+      data["time"] = { { "interval", { "..", feature.attribute( temporalEndField ).toDate().toString( Qt::ISODate ).toStdString() } } };
+    }
+  }
+  return data;
+}
+
+Qgis::GeoJsonProfile QgsWfs3AbstractItemsHandler::jsonProfileFromRequest( const QgsServerApiContext &context ) const
+{
+  const QList<QgsServerOgcApi::Profile> requestedProfiles = profilesFromRequest( context.request() );
+
+  if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFg ) )
+  {
+    return Qgis::GeoJsonProfile::JsonFg;
+  }
+  else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFgPlus ) )
+  {
+    return Qgis::GeoJsonProfile::JsonFgPlus;
+  }
+  else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::Rfc7946 ) )
+  {
+    return Qgis::GeoJsonProfile::Rfc7946;
+  }
+
+  return Qgis::GeoJsonProfile::Legacy;
+}
+
 const QList<QgsServerQueryStringParameter> QgsWfs3CollectionsItemsHandler::fieldParameters( const QgsVectorLayer *mapLayer, const QgsServerApiContext &context ) const
 {
   QList<QgsServerQueryStringParameter> params;
@@ -1759,24 +1874,18 @@ void QgsWfs3CollectionsItemsHandler::writeJsonOutput( const QgsVectorLayer *mapL
       relAs = QgsServerOgcApi::Profile::RelAsKey;
   }
 
+  const Qgis::GeoJsonProfile currentProfile { jsonProfileFromRequest( context ) };
+
   // Exporter for JSON output
   QgsJsonExporter exporter { const_cast<QgsVectorLayer *>( mapLayer ) };
   exporter.setAttributes( featureRequest.subsetOfAttributes() );
   exporter.setAttributeDisplayName( true );
+  // Geometries are already transformed by the feature request
   exporter.setTransformGeometries( false );
-  if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFg ) )
-  {
-    exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::JsonFg );
-  }
-  else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFgPlus ) )
-  {
-    exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::JsonFgPlus );
-  }
-  else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::Rfc7946 ) )
-  {
-    // This is the default anyways but better explicit than implicit
-    exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::Rfc7946 );
-  }
+  // Note: the feature geometry is already in the requested CRS
+  exporter.setSourceCrs( featureRequest.destinationCrs() );
+  exporter.setDestinationCrs( featureRequest.destinationCrs() );
+  exporter.setGeoJsonProfile( currentProfile );
 
   QgsFeatureList featureList;
   QgsFeatureIterator features { mapLayer->getFeatures( featureRequest ) };
@@ -1834,28 +1943,11 @@ void QgsWfs3CollectionsItemsHandler::writeJsonOutput( const QgsVectorLayer *mapL
   QString temporalInstantField;
   QString temporalStartField;
   QString temporalEndField;
-  const QgsVectorLayerTemporalProperties *temporalProperties = static_cast<QgsVectorLayerTemporalProperties *>( const_cast<QgsVectorLayer *>( mapLayer )->temporalProperties() );
-  if ( temporalProperties && temporalProperties->isActive() )
-  {
-    switch ( temporalProperties->mode() )
-    {
-      case Qgis::VectorTemporalMode::FeatureDateTimeInstantFromField:
-      {
-        temporalInstantField = temporalProperties->startField();
-        break;
-      }
-      case Qgis::VectorTemporalMode::FeatureDateTimeStartAndEndFromFields:
+  bool isDateTimeField = false;
 
-      {
-        temporalStartField = temporalProperties->startField();
-        temporalEndField = temporalProperties->endField();
-        break;
-      }
-      default:
-      {
-        // Not supported for now.
-      }
-    }
+  if ( currentProfile == Qgis::GeoJsonProfile::JsonFg || currentProfile == Qgis::GeoJsonProfile::JsonFgPlus )
+  {
+    exposedTimeDimensions( temporalInstantField, temporalStartField, temporalEndField, isDateTimeField, mapLayer, requestedAttributes );
   }
 
   // Patch features
@@ -1868,41 +1960,13 @@ void QgsWfs3CollectionsItemsHandler::writeJsonOutput( const QgsVectorLayer *mapL
   {
     data["features"][i]["id"] = fidMap.value( data["features"][i]["id"] ).toStdString();
 
-    if ( !temporalInstantField.isEmpty() )
+    // Temporal
+    if ( currentProfile == Qgis::GeoJsonProfile::JsonFg || currentProfile == Qgis::GeoJsonProfile::JsonFgPlus )
     {
-      const int instantField = mapLayer->fields().lookupField( temporalInstantField );
-      if ( requestedAttributes.contains( instantField ) )
+      const json timeData = timeDimensionInfo( featureList[i], temporalInstantField, temporalStartField, temporalEndField, isDateTimeField );
+      if ( timeData.contains( "time" ) )
       {
-        if ( mapLayer->fields().at( instantField ).type() == QMetaType::QDateTime )
-        {
-          const QDateTime instant = featureList[i].attribute( instantField ).toDateTime();
-          data["features"][i]["time"] = { { "timestamp", instant.toString( Qt::ISODate ).toStdString() } };
-        }
-        else if ( mapLayer->fields().at( instantField ).type() == QMetaType::QDate )
-        {
-          data["features"][i]["time"] = { { "date", featureList[i].attribute( instantField ).toDate().toString( Qt::ISODate ).toStdString() } };
-        }
-      }
-    }
-    else if ( !temporalStartField.isEmpty() && !temporalEndField.isEmpty() )
-    {
-      const int startField = mapLayer->fields().lookupField( temporalStartField );
-      const int endField = mapLayer->fields().lookupField( temporalEndField );
-      if ( requestedAttributes.contains( startField ) && requestedAttributes.contains( endField ) )
-      {
-        if ( mapLayer->fields().at( startField ).type() == QMetaType::QDateTime && mapLayer->fields().at( endField ).type() == QMetaType::QDateTime )
-        {
-          const QDateTime start = featureList[i].attribute( startField ).toDateTime();
-          const QDateTime end = featureList[i].attribute( endField ).toDateTime();
-          data["features"][i]["time"] = { { "interval", { start.toString( Qt::ISODate ).toStdString(), "..", end.toString( Qt::ISODate ).toStdString() } } };
-        }
-        else if ( mapLayer->fields().at( startField ).type() == QMetaType::QDate && mapLayer->fields().at( endField ).type() == QMetaType::QDate )
-        {
-          data["features"][i]["time"] = {
-            { "interval",
-              { featureList[i].attribute( startField ).toDate().toString( Qt::ISODate ).toStdString(), "..", featureList[i].attribute( endField ).toDate().toString( Qt::ISODate ).toStdString() } }
-          };
-        }
+        data["features"][i].update( timeData );
       }
     }
 
@@ -2341,6 +2405,13 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
         throw QgsServerApiBadRequestException( u"Requested CRS is not valid"_s );
       }
 
+      // Check if requested profile is Rfc7946, if so, the requested CRS must be OGC:CRS84
+      const Qgis::GeoJsonProfile requestedProfile { jsonProfileFromRequest( context ) };
+      if ( requestedProfile == Qgis::GeoJsonProfile::Rfc7946 && requestedCrs.authid() != "OGC:CRS84"_L1 )
+      {
+        throw QgsServerApiBadRequestException( u"Requested CRS must be OGC:CRS84 when requested profile is Rfc7946"_s );
+      }
+
       // resultType
       const QString resultType { params[u"resultType"_s].toString() };
       static const QStringList availableResultTypes { u"results"_s, u"hits"_s };
@@ -2480,7 +2551,9 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       }
 
       // WFS3 initial core specs only serves CRS84 but we support transformations with new profiles
+      // unless requested profile is Rfc 7946 (CRS84) then we transform to the requested CRS
       featureRequest.setDestinationCrs( requestedCrs, context.project()->transformContext() );
+
       // Add offset to limit because paging is not supported by QgsFeatureRequest
       featureRequest.setLimit( limit + offset );
 
@@ -2714,6 +2787,13 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
     throw QgsServerApiBadRequestException( u"Requested CRS is not valid"_s );
   }
 
+  // Check if requested profile is Rfc7946, if so, the requested CRS must be OGC:CRS84
+  const Qgis::GeoJsonProfile requestedProfile { jsonProfileFromRequest( context ) };
+  if ( requestedProfile == Qgis::GeoJsonProfile::Rfc7946 && requestedCrs.authid() != "OGC:CRS84"_L1 )
+  {
+    throw QgsServerApiBadRequestException( u"Requested CRS must be OGC:CRS84 when requested profile is Rfc7946"_s );
+  }
+
   const QString collectionId { match.captured( u"collectionId"_s ) };
   // May throw if not found
   QgsVectorLayer *mapLayer { layerFromCollectionId( context, collectionId ) };
@@ -2757,8 +2837,6 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
     throw QgsServerApiInternalServerError( u"Invalid feature [%1]"_s.arg( featureId ) );
   }
 
-  const QList<QgsServerOgcApi::Profile> requestedProfiles = profilesFromRequest( context.request() );
-
   auto doGet = [&]() {
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = context.serverInterface()->accessControls();
@@ -2773,26 +2851,17 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
 
     const QgsAttributeList requestedAttributes = featureRequest.subsetOfAttributes();
 
+    // Note: the feature geometry is already in the requested CRS
     QgsJsonExporter exporter { mapLayer };
     exporter.setAttributes( requestedAttributes );
     exporter.setAttributeDisplayName( true );
-    exporter.setTransformGeometries( true );
-    exporter.setSourceCrs( mapLayer->crs() );
+    exporter.setTransformGeometries( false );
+    // Set CRS info so that the exporter can handle the transformation to CRS84 if the profile requires it
+    exporter.setSourceCrs( requestedCrs );
     exporter.setDestinationCrs( requestedCrs );
+    exporter.setGeoJsonProfile( requestedProfile );
 
-    if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFg ) )
-    {
-      exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::JsonFg );
-    }
-    else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::JsonFgPlus ) )
-    {
-      exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::JsonFgPlus );
-    }
-    else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::Rfc7946 ) )
-    {
-      // This is the default anyways but better explicit than implicit
-      exporter.setGeoJsonProfile( Qgis::GeoJsonProfile::Rfc7946 );
-    }
+    json data = exporter.exportFeatureToJsonObject( feature );
 
     QMap<int, ReferencedLayerInfo> referencedInfo = gatherReferencedLayerInfo( mapLayer, context );
     // remove if attributes are not requested
@@ -2803,33 +2872,20 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
     QgsServerOgcApi::Profile relAs = QgsServerOgcApi::Profile::Unset;
     bool hasReferencedObjects = !referencedInfo.isEmpty();
 
-    QString temporalInstantField;
-    QString temporalStartField;
-    QString temporalEndField;
-    const QgsVectorLayerTemporalProperties *temporalProperties = static_cast<QgsVectorLayerTemporalProperties *>( const_cast<QgsVectorLayer *>( mapLayer )->temporalProperties() );
-    if ( temporalProperties && temporalProperties->isActive() )
+    // Temporal
+    if ( requestedProfile == Qgis::GeoJsonProfile::JsonFg || requestedProfile == Qgis::GeoJsonProfile::JsonFgPlus )
     {
-      switch ( temporalProperties->mode() )
+      QString temporalInstantField;
+      QString temporalStartField;
+      QString temporalEndField;
+      bool isDateTime( false );
+      exposedTimeDimensions( temporalInstantField, temporalStartField, temporalEndField, isDateTime, mapLayer, requestedAttributes );
+      const json timeData = timeDimensionInfo( feature, temporalInstantField, temporalStartField, temporalEndField, isDateTime );
+      if ( timeData.contains( "time" ) )
       {
-        case Qgis::VectorTemporalMode::FeatureDateTimeInstantFromField:
-        {
-          temporalInstantField = temporalProperties->startField();
-          break;
-        }
-        case Qgis::VectorTemporalMode::FeatureDateTimeStartAndEndFromFields:
-
-        {
-          temporalStartField = temporalProperties->startField();
-          temporalEndField = temporalProperties->endField();
-          break;
-        }
-        default:
-        {
-          // Not supported for now.
-        }
+        data.update( timeData );
       }
     }
-    json data = exporter.exportFeatureToJsonObject( feature );
 
     // Patch feature
     //  - IDs with server feature IDs
@@ -2837,28 +2893,9 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
     //  - format extra geometries
     data["id"] = featureId.toStdString();
 
-    if ( !temporalInstantField.isEmpty() )
-    {
-      data["time"] = { { "timestamp", feature.attribute( temporalInstantField ).toDateTime().toString( Qt::ISODate ).toStdString() } };
-    }
-    else if ( !temporalStartField.isEmpty() && !temporalEndField.isEmpty() )
-    {
-      data["time"] = {
-        { "interval",
-          { feature.attribute( temporalStartField ).toDateTime().toString( Qt::ISODate ).toStdString(), "..", feature.attribute( temporalEndField ).toDateTime().toString( Qt::ISODate ).toStdString() } }
-      };
-    }
-    else if ( !temporalStartField.isEmpty() )
-    {
-      data["time"] = { { "interval", { feature.attribute( temporalStartField ).toDateTime().toString( Qt::ISODate ).toStdString(), ".." } } };
-    }
-    else if ( !temporalEndField.isEmpty() )
-    {
-      data["time"] = { { "interval", { "..", feature.attribute( temporalEndField ).toDateTime().toString( Qt::ISODate ).toStdString() } } };
-    }
-
     if ( hasReferencedObjects )
     {
+      const QList<QgsServerOgcApi::Profile> requestedProfiles = profilesFromRequest( context.request() );
       if ( requestedProfiles.contains( QgsServerOgcApi::Profile::RelAsUri ) )
         relAs = QgsServerOgcApi::Profile::RelAsUri;
       else if ( requestedProfiles.contains( QgsServerOgcApi::Profile::RelAsLink ) )
@@ -3057,6 +3094,20 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
 
         // Now we need to send the updated feature to the client
         feature = mapLayer->getFeature( feature.id() );
+        // Transform the geometry to the requested CRS because that's what doGet expects
+        if ( mapLayer->crs() != requestedCrs )
+        {
+          QgsGeometry geom { feature.geometry() };
+          try
+          {
+            geom.transform( QgsCoordinateTransform( mapLayer->crs(), requestedCrs, context.project()->transformContext() ) );
+          }
+          catch ( QgsCsException & )
+          {
+            throw QgsServerApiInternalServerError( u"Geometry could not be transformed to requested CRS"_s );
+          }
+          feature.setGeometry( geom );
+        }
         doGet();
       }
       catch ( json::exception &ex )
@@ -3180,6 +3231,20 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
 
       // Now we need to send the updated feature to the client
       feature = mapLayer->getFeature( feature.id() );
+      // Transform the geometry to the requested CRS because that's what doGet expects
+      if ( mapLayer->crs() != requestedCrs )
+      {
+        QgsGeometry geom { feature.geometry() };
+        try
+        {
+          geom.transform( QgsCoordinateTransform( mapLayer->crs(), requestedCrs, context.project()->transformContext() ) );
+        }
+        catch ( QgsCsException & )
+        {
+          throw QgsServerApiInternalServerError( u"Geometry could not be transformed to requested CRS"_s );
+        }
+        feature.setGeometry( geom );
+      }
       doGet();
 
       break;

--- a/src/server/services/wfs3/qgswfs3handlers.h
+++ b/src/server/services/wfs3/qgswfs3handlers.h
@@ -132,6 +132,20 @@ class QgsWfs3AbstractItemsHandler : public QgsServerOgcApiHandler
         QString referencingFieldComment;         //!< The comment of the referencing field (if available), to be used in the description of the reference
     };
 
+    void exposedTimeDimensions( QString &instantField, QString &startField, QString &endField, bool &isDateTime, const QgsVectorLayer *mapLayer, const QgsAttributeList &requestedAttributes ) const;
+
+    /**
+     *  Returns the json["time"] interval information for the given \a feature, using the given \a temporalInstantField, \a temporalStartField and \a temporalEndField.
+     *  See: https://docs.ogc.org/is/21-045r1/21-045r1.html#time
+     *  \note: this method returns an empty json object if the given temporal fields are empty.
+     */
+    json timeDimensionInfo( const QgsFeature &feature, const QString &temporalInstantField, const QString &temporalStartField, const QString &temporalEndField, bool isDateTime ) const;
+
+    /**
+     * Returns the json profile to be used for the response of the handler, based on the "profile" query parameter in the given \a context, default to Legacy.
+     */
+    Qgis::GeoJsonProfile jsonProfileFromRequest( const QgsServerApiContext &context ) const;
+
     /**
      * Returns the information about the referenced layers for the given \a mapLayer and \a apiContext.
      * The returned map has as key the index of the field in the \a mapLayer that contains the reference to the other layer, and as value a ReferencedLayerInfo struct with the information about the referenced layer.
@@ -323,6 +337,7 @@ class QgsWfs3CollectionsItemsHandler : public QgsWfs3AbstractItemsHandler
         QString filterExpression;
         QgsRectangle filterRect;
     };
+
 
     // Retrieve the fields filter parameters
     const QList<QgsServerQueryStringParameter> fieldParameters( const QgsVectorLayer *mapLayer, const QgsServerApiContext &context ) const;

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3160,7 +3160,13 @@ namespace QgsWms
         exporter.setAttributeDisplayName( true );
         exporter.setAttributes( attributes );
         exporter.setIncludeGeometry( withGeometry );
+        // Always add CRS information so that the export knows if it needs to transform geometries
+        // to CRS84 in case the requested profile needs it, the feature geometyries are already
+        // in the CRS of the request, so no transformation is needed
         exporter.setTransformGeometries( false );
+        exporter.setDestinationCrs( destCRS );
+        // This is the CRS of the features that the exporter receives
+        exporter.setSourceCrs( destCRS );
 
         QgsJsonUtils::addCrsInfo( jsonCollection, destCRS );
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3161,7 +3161,7 @@ namespace QgsWms
         exporter.setAttributes( attributes );
         exporter.setIncludeGeometry( withGeometry );
         // Always add CRS information so that the export knows if it needs to transform geometries
-        // to CRS84 in case the requested profile needs it, the feature geometyries are already
+        // to CRS84 in case the requested profile needs it, the feature geometries are already
         // in the CRS of the request, so no transformation is needed
         exporter.setTransformGeometries( false );
         exporter.setDestinationCrs( destCRS );

--- a/tests/src/python/test_qgsserver_ogcapi_features.py
+++ b/tests/src/python/test_qgsserver_ogcapi_features.py
@@ -32,8 +32,8 @@ from qgis.core import (
     QgsProviderRegistry,
     QgsRelation,
     QgsRelationContext,
+    QgsServerWmsDimensionProperties,
     QgsVectorLayer,
-    QgsVectorLayerTemporalProperties,
     QgsWkbTypes,
 )
 from qgis.PyQt import QtCore
@@ -66,18 +66,30 @@ class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
     # Set to True in child classes to re-generate reference files for this class
     regenerate_api_reference = False
 
-    def _getJsonResponse(self, url, project):
+    def _getJsonResponse(self, url, project, expected_error=None):
         request = QgsBufferServerRequest(url)
         response = QgsBufferServerResponse()
         server = QgsServer()
         server.handleRequest(request, response, project)
-        self.assertEqual(
-            response.statusCode(),
-            200,
-            f"Request failed with status {response.statusCode()} and message: {bytes(response.body()).decode('utf8')} for URL: {url}",
-        )
+        if expected_error is None:
+            self.assertEqual(
+                response.statusCode(),
+                200,
+                f"Request failed with status {response.statusCode()} and message: {bytes(response.body()).decode('utf8')} for URL: {url}",
+            )
+        else:
+            self.assertEqual(
+                response.statusCode(),
+                400,
+                f"Request failed with status {response.statusCode()} and message: {bytes(response.body()).decode('utf8')} for URL: {url}",
+            )
+            return None
+
         response_str = bytes(response.body()).decode("utf8")
         j = json.loads(response_str)
+
+        if expected_error is not None:
+            self.assertEqual(j[0]["description"], expected_error)
         return j
 
     def _check_profile(self, profile, project):
@@ -92,12 +104,12 @@ class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
         # No default
         if not profile:
             self.assertNotIn(
-                "http://www.opengis.net/def/profile/OGC/0/rel-as-key",
+                "http://www.opengis.net/def/profile/ogc/0/rel-as-key",
                 links,
             )
         else:
             self.assertIn(
-                f"http://www.opengis.net/def/profile/OGC/0/{profile}",
+                f"http://www.opengis.net/def/profile/ogc/0/{profile}",
                 links,
             )
         return j["features"][0]
@@ -338,24 +350,18 @@ class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
 
         # Layer with timestamp
         layer = QgsVectorLayer(
-            "Point?field=event_id:integer&field=event_date:date", "temporal", "memory"
+            "Point?field=event_id:integer&field=event_date:date&field=event_date_end:date",
+            "temporal",
+            "memory",
         )
         self.assertTrue(layer.isValid())
-        layer.temporalProperties().setIsActive(True)
-        props = layer.temporalProperties()
-        self.assertTrue(props.isActive())
-        self.assertEqual(props.startField(), "event_date")
-        self.assertFalse(props.endField())
-        self.assertEqual(
-            props.mode(),
-            QgsVectorLayerTemporalProperties.TemporalMode.ModeFeatureDateTimeInstantFromField,
-        )
 
         # Add features
         feature = QgsFeature(layer.fields())
         feature.setGeometry(QgsGeometry.fromWkt("POINT(0 0)"))
         feature.setAttribute("event_id", 1)
         feature.setAttribute("event_date", QtCore.QDate(2024, 1, 1))
+        feature.setAttribute("event_date_end", QtCore.QDate(2024, 1, 2))
         self.assertTrue(layer.dataProvider().addFeature(feature))
 
         # Add to project and expose to WFS
@@ -364,12 +370,245 @@ class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
         project.writeEntry("WFSLayers", "/", [layer.id()])
 
         # Retrieve the feature and check temporal properties in the response
+
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg",
+            project,
+        )
+        self.assertNotIn("time", j)
+
+        info = QgsServerWmsDimensionProperties.WmsDimensionInfo("date", "event_date")
+        layer.serverProperties().setWmsDimensions([info])
+
         j = self._getJsonResponse(
             "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg",
             project,
         )
         self.assertIn("event_date", j["properties"])
-        self.assertEqual(j["properties"]["time"], "2024-01-01T00:00:00Z")
+        self.assertEqual(j["time"], {"date": "2024-01-01"})
+
+        info = QgsServerWmsDimensionProperties.WmsDimensionInfo(
+            "date", "event_date", "event_date_end"
+        )
+        layer.serverProperties().setWmsDimensions([info])
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg",
+            project,
+        )
+        self.assertIn("event_date", j["properties"])
+        self.assertEqual(j["time"], {"interval": ["2024-01-01", "2024-01-02"]})
+
+        # NOTE: we cannot test open intevals because the server's wmsDimensions API do not support anything
+        #       other than instant and closed intervals.
+
+        layer = QgsVectorLayer(
+            "Point?field=event_id:integer&field=event_date:datetime&field=event_date_end:datetime",
+            "temporal",
+            "memory",
+        )
+        self.assertTrue(layer.isValid())
+
+        # Add features
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(QgsGeometry.fromWkt("POINT(0 0)"))
+        feature.setAttribute("event_id", 1)
+        feature.setAttribute(
+            "event_date",
+            QtCore.QDateTime(
+                QtCore.QDate(2024, 1, 1), QtCore.QTime(12, 0), QtCore.QTimeZone(3600)
+            ),
+        )
+        feature.setAttribute(
+            "event_date_end",
+            QtCore.QDateTime(
+                QtCore.QDate(2024, 1, 2), QtCore.QTime(12, 0), QtCore.QTimeZone(3600)
+            ),
+        )
+        self.assertTrue(layer.dataProvider().addFeature(feature))
+
+        info = QgsServerWmsDimensionProperties.WmsDimensionInfo("time", "event_date")
+        layer.serverProperties().setWmsDimensions([info])
+
+        project = QgsProject()
+        project.addMapLayer(layer)
+        project.writeEntry("WFSLayers", "/", [layer.id()])
+
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg",
+            project,
+        )
+        # Notice: the time is returned in UTC, not local time, so we expect 11:00:00Z instead of 12:00:00Z
+        self.assertEqual(j["time"], {"timestamp": "2024-01-01T11:00:00Z"})
+
+        info = QgsServerWmsDimensionProperties.WmsDimensionInfo(
+            "time", "event_date", "event_date_end"
+        )
+        layer.serverProperties().setWmsDimensions([info])
+
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg",
+            project,
+        )
+        self.assertEqual(
+            j["time"], {"interval": ["2024-01-01T11:00:00Z", "2024-01-02T11:00:00Z"]}
+        )
+
+        # Check if a string field can be used as a temporal dimension
+        layer = QgsVectorLayer(
+            "Point?field=event_id:integer&field=event_date:string", "temporal", "memory"
+        )
+        self.assertTrue(layer.isValid())
+
+        # Add features
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(QgsGeometry.fromWkt("POINT(0 0)"))
+        feature.setAttribute("event_id", 1)
+        feature.setAttribute("event_date", "2024-01-01T12:00:00+01:00")
+        self.assertTrue(layer.dataProvider().addFeature(feature))
+
+        info = QgsServerWmsDimensionProperties.WmsDimensionInfo("time", "event_date")
+        layer.serverProperties().setWmsDimensions([info])
+
+        project = QgsProject()
+        project.addMapLayer(layer)
+        project.writeEntry("WFSLayers", "/", [layer.id()])
+
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg",
+            project,
+        )
+        self.assertEqual(j["time"], {"timestamp": "2024-01-01T11:00:00Z"})
+
+        # Test Rfc profile does not have any temporal properties
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json",
+            project,
+        )
+
+    def testSingleFeatureJsonProfiles(self):
+
+        layer = QgsVectorLayer(
+            "Point?crs=EPSG:3857&field=event_id:integer&field=name:string",
+            "temporal",
+            "memory",
+        )
+        self.assertTrue(layer.isValid())
+
+        # Add features
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(QgsGeometry.fromWkt("POINT(856053 5633001)"))
+        feature.setAttribute("name", "test")
+        layer.dataProvider().addFeature(feature)
+
+        project = QgsProject()
+        project.addMapLayer(layer)
+        project.writeEntry("WFSLayers", "/", [layer.id()])
+
+        # Test with no explicit profile, should return the default Legacy profile (CRS respected)
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?crs=http://www.opengis.net/def/crs/EPSG/0/3857",
+            project,
+        )
+        self.assertNotIn("place", j)
+        self.assertAlmostEqual(j["geometry"]["coordinates"][0], 856053, delta=1)
+        self.assertAlmostEqual(j["geometry"]["coordinates"][1], 5633001, delta=1)
+
+        # Test with explicit profile RFC7946 error is returned because CRS is not OGC:CRS84
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=rfc7946&crs=http://www.opengis.net/def/crs/EPSG/0/3857",
+            project,
+            expected_error="Requested CRS must be OGC:CRS84 when requested profile is Rfc7946",
+        )
+
+        # Test with explicit profile JSON-FG
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg&crs=http://www.opengis.net/def/crs/EPSG/0/3857",
+            project,
+        )
+        self.assertIn("place", j)
+
+        # Test with explicit profile JSON-FG-PLUS
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg-plus&crs=http://www.opengis.net/def/crs/EPSG/0/3857",
+            project,
+        )
+        self.assertIn("place", j)
+
+        self.assertAlmostEqual(j["place"]["coordinates"][0], 856053, delta=1)
+        self.assertAlmostEqual(j["place"]["coordinates"][1], 5633001, delta=1)
+        self.assertAlmostEqual(j["geometry"]["coordinates"][0], 7.6, delta=1)
+        self.assertAlmostEqual(j["geometry"]["coordinates"][1], 45.1, delta=1)
+
+    def testCollectionJsonProfiles(self):
+
+        layer = QgsVectorLayer(
+            "Point?crs=EPSG:3857&field=event_id:integer&field=name:string",
+            "temporal",
+            "memory",
+        )
+        self.assertTrue(layer.isValid())
+
+        # Add features
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(QgsGeometry.fromWkt("POINT(856053 5633001)"))
+        feature.setAttribute("name", "test")
+        layer.dataProvider().addFeature(feature)
+
+        project = QgsProject()
+        project.addMapLayer(layer)
+        project.writeEntry("WFSLayers", "/", [layer.id()])
+
+        # Test default (Legacy) profile (CRS is respected)
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items.json?crs=http://www.opengis.net/def/crs/EPSG/0/3857",
+            project,
+        )
+        self.assertNotIn("place", j["features"][0])
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][0], 856053, delta=1
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][1], 5633001, delta=1
+        )
+
+        # Test with explicit profile JSON-FG
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items.json?profile=json-fg&crs=http://www.opengis.net/def/crs/EPSG/0/3857",
+            project,
+        )
+        self.assertIn("place", j["features"][0])
+        self.assertAlmostEqual(
+            j["features"][0]["place"]["coordinates"][0], 856053, delta=1
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["place"]["coordinates"][1], 5633001, delta=1
+        )
+
+        # Test CRS with explicit profile RFC7946 error is returned because
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items.json?profile=rfc7946&crs=http://www.opengis.net/def/crs/EPSG/0/3857",
+            project,
+            expected_error="Requested CRS must be OGC:CRS84 when requested profile is Rfc7946",
+        )
+
+        # Test with explicit profile JSON-FG-PLUS
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items.json?profile=json-fg-plus&crs=http://www.opengis.net/def/crs/EPSG/0/3857",
+            project,
+        )
+        self.assertIn("place", j["features"][0])
+        self.assertAlmostEqual(
+            j["features"][0]["place"]["coordinates"][0], 856053, delta=1
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["place"]["coordinates"][1], 5633001, delta=1
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][0], 7.6, delta=1
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][1], 45.1, delta=1
+        )
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsserver_ogcapi_features.py
+++ b/tests/src/python/test_qgsserver_ogcapi_features.py
@@ -15,59 +15,35 @@ __copyright__ = "Copyright 2026, The QGIS Project"
 
 import json
 import os
-import re
-import shutil
-
-from osgeo import gdal, ogr
-from provider_python import PyProvider
 
 # Deterministic XML
 os.environ["QT_HASH_SEED"] = "1"
-
-from contextlib import contextmanager
-from urllib import parse
 
 from qgis.core import (
     Qgis,
     QgsApplication,
     QgsCoordinateReferenceSystem,
-    QgsDataProvider,
     QgsEditorWidgetSetup,
     QgsFeature,
-    QgsFeatureRequest,
     QgsField,
-    QgsFieldConstraints,
     QgsFields,
     QgsGeometry,
-    QgsMemoryProviderUtils,
     QgsProject,
-    QgsProviderMetadata,
     QgsProviderRegistry,
     QgsRelation,
     QgsRelationContext,
     QgsVectorLayer,
-    QgsVectorLayerServerProperties,
+    QgsVectorLayerTemporalProperties,
     QgsWkbTypes,
 )
 from qgis.PyQt import QtCore
 from qgis.server import (
-    QgsAccessControlFilter,
     QgsBufferServerRequest,
     QgsBufferServerResponse,
     QgsServer,
-    QgsServerApi,
-    QgsServerApiBadRequestException,
-    QgsServerApiContext,
-    QgsServerApiUtils,
-    QgsServerOgcApi,
-    QgsServerOgcApiHandler,
-    QgsServerQueryStringParameter,
-    QgsServiceRegistry,
 )
 from qgis.testing import unittest
-from test_qgsserver import QgsServerTestBase
 from test_qgsserver_api import QgsServerAPITestBase
-from utilities import unitTestDataPath
 
 
 class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
@@ -116,12 +92,12 @@ class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
         # No default
         if not profile:
             self.assertNotIn(
-                "http://www.opengis.net/def/profile/ogc/0/rel-as-key",
+                "http://www.opengis.net/def/profile/OGC/0/rel-as-key",
                 links,
             )
         else:
             self.assertIn(
-                f"http://www.opengis.net/def/profile/ogc/0/{profile}",
+                f"http://www.opengis.net/def/profile/OGC/0/{profile}",
                 links,
             )
         return j["features"][0]
@@ -357,6 +333,43 @@ class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
         self.assertEqual(
             j["features"][0]["properties"], {"fid": 1, "name": "test", "other_id": 1}
         )
+
+    def testTemporalProperties(self):
+
+        # Layer with timestamp
+        layer = QgsVectorLayer(
+            "Point?field=event_id:integer&field=event_date:date", "temporal", "memory"
+        )
+        self.assertTrue(layer.isValid())
+        layer.temporalProperties().setIsActive(True)
+        props = layer.temporalProperties()
+        self.assertTrue(props.isActive())
+        self.assertEqual(props.startField(), "event_date")
+        self.assertFalse(props.endField())
+        self.assertEqual(
+            props.mode(),
+            QgsVectorLayerTemporalProperties.TemporalMode.ModeFeatureDateTimeInstantFromField,
+        )
+
+        # Add features
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(QgsGeometry.fromWkt("POINT(0 0)"))
+        feature.setAttribute("event_id", 1)
+        feature.setAttribute("event_date", QtCore.QDate(2024, 1, 1))
+        self.assertTrue(layer.dataProvider().addFeature(feature))
+
+        # Add to project and expose to WFS
+        project = QgsProject()
+        project.addMapLayer(layer)
+        project.writeEntry("WFSLayers", "/", [layer.id()])
+
+        # Retrieve the feature and check temporal properties in the response
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=json-fg",
+            project,
+        )
+        self.assertIn("event_date", j["properties"])
+        self.assertEqual(j["properties"]["time"], "2024-01-01T00:00:00Z")
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsserver_ogcapi_features.py
+++ b/tests/src/python/test_qgsserver_ogcapi_features.py
@@ -479,11 +479,19 @@ class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
         )
         self.assertEqual(j["time"], {"timestamp": "2024-01-01T11:00:00Z"})
 
-        # Test Rfc profile does not have any temporal properties
+        # Test Legacy profile does not have any temporal properties
         j = self._getJsonResponse(
             "http://server.qgis.org/wfs3/collections/temporal/items/1.json",
             project,
         )
+        self.assertNotIn("time", j)
+
+        # Test that Rfc7946 profile does not have any temporal properties
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/temporal/items/1.json?profile=rfc7946",
+            project,
+        )
+        self.assertNotIn("time", j)
 
     def testSingleFeatureJsonProfiles(self):
 
@@ -584,7 +592,7 @@ class QgsServerOgcApiFeaturesTest(QgsServerAPITestBase):
             j["features"][0]["place"]["coordinates"][1], 5633001, delta=1
         )
 
-        # Test CRS with explicit profile RFC7946 error is returned because
+        # Test CRS with explicit profile RFC7946 error is returned because CRS is not OGC:CRS84
         j = self._getJsonResponse(
             "http://server.qgis.org/wfs3/collections/temporal/items.json?profile=rfc7946&crs=http://www.opengis.net/def/crs/EPSG/0/3857",
             project,

--- a/tests/src/python/test_qgsserver_ogcapi_schema.py
+++ b/tests/src/python/test_qgsserver_ogcapi_schema.py
@@ -15,57 +15,39 @@ __copyright__ = "Copyright 2026, The QGIS Project"
 
 import json
 import os
-import re
-import shutil
 
-from osgeo import gdal, ogr
+from osgeo import ogr
 from provider_python import PyProvider
 
 # Deterministic XML
 os.environ["QT_HASH_SEED"] = "1"
 
-from contextlib import contextmanager
 from urllib import parse
 
 from qgis.core import (
-    Qgis,
     QgsApplication,
-    QgsCoordinateReferenceSystem,
     QgsDataProvider,
     QgsEditorWidgetSetup,
     QgsExpression,
     QgsFeature,
-    QgsFeatureRequest,
     QgsField,
     QgsFieldConstraints,
-    QgsFields,
     QgsGeometry,
-    QgsMemoryProviderUtils,
     QgsProject,
     QgsProviderMetadata,
     QgsProviderRegistry,
     QgsRelation,
     QgsRelationContext,
+    QgsServerWmsDimensionProperties,
     QgsVectorLayer,
-    QgsVectorLayerServerProperties,
 )
 from qgis.PyQt import QtCore
 from qgis.server import (
-    QgsAccessControlFilter,
     QgsBufferServerRequest,
     QgsBufferServerResponse,
     QgsServer,
-    QgsServerApi,
-    QgsServerApiBadRequestException,
-    QgsServerApiContext,
-    QgsServerApiUtils,
-    QgsServerOgcApi,
-    QgsServerOgcApiHandler,
-    QgsServerQueryStringParameter,
-    QgsServiceRegistry,
 )
 from qgis.testing import unittest
-from test_qgsserver import QgsServerTestBase
 from test_qgsserver_api import QgsServerAPITestBase
 from utilities import compareWkt, unitTestDataPath
 
@@ -718,9 +700,67 @@ class QgsServerOgcApiSchemaTest(QgsServerAPITestBase):
             )
         )
 
-        self.assertAlmostEqual(j["geometry"]["coordinates"][0], 111319, delta=0.1)
-        self.assertAlmostEqual(
-            j["geometry"]["coordinates"][1], 110579.823312, delta=0.1
+        self.assertAlmostEqual(j["geometry"]["coordinates"][0], 111319.0, delta=0.1)
+        self.assertAlmostEqual(j["geometry"]["coordinates"][1], 110579.8, delta=0.1)
+
+    def test_time(self):
+
+        layer = QgsVectorLayer(
+            "Point?crs=epsg:4326&field=pk:integer&field=time:datetime&field=time_start:datetime&field=time_end:datetime&key=pk",
+            "layer1",
+            "memory",
+        )
+
+        # Set time dimension on the layer
+        info = QgsServerWmsDimensionProperties.WmsDimensionInfo("time", "time")
+        layer.serverProperties().setWmsDimensions([info])
+
+        project = QgsProject()
+        project.addMapLayer(layer)
+        # Expose to WFS
+        project.writeEntry("WFSLayers", "/", [layer.id()])
+
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/layer1/schema.json", project
+        )
+
+        self.assertEqual(
+            j["properties"]["time"],
+            {
+                "format": "date-time",
+                "type": "string",
+                "x-ogc-propertySeq": 2,
+                "x-ogc-role": "primary-instant",
+            },
+        )
+
+        # Check interval fields are correctly exposed as date-time
+        info = QgsServerWmsDimensionProperties.WmsDimensionInfo(
+            "time", "time_start", "time_end"
+        )
+        layer.serverProperties().setWmsDimensions([info])
+
+        j = self._getJsonResponse(
+            "http://server.qgis.org/wfs3/collections/layer1/schema.json", project
+        )
+
+        self.assertEqual(
+            j["properties"]["time_start"],
+            {
+                "format": "date-time",
+                "type": "string",
+                "x-ogc-propertySeq": 3,
+                "x-ogc-role": "primary-interval-start",
+            },
+        )
+        self.assertEqual(
+            j["properties"]["time_end"],
+            {
+                "format": "date-time",
+                "type": "string",
+                "x-ogc-propertySeq": 4,
+                "x-ogc-role": "primary-interval-end",
+            },
         )
 
 


### PR DESCRIPTION
### Expose JSON-FG and JSON-FG-PLUS  (and RFC7946) as profiles for OGCAPI for features.

### Also expose "time" dimension as in the specifications:

https://docs.ogc.org/is/21-045r1/21-045r1.html#time
https://docs.ogc.org/is/23-058r2/23-058r2.html#_primary_temporal_information

### This work is the result a collective funding effort from:

Funded by: QGIS Anwendergruppe Deutschland e.V. (QGIS-DE e.V.)
Funded by: Gis3W
Funded by: QTIBIA
Funded by: Oslandia