### PR TITLE
[Core] Use unique_ptr when class has clear ownership

### DIFF
--- a/python/PyQt6/core/auto_generated/raster/qgsrasterblock.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterblock.sip.in
@@ -25,6 +25,7 @@ Raster data container.
   public:
     QgsRasterBlock();
 
+
     QgsRasterBlock( Qgis::DataType dataType, int width, int height );
 %Docstring
 Constructor which allocates data block in memory
@@ -595,9 +596,9 @@ Returns the minimum and maximum value present in the raster block.
 .. versionadded:: 3.42
 %End
 
+  private:
+  QgsRasterBlock( const QgsRasterBlock &rh );
 };
-
-
 
 
 

--- a/src/core/editform/qgseditformconfig.cpp
+++ b/src/core/editform/qgseditformconfig.cpp
@@ -75,7 +75,7 @@ void QgsEditFormConfig::setFields( const QgsFields &fields )
     d->mInvisibleRootContainer->clear();
     for ( int i = 0; i < d->mFields.size(); ++i )
     {
-      QgsAttributeEditorField *field = new QgsAttributeEditorField( d->mFields.at( i ).name(), i, d->mInvisibleRootContainer );
+      QgsAttributeEditorField *field = new QgsAttributeEditorField( d->mFields.at( i ).name(), i, d->mInvisibleRootContainer.get() );
       d->mInvisibleRootContainer->addChildElement( field );
     }
   }
@@ -147,7 +147,7 @@ bool QgsEditFormConfig::setWidgetConfig( const QString &widgetName, const QVaria
       u"Deprecation Warning: Trying to set a relation config directly on the relation %1. Relation settings should be done for the specific widget instance instead. Use attributeEditorRelation->setNmRelationId() or attributeEditorRelation->setForceSuppressFormPopup() instead."_s
         .arg( widgetName )
     );
-    legacyUpdateRelationWidgetInTabs( d->mInvisibleRootContainer, widgetName, config );
+    legacyUpdateRelationWidgetInTabs( d->mInvisibleRootContainer.get(), widgetName, config );
   }
 
   d.detach();
@@ -201,7 +201,7 @@ void QgsEditFormConfig::clearTabs()
 
 QgsAttributeEditorContainer *QgsEditFormConfig::invisibleRootContainer()
 {
-  return d->mInvisibleRootContainer;
+  return d->mInvisibleRootContainer.get();
 }
 
 Qgis::AttributeFormLayout QgsEditFormConfig::layout() const

--- a/src/core/editform/qgseditformconfig_p.h
+++ b/src/core/editform/qgseditformconfig_p.h
@@ -50,7 +50,7 @@ class QgsEditFormConfigPrivate : public QSharedData
       , mFields( o.mFields )
     {}
 
-    ~QgsEditFormConfigPrivate() { delete mInvisibleRootContainer; }
+    ~QgsEditFormConfigPrivate() {}
 
     static QgsPropertiesDefinition &propertyDefinitions()
     {
@@ -64,7 +64,7 @@ class QgsEditFormConfigPrivate : public QSharedData
     };
 
     //! The invisible root container for attribute editors in the drag and drop designer
-    QgsAttributeEditorContainer *mInvisibleRootContainer = nullptr;
+    std::unique_ptr<QgsAttributeEditorContainer> mInvisibleRootContainer;
 
     //! This flag is set if the root container was configured by the user
     bool mConfiguredRootContainer = false;

--- a/src/core/effects/qgsgloweffect.cpp
+++ b/src/core/effects/qgsgloweffect.cpp
@@ -40,9 +40,7 @@ QgsGlowEffect::QgsGlowEffect( const QgsGlowEffect &other )
 }
 
 QgsGlowEffect::~QgsGlowEffect()
-{
-  delete mRamp;
-}
+{}
 
 Qgis::PaintEffectFlags QgsGlowEffect::flags() const
 {
@@ -67,7 +65,7 @@ void QgsGlowEffect::draw( QgsRenderContext &context )
   std::unique_ptr< QgsGradientColorRamp > tempRamp;
   if ( mColorType == ColorRamp && mRamp )
   {
-    ramp = mRamp;
+    ramp = mRamp.get();
   }
   else
   {
@@ -205,21 +203,20 @@ void QgsGlowEffect::readProperties( const QVariantMap &props )
   }
 
   //attempt to create color ramp from props
-  delete mRamp;
+  mRamp.reset();
   if ( props.contains( u"rampType"_s ) && props[u"rampType"_s] == QgsCptCityColorRamp::typeString() )
   {
-    mRamp = QgsCptCityColorRamp::create( props );
+    mRamp.reset( QgsCptCityColorRamp::create( props ) );
   }
   else
   {
-    mRamp = QgsGradientColorRamp::create( props );
+    mRamp.reset( QgsGradientColorRamp::create( props ) );
   }
 }
 
 void QgsGlowEffect::setRamp( QgsColorRamp *ramp )
 {
-  delete mRamp;
-  mRamp = ramp;
+  mRamp.reset( ramp );
 }
 
 QgsGlowEffect &QgsGlowEffect::operator=( const QgsGlowEffect &rhs )
@@ -227,12 +224,12 @@ QgsGlowEffect &QgsGlowEffect::operator=( const QgsGlowEffect &rhs )
   if ( &rhs == this )
     return *this;
 
-  delete mRamp;
+  mRamp.reset( rhs.ramp() ? rhs.ramp()->clone() : nullptr );
 
   mSpread = rhs.spread();
   mSpreadUnit = rhs.spreadUnit();
   mSpreadMapUnitScale = rhs.spreadMapUnitScale();
-  mRamp = rhs.ramp() ? rhs.ramp()->clone() : nullptr;
+
   mBlurLevel = rhs.blurLevel();
   mBlurUnit = rhs.mBlurUnit;
   mBlurMapUnitScale = rhs.mBlurMapUnitScale;

--- a/src/core/effects/qgsgloweffect.h
+++ b/src/core/effects/qgsgloweffect.h
@@ -221,7 +221,7 @@ class CORE_EXPORT QgsGlowEffect : public QgsPaintEffect
      * \see setRamp
      * \see colorType
      */
-    QgsColorRamp *ramp() const { return mRamp; }
+    QgsColorRamp *ramp() const { return mRamp.get(); }
 
     /**
      * Sets the blend mode for the effect
@@ -277,7 +277,7 @@ class CORE_EXPORT QgsGlowEffect : public QgsPaintEffect
     double mSpread = 2.0;
     Qgis::RenderUnit mSpreadUnit = Qgis::RenderUnit::Millimeters;
     QgsMapUnitScale mSpreadMapUnitScale;
-    QgsColorRamp *mRamp = nullptr;
+    std::unique_ptr<QgsColorRamp> mRamp;
     double mBlurLevel = 2.645;
     Qgis::RenderUnit mBlurUnit = Qgis::RenderUnit::Millimeters;
     QgsMapUnitScale mBlurMapUnitScale;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -109,23 +109,20 @@ bool QgsMeshLayer::hasSimplifiedMeshes() const
 }
 
 QgsMeshLayer::~QgsMeshLayer()
-{
-  delete mLabeling;
-  delete mDataProvider;
-}
+{}
 
 QgsMeshDataProvider *QgsMeshLayer::dataProvider()
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return mDataProvider;
+  return mDataProvider.get();
 }
 
 const QgsMeshDataProvider *QgsMeshLayer::dataProvider() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  return mDataProvider;
+  return mDataProvider.get();
 }
 
 QgsMeshLayer *QgsMeshLayer::clone() const
@@ -1214,7 +1211,7 @@ bool QgsMeshLayer::commitFrameEditing( const QgsCoordinateTransform &transform, 
   mDataProvider->reloadData();
   mDataProvider->populateMesh( mNativeMesh.get() );
   mDatasetGroupStore = std::make_unique<QgsMeshDatasetGroupStore>( this );
-  mDatasetGroupStore->setPersistentProvider( mDataProvider, QStringList() );
+  mDatasetGroupStore->setPersistentProvider( mDataProvider.get(), QStringList() );
   resetDatasetGroupTreeItem();
   return true;
 }
@@ -1247,7 +1244,7 @@ bool QgsMeshLayer::rollBackFrameEditing( const QgsCoordinateTransform &transform
     emit editingStopped();
 
     mDatasetGroupStore = std::make_unique<QgsMeshDatasetGroupStore>( this );
-    mDatasetGroupStore->setPersistentProvider( mDataProvider, QStringList() );
+    mDatasetGroupStore->setPersistentProvider( mDataProvider.get(), QStringList() );
     resetDatasetGroupTreeItem();
     emit dataChanged();
     return true;
@@ -2092,7 +2089,7 @@ void QgsMeshLayer::reload()
   if ( !mMeshEditor && mDataProvider && mDataProvider->isValid() )
   {
     mDataProvider->reloadData();
-    mDatasetGroupStore->setPersistentProvider( mDataProvider, QStringList() ); //extra dataset are already loaded
+    mDatasetGroupStore->setPersistentProvider( mDataProvider.get(), QStringList() ); //extra dataset are already loaded
 
     //reload the mesh structure
     if ( !mNativeMesh )
@@ -2215,13 +2212,13 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
 
   mDatasetGroupStore->setPersistentProvider( nullptr, QStringList() );
 
-  delete mDataProvider;
+  mDataProvider.reset();
   mProviderKey = provider;
   const QString dataSource = mDataSource;
 
   if ( mPreloadedProvider )
   {
-    mDataProvider = qobject_cast< QgsMeshDataProvider * >( mPreloadedProvider.release() );
+    mDataProvider.reset( qobject_cast< QgsMeshDataProvider * >( mPreloadedProvider.release() ) );
   }
   else
   {
@@ -2229,7 +2226,7 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
     if ( QgsApplication::profiler()->groupIsActive( u"projectload"_s ) )
       profile = std::make_unique< QgsScopedRuntimeProfile >( tr( "Create %1 provider" ).arg( provider ), u"projectload"_s );
 
-    mDataProvider = qobject_cast<QgsMeshDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, dataSource, options, flags ) );
+    mDataProvider.reset( qobject_cast<QgsMeshDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, dataSource, options, flags ) ) );
   }
 
   if ( !mDataProvider )
@@ -2255,7 +2252,7 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
 
   mDataProvider->setTemporalUnit( mTemporalUnit );
 
-  mDatasetGroupStore->setPersistentProvider( mDataProvider, mExtraDatasetUri );
+  mDatasetGroupStore->setPersistentProvider( mDataProvider.get(), mExtraDatasetUri );
 
   setCrs( mDataProvider->crs() );
 
@@ -2268,7 +2265,7 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
   // set default style if required by flags or if the dataset group does not has a style yet
   for ( int i = 0; i < mDataProvider->datasetGroupCount(); ++i )
   {
-    int globalIndex = mDatasetGroupStore->globalDatasetGroupIndexInSource( mDataProvider, i );
+    int globalIndex = mDatasetGroupStore->globalDatasetGroupIndexInSource( mDataProvider.get(), i );
     if ( globalIndex != -1 && ( !mRendererSettings.hasSettings( globalIndex ) || ( flags & Qgis::DataProviderReadFlag::LoadDefaultStyle ) ) )
       assignDefaultStyleToDatasetGroup( globalIndex );
   }
@@ -2276,7 +2273,7 @@ bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvid
   emit rendererChanged();
   emitStyleChanged();
 
-  connect( mDataProvider, &QgsMeshDataProvider::dataChanged, this, &QgsMeshLayer::dataChanged );
+  connect( mDataProvider.get(), &QgsMeshDataProvider::dataChanged, this, &QgsMeshLayer::dataChanged );
 
   return true;
 }
@@ -2313,11 +2310,11 @@ void QgsMeshLayer::setLabeling( QgsAbstractMeshLayerLabeling *labeling )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  if ( mLabeling == labeling )
+  if ( mLabeling.get() == labeling )
     return;
 
-  delete mLabeling;
-  mLabeling = labeling;
+  mLabeling.reset( labeling );
+
   triggerRepaint();
 }
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -971,7 +971,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
      * \see setLabelsEnabled()
      * \since QGIS 3.36
      */
-    const QgsAbstractMeshLayerLabeling *labeling() const SIP_SKIP { return mLabeling; }
+    const QgsAbstractMeshLayerLabeling *labeling() const SIP_SKIP { return mLabeling.get(); }
 
     /**
      * Access to labeling configuration. May be NULLPTR if labeling is not used.
@@ -979,7 +979,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
      * \see labelsEnabled()
      * \since QGIS 3.36
      */
-    QgsAbstractMeshLayerLabeling *labeling() { return mLabeling; }
+    QgsAbstractMeshLayerLabeling *labeling() { return mLabeling.get(); }
 
     /**
      * Sets labeling configuration. Takes ownership of the object.
@@ -1100,7 +1100,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
 
   private:
     //! Pointer to data provider derived from the abastract base class QgsMeshDataProvider
-    QgsMeshDataProvider *mDataProvider = nullptr;
+    std::unique_ptr<QgsMeshDataProvider> mDataProvider;
 
     //! List of extra dataset uri associated with this layer
     QStringList mExtraDatasetUri;
@@ -1140,7 +1140,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
     bool mLabelsEnabled = false;
 
     //! Labeling configuration
-    QgsAbstractMeshLayerLabeling *mLabeling = nullptr;
+    std::unique_ptr<QgsAbstractMeshLayerLabeling> mLabeling;
 
     //! Returns the exact position in map coordinates of the closest vertex in the search area
     int closestEdge( const QgsPointXY &point, double searchRadius, QgsPointXY &projectedPoint ) const;

--- a/src/core/mesh/qgsmeshspatialindex.cpp
+++ b/src/core/mesh/qgsmeshspatialindex.cpp
@@ -152,7 +152,7 @@ class QgsMeshIteratorDataStream : public IDataStream
       readNextEntry();
     }
 
-    ~QgsMeshIteratorDataStream() override { delete mNextData; }
+    ~QgsMeshIteratorDataStream() override {}
 
     //! returns a pointer to the next entry in the stream or 0 at the end of the stream.
     IData *getNext() override
@@ -160,14 +160,13 @@ class QgsMeshIteratorDataStream : public IDataStream
       if ( mFeedback && mFeedback->isCanceled() )
         return nullptr;
 
-      RTree::Data *ret = mNextData;
-      mNextData = nullptr;
+      RTree::Data *ret = mNextData.release();
       readNextEntry();
       return ret;
     }
 
     //! returns true if there are more items in the stream.
-    bool hasNext() override { return nullptr != mNextData; }
+    bool hasNext() override { return nullptr != mNextData.get(); }
 
     //! returns the total number of entries available in the stream.
     uint32_t size() override { return static_cast<uint32_t>( mFeaturesCount ); }
@@ -185,7 +184,7 @@ class QgsMeshIteratorDataStream : public IDataStream
         r = mFeatureToRegionFunction( mMesh, mIterator, ok );
         if ( ok )
         {
-          mNextData = new RTree::Data( 0, nullptr, r, mIterator );
+          mNextData = std::make_unique<RTree::Data>( 0, nullptr, r, mIterator );
           ++mIterator;
           return;
         }
@@ -202,7 +201,7 @@ class QgsMeshIteratorDataStream : public IDataStream
     const QgsMesh &mMesh;
     int mFeaturesCount = 0;
     std::function<Region( const QgsMesh &mesh, int id, bool &ok )> mFeatureToRegionFunction;
-    RTree::Data *mNextData = nullptr;
+    std::unique_ptr<RTree::Data> mNextData;
     QgsFeedback *mFeedback = nullptr;
 };
 

--- a/src/core/pointcloud/qgspointcloudlayerexporter.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerexporter.cpp
@@ -74,11 +74,7 @@ QgsPointCloudLayerExporter::QgsPointCloudLayerExporter( QgsPointCloudLayer *laye
 }
 
 QgsPointCloudLayerExporter::~QgsPointCloudLayerExporter()
-{
-  delete mMemoryLayer;
-  delete mVectorSink;
-  delete mTransform;
-}
+{}
 
 bool QgsPointCloudLayerExporter::setFormat( const ExportFormat format )
 {
@@ -197,8 +193,8 @@ QgsFields QgsPointCloudLayerExporter::outputFields()
 
 void QgsPointCloudLayerExporter::prepareExport()
 {
-  delete mMemoryLayer;
-  mMemoryLayer = nullptr;
+  mMemoryLayer.reset();
+
 
   if ( mFormat == ExportFormat::Memory )
   {
@@ -209,13 +205,13 @@ void QgsPointCloudLayerExporter::prepareExport()
     }
 #endif
 
-    mMemoryLayer = QgsMemoryProviderUtils::createMemoryLayer( mName, outputFields(), Qgis::WkbType::PointZ, mTargetCrs );
+    mMemoryLayer.reset( QgsMemoryProviderUtils::createMemoryLayer( mName, outputFields(), Qgis::WkbType::PointZ, mTargetCrs ) );
   }
 }
 
 void QgsPointCloudLayerExporter::doExport()
 {
-  mTransform = new QgsCoordinateTransform( mSourceCrs, mTargetCrs, mTransformContext );
+  mTransform = std::make_unique<QgsCoordinateTransform>( mSourceCrs, mTargetCrs, mTransformContext );
   if ( mExtent.isFinite() )
   {
     try
@@ -278,7 +274,7 @@ void QgsPointCloudLayerExporter::doExport()
       saveOptions.symbologyExport = Qgis::FeatureSymbologyExport::NoSymbology;
       saveOptions.actionOnExistingFile = mActionOnExistingFile;
       saveOptions.feedback = mFeedback;
-      mVectorSink = QgsVectorFileWriter::create( mFilename, outputFields(), Qgis::WkbType::PointZ, mTargetCrs, QgsCoordinateTransformContext(), saveOptions );
+      mVectorSink.reset( QgsVectorFileWriter::create( mFilename, outputFields(), Qgis::WkbType::PointZ, mTargetCrs, QgsCoordinateTransformContext(), saveOptions ) );
       ExporterVector exp( this );
       exp.run();
       return;
@@ -292,9 +288,7 @@ QgsMapLayer *QgsPointCloudLayerExporter::takeExportedLayer()
   {
     case ExportFormat::Memory:
     {
-      QgsMapLayer *retVal = mMemoryLayer;
-      mMemoryLayer = nullptr;
-      return retVal;
+      return mMemoryLayer.release();
     }
 
     case ExportFormat::Las:
@@ -450,7 +444,7 @@ void QgsPointCloudLayerExporter::ExporterMemory::handlePoint( double x, double y
 
 void QgsPointCloudLayerExporter::ExporterMemory::handleNode()
 {
-  QgsVectorLayer *vl = qgis::down_cast<QgsVectorLayer *>( mParent->mMemoryLayer );
+  QgsVectorLayer *vl = qgis::down_cast<QgsVectorLayer *>( mParent->mMemoryLayer.get() );
   if ( vl )
   {
     if ( !vl->dataProvider()->addFeatures( mFeatures ) )
@@ -475,8 +469,7 @@ QgsPointCloudLayerExporter::ExporterVector::ExporterVector( QgsPointCloudLayerEx
 
 QgsPointCloudLayerExporter::ExporterVector::~ExporterVector()
 {
-  delete mParent->mVectorSink;
-  mParent->mVectorSink = nullptr;
+  mParent->mVectorSink.reset();
 }
 
 void QgsPointCloudLayerExporter::ExporterVector::handlePoint( double x, double y, double z, const QVariantMap &map, const qint64 pointNumber )

--- a/src/core/pointcloud/qgspointcloudlayerexporter.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerexporter.cpp
@@ -515,7 +515,7 @@ QgsPointCloudLayerExporter::ExporterPdal::ExporterPdal( QgsPointCloudLayerExport
   mOptions.add( "a_srs", mParent->mTargetCrs.toWkt().toStdString() );
   mOptions.add( "minor_version", u"4"_s.toStdString() ); // delault to LAZ 1.4 to properly handle pdrf >= 6
   mOptions.add( "format", QString::number( mPointFormat ).toStdString() );
-  if ( mParent->mTransform->isShortCircuited() )
+  if ( mParent->mTransform.isShortCircuited() )
   {
     mOptions.add( "offset_x", QString::number( mParent->mIndex.offset().x() ).toStdString() );
     mOptions.add( "offset_y", QString::number( mParent->mIndex.offset().y() ).toStdString() );

--- a/src/core/pointcloud/qgspointcloudlayerexporter.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerexporter.cpp
@@ -211,12 +211,12 @@ void QgsPointCloudLayerExporter::prepareExport()
 
 void QgsPointCloudLayerExporter::doExport()
 {
-  mTransform = std::make_unique<QgsCoordinateTransform>( mSourceCrs, mTargetCrs, mTransformContext );
+  mTransform = QgsCoordinateTransform( mSourceCrs, mTargetCrs, mTransformContext );
   if ( mExtent.isFinite() )
   {
     try
     {
-      mExtent = mTransform->transformBoundingBox( mExtent, Qgis::TransformDirection::Reverse );
+      mExtent = mTransform.transformBoundingBox( mExtent, Qgis::TransformDirection::Reverse );
     }
     catch ( const QgsCsException &cse )
     {
@@ -397,7 +397,7 @@ void QgsPointCloudLayerExporter::ExporterBase::run()
 
       try
       {
-        mParent->mTransform->transformInPlace( x, y, z );
+        mParent->mTransform.transformInPlace( x, y, z );
         const QVariantMap attributeMap = QgsPointCloudAttribute::getAttributeMap( ptr, i * recordSize, attributesCollection );
         handlePoint( x, y, z, attributeMap, pointsExported );
         ++pointsExported;

--- a/src/core/pointcloud/qgspointcloudlayerexporter.h
+++ b/src/core/pointcloud/qgspointcloudlayerexporter.h
@@ -277,9 +277,9 @@ class CORE_EXPORT QgsPointCloudLayerExporter SIP_NODEFAULTCTORS
     int mPointRecordFormat;
     QgsVectorFileWriter::ActionOnExistingFile mActionOnExistingFile = QgsVectorFileWriter::ActionOnExistingFile::CreateOrOverwriteFile;
 
-    QgsMapLayer *mMemoryLayer = nullptr;
-    QgsFeatureSink *mVectorSink = nullptr;
-    QgsCoordinateTransform *mTransform = nullptr;
+    std::unique_ptr<QgsMapLayer> mMemoryLayer;
+    std::unique_ptr<QgsFeatureSink> mVectorSink;
+    std::unique_ptr<QgsCoordinateTransform> mTransform;
 
 
     class ExporterBase

--- a/src/core/pointcloud/qgspointcloudlayerexporter.h
+++ b/src/core/pointcloud/qgspointcloudlayerexporter.h
@@ -279,7 +279,7 @@ class CORE_EXPORT QgsPointCloudLayerExporter SIP_NODEFAULTCTORS
 
     std::unique_ptr<QgsMapLayer> mMemoryLayer;
     std::unique_ptr<QgsFeatureSink> mVectorSink;
-    std::unique_ptr<QgsCoordinateTransform> mTransform;
+    QgsCoordinateTransform mTransform;
 
 
     class ExporterBase

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -851,8 +851,7 @@ bool QgsProperty::loadVariant( const QVariant &property )
   }
 
   //restore transformer if present
-  delete d->transformer;
-  d->transformer = nullptr;
+  d->transformer.reset();
 
 
   const QVariant transform = propertyMap.value( u"transformer"_s );
@@ -867,7 +866,7 @@ bool QgsProperty::loadVariant( const QVariant &property )
     if ( transformer )
     {
       if ( transformer->loadVariant( transformerMap.value( u"d"_s ) ) )
-        d->transformer = transformer.release();
+        d->transformer = std::move( transformer );
     }
   }
 
@@ -878,12 +877,12 @@ bool QgsProperty::loadVariant( const QVariant &property )
 void QgsProperty::setTransformer( QgsPropertyTransformer *transformer )
 {
   d.detach();
-  d->transformer = transformer;
+  d->transformer.reset( transformer );
 }
 
 const QgsPropertyTransformer *QgsProperty::transformer() const
 {
-  return d->transformer;
+  return d->transformer.get();
 }
 
 bool QgsProperty::convertToTransformer()
@@ -901,7 +900,7 @@ bool QgsProperty::convertToTransformer()
     return false;
 
   d.detach();
-  d->transformer = transformer.release();
+  d->transformer = std::move( transformer );
   if ( !fieldName.isEmpty() )
     setField( fieldName );
   else

--- a/src/core/qgsproperty_p.h
+++ b/src/core/qgsproperty_p.h
@@ -55,7 +55,7 @@ class QgsPropertyPrivate : public QSharedData
       , expressionReferencedCols( other.expressionReferencedCols )
     {}
 
-    ~QgsPropertyPrivate() { delete transformer; }
+    ~QgsPropertyPrivate() {}
 
     Qgis::PropertyType type = Qgis::PropertyType::Invalid;
 
@@ -63,7 +63,7 @@ class QgsPropertyPrivate : public QSharedData
     bool active = true;
 
     //! Optional transformer
-    QgsPropertyTransformer *transformer = nullptr;
+    std::unique_ptr<QgsPropertyTransformer> transformer;
 
     // StaticData
     QVariant staticValue;

--- a/src/core/qgsspatialindex.cpp
+++ b/src/core/qgsspatialindex.cpp
@@ -283,22 +283,18 @@ class QgsSpatialIndexData : public QSharedData
       double low[] = { std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest() };
       double high[] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max() };
       const SpatialIndex::Region query( low, high, 2 );
-      QgsSpatialIndexCopyVisitor visitor( mRTree );
+      QgsSpatialIndexCopyVisitor visitor( mRTree.get() );
       other.mRTree->intersectsWithQuery( query, visitor );
     }
 
-    ~QgsSpatialIndexData()
-    {
-      delete mRTree;
-      delete mStorage;
-    }
+    ~QgsSpatialIndexData() {}
 
     QgsSpatialIndexData &operator=( const QgsSpatialIndexData &rh ) = delete;
 
     void initTree( IDataStream *inputStream = nullptr )
     {
       // for now only memory manager
-      mStorage = StorageManager::createNewMemoryStorageManager();
+      mStorage.reset( StorageManager::createNewMemoryStorageManager() );
 
       // R-Tree parameters
       const double fillFactor = 0.7;
@@ -311,16 +307,16 @@ class QgsSpatialIndexData : public QSharedData
       SpatialIndex::id_type indexId;
 
       if ( inputStream && inputStream->hasNext() )
-        mRTree = RTree::createAndBulkLoadNewRTree( RTree::BLM_STR, *inputStream, *mStorage, fillFactor, indexCapacity, leafCapacity, dimension, variant, indexId );
+        mRTree.reset( RTree::createAndBulkLoadNewRTree( RTree::BLM_STR, *inputStream, *mStorage, fillFactor, indexCapacity, leafCapacity, dimension, variant, indexId ) );
       else
-        mRTree = RTree::createNewRTree( *mStorage, fillFactor, indexCapacity, leafCapacity, dimension, variant, indexId );
+        mRTree.reset( RTree::createNewRTree( *mStorage, fillFactor, indexCapacity, leafCapacity, dimension, variant, indexId ) );
     }
 
     //! Storage manager
-    SpatialIndex::IStorageManager *mStorage = nullptr;
+    std::unique_ptr<SpatialIndex::IStorageManager> mStorage;
 
     //! R-tree containing spatial index
-    SpatialIndex::ISpatialIndex *mRTree = nullptr;
+    std::unique_ptr<SpatialIndex::ISpatialIndex> mRTree;
 
     mutable QRecursiveMutex mMutex;
 };

--- a/src/core/raster/qgsrasterblock.cpp
+++ b/src/core/raster/qgsrasterblock.cpp
@@ -53,7 +53,7 @@ QgsRasterBlock::~QgsRasterBlock()
 {
   QgsDebugMsgLevel( u"mData = %1"_s.arg( reinterpret_cast< quint64 >( mData ) ), 4 );
   qgsFree( mData );
-  delete mImage;
+
   qgsFree( mNoDataBitmap );
 }
 
@@ -63,8 +63,8 @@ bool QgsRasterBlock::reset( Qgis::DataType dataType, int width, int height )
 
   qgsFree( mData );
   mData = nullptr;
-  delete mImage;
-  mImage = nullptr;
+  mImage.reset();
+
   qgsFree( mNoDataBitmap );
   mNoDataBitmap = nullptr;
   mDataType = Qgis::DataType::UnknownDataType;
@@ -91,7 +91,7 @@ bool QgsRasterBlock::reset( Qgis::DataType dataType, int width, int height )
   {
     QgsDebugMsgLevel( u"Color type"_s, 4 );
     const QImage::Format format = imageFormat( dataType );
-    mImage = new QImage( width, height, format );
+    mImage = std::make_unique<QImage>( width, height, format );
   }
   else
   {
@@ -104,7 +104,14 @@ bool QgsRasterBlock::reset( Qgis::DataType dataType, int width, int height )
   mTypeSize = QgsRasterBlock::typeSize( mDataType );
   mWidth = width;
   mHeight = height;
-  QgsDebugMsgLevel( u"mWidth= %1 mHeight = %2 mDataType = %3 mData = %4 mImage = %5"_s.arg( mWidth ).arg( mHeight ).arg( static_cast< int>( mDataType ) ).arg( reinterpret_cast< quint64 >( mData ) ).arg( reinterpret_cast< quint64 >( mImage ) ), 4 );
+  QgsDebugMsgLevel(
+    u"mWidth= %1 mHeight = %2 mDataType = %3 mData = %4 mImage = %5"_s.arg( mWidth )
+      .arg( mHeight )
+      .arg( static_cast< int>( mDataType ) )
+      .arg( reinterpret_cast< quint64 >( mData ) )
+      .arg( reinterpret_cast< quint64 >( mImage.get() ) ),
+    4
+  );
   return true;
 }
 
@@ -136,7 +143,14 @@ Qgis::DataType QgsRasterBlock::dataType( QImage::Format format )
 
 bool QgsRasterBlock::isEmpty() const
 {
-  QgsDebugMsgLevel( u"mWidth= %1 mHeight = %2 mDataType = %3 mData = %4 mImage = %5"_s.arg( mWidth ).arg( mHeight ).arg( qgsEnumValueToKey( mDataType ) ).arg( reinterpret_cast< quint64 >( mData ) ).arg( reinterpret_cast< quint64 >( mImage ) ), 4 );
+  QgsDebugMsgLevel(
+    u"mWidth= %1 mHeight = %2 mDataType = %3 mData = %4 mImage = %5"_s.arg( mWidth )
+      .arg( mHeight )
+      .arg( qgsEnumValueToKey( mDataType ) )
+      .arg( reinterpret_cast< quint64 >( mData ) )
+      .arg( reinterpret_cast< quint64 >( mImage.get() ) ),
+    4
+  );
   return mWidth == 0 || mHeight == 0 || ( typeIsNumeric( mDataType ) && !mData ) || ( typeIsColor( mDataType ) && !mImage );
 }
 
@@ -754,9 +768,8 @@ bool QgsRasterBlock::setImage( const QImage *image )
 {
   qgsFree( mData );
   mData = nullptr;
-  delete mImage;
-  mImage = nullptr;
-  mImage = new QImage( *image );
+
+  mImage = std::make_unique<QImage>( *image );
   mWidth = mImage->width();
   mHeight = mImage->height();
   mDataType = dataType( mImage->format() );

--- a/src/core/raster/qgsrasterblock.h
+++ b/src/core/raster/qgsrasterblock.h
@@ -43,6 +43,9 @@ class CORE_EXPORT QgsRasterBlock
   public:
     QgsRasterBlock();
 
+    QgsRasterBlock( const QgsRasterBlock &rh ) = delete;
+    QgsRasterBlock &operator=( const QgsRasterBlock &rh ) = delete;
+
     /**
      * \brief Constructor which allocates data block in memory
      *  \param dataType raster data type
@@ -810,6 +813,11 @@ class CORE_EXPORT QgsRasterBlock
     bool minimumMaximum( double &minimum SIP_OUT, int &minimumRow SIP_OUT, int &minimumColumn SIP_OUT, double &maximum SIP_OUT, int &maximumRow SIP_OUT, int &maximumColumn SIP_OUT ) const;
 
   private:
+
+#ifdef SIP_RUN
+  QgsRasterBlock( const QgsRasterBlock &rh );
+#endif
+
     static QImage::Format imageFormat( Qgis::DataType dataType );
     static Qgis::DataType dataType( QImage::Format format );
 
@@ -880,7 +888,7 @@ class CORE_EXPORT QgsRasterBlock
     void *mData = nullptr;
 
     // Image for image data types, not used with numerical data types
-    QImage *mImage = nullptr;
+    std::unique_ptr<QImage> mImage;
 
     // Bitmap of no data. One bit for each pixel. Bit is 1 if a pixels is no data.
     // Each row is represented by whole number of bytes (last bits may be unused)
@@ -1035,5 +1043,3 @@ inline bool QgsRasterBlock::isNoDataValue( double value ) const SIP_SKIP
 }
 
 #endif
-
-

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -81,7 +81,7 @@ void QgsRasterLayerRendererFeedback::onNewData()
   feedback.setRenderPartialOutput( true );
   QgsRasterIterator iterator( mR->mPipe->last() );
   QgsRasterDrawer drawer( &iterator );
-  drawer.draw( *( mR->renderContext() ), mR->mRasterViewPort, &feedback );
+  drawer.draw( *( mR->renderContext() ), mR->mRasterViewPort.get(), &feedback );
   mR->mReadyToCompose = true;
   QgsDebugMsgLevel( u"total raster preview time: %1 ms"_s.arg( t.elapsed() ), 3 );
   mLastPreview = QTime::currentTime();
@@ -95,7 +95,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   , mLayerOpacity( layer->opacity() )
   , mProviderCapabilities( layer->dataProvider()->providerCapabilities() )
   , mInterfaceCapabilities( layer->dataProvider()->capabilities() )
-  , mFeedback( new QgsRasterLayerRendererFeedback( this ) )
+  , mFeedback( std::make_unique<QgsRasterLayerRendererFeedback>( this ) )
   , mEnableProfile( rendererContext.flags() & Qgis::RenderContextFlag::RecordProfile )
 {
   mReadyToCompose = false;
@@ -226,7 +226,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   //
   //this is not a class level member because every time the user pans or zooms
   //the contents of the rasterViewPort will change
-  mRasterViewPort = new QgsRasterViewPort();
+  mRasterViewPort = std::make_unique<QgsRasterViewPort>();
 
   mRasterViewPort->mDrawnExtent = visibleExtentOfRasterInMapCrs;
   if ( rendererContext.coordinateTransform().isValid() )
@@ -500,11 +500,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
 }
 
 QgsRasterLayerRenderer::~QgsRasterLayerRenderer()
-{
-  delete mFeedback;
-
-  delete mRasterViewPort;
-}
+{}
 
 bool QgsRasterLayerRenderer::render()
 {
@@ -600,7 +596,7 @@ bool QgsRasterLayerRenderer::render()
   }
 
   QgsRasterDrawer drawer( &iterator );
-  drawer.draw( *( renderContext() ), mRasterViewPort, mFeedback );
+  drawer.draw( *( renderContext() ), mRasterViewPort.get(), mFeedback.get() );
 
   if ( mDrawElevationMap )
     drawElevationMap();
@@ -638,7 +634,7 @@ bool QgsRasterLayerRenderer::render()
 
 QgsFeedback *QgsRasterLayerRenderer::feedback() const
 {
-  return mFeedback;
+  return mFeedback.get();
 }
 
 bool QgsRasterLayerRenderer::forceRasterRender() const
@@ -698,7 +694,7 @@ void QgsRasterLayerRenderer::prepareLabeling( QgsRasterLayer *layer )
 void QgsRasterLayerRenderer::drawLabeling()
 {
   if ( mLabelProvider )
-    mLabelProvider->generateLabels( *renderContext(), mPipe.get(), mRasterViewPort, mFeedback );
+    mLabelProvider->generateLabels( *renderContext(), mPipe.get(), mRasterViewPort.get(), mFeedback.get() );
 }
 
 void QgsRasterLayerRenderer::drawElevationMap()
@@ -724,7 +720,7 @@ void QgsRasterLayerRenderer::drawElevationMap()
     std::unique_ptr<QgsRasterBlock> elevationBlock;
     if ( mRasterViewPort->mSrcCRS == mRasterViewPort->mDestCRS )
     {
-      elevationBlock.reset( dataProvider->block( mElevationBand, mRasterViewPort->mDrawnExtent, outputWidth, outputHeight, mFeedback ) );
+      elevationBlock.reset( dataProvider->block( mElevationBand, mRasterViewPort->mDrawnExtent, outputWidth, outputHeight, mFeedback.get() ) );
       canRenderElevation = true;
     }
     else
@@ -779,7 +775,7 @@ void QgsRasterLayerRenderer::drawElevationMap()
         );
 
         // Now we can do the resampling
-        std::unique_ptr<QgsRasterBlock> sourcedata( dataProvider->block( mElevationBand, viewExtentInLayerCoordinate, sourceWidth, sourceHeight, mFeedback ) );
+        std::unique_ptr<QgsRasterBlock> sourcedata( dataProvider->block( mElevationBand, viewExtentInLayerCoordinate, sourceWidth, sourceHeight, mFeedback.get() ) );
         gdal::dataset_unique_ptr gdalDsInput = QgsGdalUtils::blockToSingleBandMemoryDataset( viewExtentInLayerCoordinate, sourcedata.get() );
 
 

--- a/src/core/raster/qgsrasterlayerrenderer.h
+++ b/src/core/raster/qgsrasterlayerrenderer.h
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsRasterLayerRenderer : public QgsMapLayerRenderer
     void drawLabeling();
 
     QString mLayerName;
-    QgsRasterViewPort *mRasterViewPort = nullptr;
+    std::unique_ptr<QgsRasterViewPort> mRasterViewPort;
 
     double mLayerOpacity = 1.0;
     std::unique_ptr<QgsRasterPipe> mPipe;
@@ -91,7 +91,7 @@ class CORE_EXPORT QgsRasterLayerRenderer : public QgsMapLayerRenderer
     Qgis::RasterInterfaceCapabilities mInterfaceCapabilities;
 
     //! feedback class for cancellation and preview generation
-    QgsRasterLayerRendererFeedback *mFeedback = nullptr;
+    std::unique_ptr<QgsRasterLayerRendererFeedback> mFeedback;
 
     QList< QgsMapClippingRegion > mClippingRegions;
 

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -221,10 +221,10 @@ ProjectorData::ProjectorData(
 #endif
 
   // init helper points
-  pHelperTop = std::make_unique<QgsPointXY[]>( mDestCols );
-  pHelperBottom = std::make_unique<QgsPointXY[]>( mDestCols );
-  calcHelper( 0, pHelperTop.get() );
-  calcHelper( 1, pHelperBottom.get() );
+  pHelperTop.resize( mDestCols );
+  pHelperBottom.resize( mDestCols );
+  calcHelper( 0, pHelperTop );
+  calcHelper( 1, pHelperBottom );
   mHelperTopRow = 0;
 
   // Calculate source dimensions
@@ -438,7 +438,7 @@ inline int ProjectorData::matrixCol( int destCol ) const
   return static_cast< int >( std::floor( ( destCol + 0.5 ) / mDestColsPerMatrixCol ) );
 }
 
-void ProjectorData::calcHelper( int matrixRow, QgsPointXY *points )
+void ProjectorData::calcHelper( int matrixRow, std::vector<QgsPointXY> &points )
 {
   // TODO?: should we also precalc dest cell center coordinates for x and y?
   for ( int myDestCol = 0; myDestCol < mDestCols; myDestCol++ )
@@ -468,7 +468,7 @@ void ProjectorData::nextHelper()
 {
   // We just switch pHelperTop and pHelperBottom, memory is not lost
   swap( pHelperTop, pHelperBottom );
-  calcHelper( mHelperTopRow + 2, pHelperBottom.get() );
+  calcHelper( mHelperTopRow + 2, pHelperBottom );
   mHelperTopRow++;
 }
 

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -221,10 +221,10 @@ ProjectorData::ProjectorData(
 #endif
 
   // init helper points
-  pHelperTop = new QgsPointXY[mDestCols];
-  pHelperBottom = new QgsPointXY[mDestCols];
-  calcHelper( 0, pHelperTop );
-  calcHelper( 1, pHelperBottom );
+  pHelperTop = std::make_unique<QgsPointXY[]>( mDestCols );
+  pHelperBottom = std::make_unique<QgsPointXY[]>( mDestCols );
+  calcHelper( 0, pHelperTop.get() );
+  calcHelper( 1, pHelperBottom.get() );
   mHelperTopRow = 0;
 
   // Calculate source dimensions
@@ -235,10 +235,7 @@ ProjectorData::ProjectorData(
 }
 
 ProjectorData::~ProjectorData()
-{
-  delete[] pHelperTop;
-  delete[] pHelperBottom;
-}
+{}
 
 
 void ProjectorData::calcSrcExtent()
@@ -470,11 +467,8 @@ void ProjectorData::calcHelper( int matrixRow, QgsPointXY *points )
 void ProjectorData::nextHelper()
 {
   // We just switch pHelperTop and pHelperBottom, memory is not lost
-  QgsPointXY *tmp = nullptr;
-  tmp = pHelperTop;
-  pHelperTop = pHelperBottom;
-  pHelperBottom = tmp;
-  calcHelper( mHelperTopRow + 2, pHelperBottom );
+  swap( pHelperTop, pHelperBottom );
+  calcHelper( mHelperTopRow + 2, pHelperBottom.get() );
   mHelperTopRow++;
 }
 

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -268,11 +268,11 @@ class ProjectorData
 
     //! Array of source points for each destination column on top of current CPMatrix grid row
     /* Warning: using QList is slow on access */
-    QgsPointXY *pHelperTop = nullptr;
+    std::unique_ptr<QgsPointXY[]> pHelperTop;
 
     //! Array of source points for each destination column on bottom of current CPMatrix grid row
     /* Warning: using QList is slow on access */
-    QgsPointXY *pHelperBottom = nullptr;
+    std::unique_ptr<QgsPointXY[]> pHelperBottom;
 
     //! Current mHelperTop matrix row
     int mHelperTopRow = 0;

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -203,7 +203,7 @@ class ProjectorData
     bool checkRows( const QgsCoordinateTransform &ct ) const;
 
     //! Calculate array of src helper points
-    void calcHelper( int matrixRow, QgsPointXY *points );
+    void calcHelper( int matrixRow, std::vector<QgsPointXY> &points );
 
     //! Calc / switch helper
     void nextHelper();
@@ -268,11 +268,11 @@ class ProjectorData
 
     //! Array of source points for each destination column on top of current CPMatrix grid row
     /* Warning: using QList is slow on access */
-    std::unique_ptr<QgsPointXY[]> pHelperTop;
+    std::vector<QgsPointXY> pHelperTop;
 
     //! Array of source points for each destination column on bottom of current CPMatrix grid row
     /* Warning: using QList is slow on access */
-    std::unique_ptr<QgsPointXY[]> pHelperBottom;
+    std::vector<QgsPointXY> pHelperBottom;
 
     //! Current mHelperTop matrix row
     int mHelperTopRow = 0;

--- a/src/core/symbology/qgsheatmaprenderer.cpp
+++ b/src/core/symbology/qgsheatmaprenderer.cpp
@@ -35,15 +35,13 @@ using namespace Qt::StringLiterals;
 QgsHeatmapRenderer::QgsHeatmapRenderer()
   : QgsFeatureRenderer( u"heatmapRenderer"_s )
 {
-  mGradientRamp = new QgsGradientColorRamp( QColor( 255, 255, 255 ), QColor( 0, 0, 0 ) );
+  mGradientRamp = std::make_unique<QgsGradientColorRamp>( QColor( 255, 255, 255 ), QColor( 0, 0, 0 ) );
   mLegendSettings.setMinimumLabel( QObject::tr( "Minimum" ) );
   mLegendSettings.setMaximumLabel( QObject::tr( "Maximum" ) );
 }
 
 QgsHeatmapRenderer::~QgsHeatmapRenderer()
-{
-  delete mGradientRamp;
-}
+{}
 
 void QgsHeatmapRenderer::initializeValues( QgsRenderContext &context )
 {
@@ -351,7 +349,7 @@ QDomElement QgsHeatmapRenderer::save( QDomDocument &doc, const QgsReadWriteConte
 
   if ( mGradientRamp )
   {
-    const QDomElement colorRampElem = QgsSymbolLayerUtils::saveColorRamp( u"[source]"_s, mGradientRamp, doc );
+    const QDomElement colorRampElem = QgsSymbolLayerUtils::saveColorRamp( u"[source]"_s, mGradientRamp.get(), doc );
     rendererElem.appendChild( colorRampElem );
   }
   mLegendSettings.writeXml( doc, rendererElem, context );
@@ -407,7 +405,7 @@ bool QgsHeatmapRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
   if ( mGradientRamp )
   {
-    QgsStyleColorRampEntity entity( mGradientRamp );
+    QgsStyleColorRampEntity entity( mGradientRamp.get() );
     if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) ) )
       return false;
   }
@@ -421,8 +419,7 @@ QList<QgsLayerTreeModelLegendNode *> QgsHeatmapRenderer::createLegendNodes( QgsL
 
 void QgsHeatmapRenderer::setColorRamp( QgsColorRamp *ramp )
 {
-  delete mGradientRamp;
-  mGradientRamp = ramp;
+  mGradientRamp.reset( ramp );
 }
 
 void QgsHeatmapRenderer::setLegendSettings( const QgsColorRampLegendNodeSettings &settings )

--- a/src/core/symbology/qgsheatmaprenderer.h
+++ b/src/core/symbology/qgsheatmaprenderer.h
@@ -69,7 +69,7 @@ class CORE_EXPORT QgsHeatmapRenderer : public QgsFeatureRenderer
      * \returns color ramp for heatmap
      * \see setColorRamp
      */
-    QgsColorRamp *colorRamp() const { return mGradientRamp; }
+    QgsColorRamp *colorRamp() const { return mGradientRamp.get(); }
 
     /**
      * Sets the color ramp to use for shading the heatmap.
@@ -209,7 +209,7 @@ class CORE_EXPORT QgsHeatmapRenderer : public QgsFeatureRenderer
     int mWeightAttrNum = -1;
     std::unique_ptr<QgsExpression> mWeightExpression;
 
-    QgsColorRamp *mGradientRamp = nullptr;
+    std::unique_ptr<QgsColorRamp> mGradientRamp;
 
     double mExplicitMax = 0.0;
     int mRenderQuality = 3;

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -980,14 +980,12 @@ QgsRuleBasedRenderer::QgsRuleBasedRenderer( QgsRuleBasedRenderer::Rule *root )
 QgsRuleBasedRenderer::QgsRuleBasedRenderer( QgsSymbol *defaultSymbol )
   : QgsFeatureRenderer( u"RuleRenderer"_s )
 {
-  mRootRule = new Rule( nullptr ); // root has no symbol, no filter etc - just a container
+  mRootRule = std::make_unique<Rule>( nullptr ); // root has no symbol, no filter etc - just a container
   mRootRule->appendChild( new Rule( defaultSymbol ) );
 }
 
 QgsRuleBasedRenderer::~QgsRuleBasedRenderer()
-{
-  delete mRootRule;
-}
+{}
 
 
 QgsSymbol *QgsRuleBasedRenderer::symbolForFeature( const QgsFeature &, QgsRenderContext & ) const
@@ -1016,7 +1014,7 @@ Qgis::FeatureRendererFlags QgsRuleBasedRenderer::flags() const
       exploreRule( child );
     }
   };
-  exploreRule( mRootRule );
+  exploreRule( mRootRule.get() );
 
   return res;
 }

--- a/src/core/symbology/qgsrulebasedrenderer.h
+++ b/src/core/symbology/qgsrulebasedrenderer.h
@@ -573,7 +573,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
 
     /////
 
-    QgsRuleBasedRenderer::Rule *rootRule() { return mRootRule; }
+    QgsRuleBasedRenderer::Rule *rootRule() { return mRootRule.get(); }
 
     //////
 
@@ -598,7 +598,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
 
   protected:
     //! the root node with hierarchical list of rules
-    Rule *mRootRule = nullptr;
+    std::unique_ptr<Rule> mRootRule;
 
     // temporary
     RenderQueue mRenderQueue;

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -165,6 +165,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath, const QString &b
 
   mGeometryOptions = std::make_unique<QgsGeometryOptions>();
   mActions = new QgsActionManager( this );
+  mActions->setParent( this );
   mConditionalStyles = new QgsConditionalLayerStyles( this );
   mStoredExpressionManager = new QgsStoredExpressionManager();
   mStoredExpressionManager->setParent( this );
@@ -173,7 +174,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath, const QString &b
   mJoinBuffer->setParent( this );
   connect( mJoinBuffer, &QgsVectorLayerJoinBuffer::joinedFieldsChanged, this, &QgsVectorLayer::onJoinedFieldsChanged );
 
-  mExpressionFieldBuffer = new QgsExpressionFieldBuffer();
+  mExpressionFieldBuffer = std::make_unique<QgsExpressionFieldBuffer>();
   // if we're given a provider type, try to create and bind one to this layer
   if ( !vectorLayerPath.isEmpty() && !mProviderKey.isEmpty() )
   {
@@ -232,20 +233,6 @@ QgsVectorLayer::~QgsVectorLayer()
   emit willBeDeleted();
 
   setValid( false );
-
-  delete mDataProvider;
-  delete mEditBuffer;
-  delete mJoinBuffer;
-  delete mExpressionFieldBuffer;
-  delete mLabeling;
-  delete mDiagramLayerSettings;
-  delete mDiagramRenderer;
-
-  delete mActions;
-
-  delete mRenderer;
-  delete mConditionalStyles;
-  delete mStoredExpressionManager;
 
   if ( mFeatureCounter )
     mFeatureCounter->cancel();
@@ -795,8 +782,7 @@ void QgsVectorLayer::setDiagramRenderer( QgsDiagramRenderer *r )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  delete mDiagramRenderer;
-  mDiagramRenderer = r;
+  mDiagramRenderer.reset( r );
   emit rendererChanged();
   emit styleChanged();
 }
@@ -1809,11 +1795,10 @@ void QgsVectorLayer::setLabeling( QgsAbstractVectorLayerLabeling *labeling )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  if ( mLabeling == labeling )
+  if ( mLabeling.get() == labeling )
     return;
 
-  delete mLabeling;
-  mLabeling = labeling;
+  mLabeling.reset( labeling );
 }
 
 bool QgsVectorLayer::startEditing()
@@ -2519,7 +2504,7 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
   if ( categories.testFlag( Fields ) )
   {
     if ( !mExpressionFieldBuffer )
-      mExpressionFieldBuffer = new QgsExpressionFieldBuffer();
+      mExpressionFieldBuffer = std::make_unique<QgsExpressionFieldBuffer>();
     mExpressionFieldBuffer->readXml( layerNode );
 
     updateFields();
@@ -3048,12 +3033,11 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage, Qgs
     {
       QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Diagrams" ) );
 
-      delete mDiagramRenderer;
-      mDiagramRenderer = nullptr;
+      mDiagramRenderer.reset();
       QDomElement singleCatDiagramElem = node.firstChildElement( u"SingleCategoryDiagramRenderer"_s );
       if ( !singleCatDiagramElem.isNull() )
       {
-        mDiagramRenderer = new QgsSingleCategoryDiagramRenderer();
+        mDiagramRenderer = std::make_unique<QgsSingleCategoryDiagramRenderer>();
         mDiagramRenderer->readXml( singleCatDiagramElem, context );
       }
       QDomElement linearDiagramElem = node.firstChildElement( u"LinearlyInterpolatedDiagramRenderer"_s );
@@ -3067,13 +3051,13 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage, Qgs
             linearDiagramElem.setAttribute( u"classificationField"_s, mFields.at( idx ).name() );
         }
 
-        mDiagramRenderer = new QgsLinearlyInterpolatedDiagramRenderer();
+        mDiagramRenderer = std::make_unique<QgsLinearlyInterpolatedDiagramRenderer>();
         mDiagramRenderer->readXml( linearDiagramElem, context );
       }
       QDomElement stackedDiagramElem = node.firstChildElement( u"StackedDiagramRenderer"_s );
       if ( !stackedDiagramElem.isNull() )
       {
-        mDiagramRenderer = new QgsStackedDiagramRenderer();
+        mDiagramRenderer = std::make_unique<QgsStackedDiagramRenderer>();
         mDiagramRenderer->readXml( stackedDiagramElem, context );
       }
 
@@ -3117,8 +3101,7 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage, Qgs
             diagramSettingsElem.appendChild( propertiesElem );
           }
 
-          delete mDiagramLayerSettings;
-          mDiagramLayerSettings = new QgsDiagramLayerSettings();
+          mDiagramLayerSettings = std::make_unique<QgsDiagramLayerSettings>();
           mDiagramLayerSettings->readXml( diagramSettingsElem );
         }
       }
@@ -4542,17 +4525,16 @@ void QgsVectorLayer::setRenderer( QgsFeatureRenderer *r )
   if ( r && !isSpatial() && mWkbType != Qgis::WkbType::Unknown )
     return;
 
-  if ( r != mRenderer )
+  if ( r != mRenderer.get() )
   {
-    delete mRenderer;
-    mRenderer = r;
+    mRenderer.reset( r );
     mSymbolFeatureCounted = false;
     mSymbolFeatureCountMap.clear();
     mSymbolFeatureIdMap.clear();
 
     if ( mRenderer )
     {
-      const double refreshRate = QgsSymbolLayerUtils::rendererFrameRate( mRenderer );
+      const double refreshRate = QgsSymbolLayerUtils::rendererFrameRate( mRenderer.get() );
       if ( refreshRate <= 0 )
       {
         mRefreshRendererTimer->stop();
@@ -5329,13 +5311,15 @@ void QgsVectorLayer::createEditBuffer()
   if ( mDataProvider->transaction() )
   {
     mEditBuffer = new QgsVectorLayerEditPassthrough( this );
-
     connect( mDataProvider->transaction(), &QgsTransaction::dirtied, this, &QgsVectorLayer::onDirtyTransaction, Qt::UniqueConnection );
   }
   else
   {
     mEditBuffer = new QgsVectorLayerEditBuffer( this );
   }
+
+  mEditBuffer->setParent( this );
+
   // forward signals
   connect( mEditBuffer, &QgsVectorLayerEditBuffer::layerModified, this, &QgsVectorLayer::invalidateSymbolCountedFlag );
   connect( mEditBuffer, &QgsVectorLayerEditBuffer::layerModified, this, &QgsVectorLayer::layerModified ); // TODO[MD]: necessary?
@@ -6088,7 +6072,7 @@ void QgsVectorLayer::setDiagramLayerSettings( const QgsDiagramLayerSettings &s )
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   if ( !mDiagramLayerSettings )
-    mDiagramLayerSettings = new QgsDiagramLayerSettings();
+    mDiagramLayerSettings = std::make_unique<QgsDiagramLayerSettings>();
   *mDiagramLayerSettings = s;
 }
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -937,10 +937,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
 
     //! Sets diagram rendering object (takes ownership)
     void setDiagramRenderer( QgsDiagramRenderer *r SIP_TRANSFER );
-    const QgsDiagramRenderer *diagramRenderer() const { return mDiagramRenderer; }
+    const QgsDiagramRenderer *diagramRenderer() const { return mDiagramRenderer.get(); }
 
     void setDiagramLayerSettings( const QgsDiagramLayerSettings &s );
-    const QgsDiagramLayerSettings *diagramLayerSettings() const { return mDiagramLayerSettings; }
+    const QgsDiagramLayerSettings *diagramLayerSettings() const { return mDiagramLayerSettings.get(); }
 
     /**
      * Returns the feature renderer used for rendering the features in the layer in 2D
@@ -948,7 +948,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      *
      * \see setRenderer()
      */
-    QgsFeatureRenderer *renderer() { return mRenderer; }
+    QgsFeatureRenderer *renderer() { return mRenderer.get(); }
 
     /**
      * Returns the feature renderer used for rendering the features in the layer in 2D
@@ -957,7 +957,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \see setRenderer()
      * \note not available in Python bindings
      */
-    const QgsFeatureRenderer *renderer() const SIP_SKIP { return mRenderer; }
+    const QgsFeatureRenderer *renderer() const SIP_SKIP { return mRenderer.get(); }
 
     /**
      * Sets the feature renderer which will be invoked to represent this layer in 2D map views.
@@ -1617,14 +1617,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \note Labels will only be rendered if labelsEnabled() returns TRUE.
      * \see labelsEnabled()
      */
-    const QgsAbstractVectorLayerLabeling *labeling() const SIP_SKIP { return mLabeling; }
+    const QgsAbstractVectorLayerLabeling *labeling() const SIP_SKIP { return mLabeling.get(); }
 
     /**
      * Access to labeling configuration. May be NULLPTR if labeling is not used.
      * \note Labels will only be rendered if labelsEnabled() returns TRUE.
      * \see labelsEnabled()
      */
-    QgsAbstractVectorLayerLabeling *labeling() { return mLabeling; }
+    QgsAbstractVectorLayerLabeling *labeling() { return mLabeling.get(); }
 
     /**
      * Sets labeling configuration. Takes ownership of the object.
@@ -3010,13 +3010,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
     Qgis::WkbType mWkbType = Qgis::WkbType::Unknown;
 
     //! Renderer object which holds the information about how to display the features
-    QgsFeatureRenderer *mRenderer = nullptr;
+    std::unique_ptr<QgsFeatureRenderer> mRenderer;
 
     //! Simplification object which holds the information about how to simplify the features for fast rendering
     QgsVectorSimplifyMethod mSimplifyMethod;
 
     //! Labeling configuration
-    QgsAbstractVectorLayerLabeling *mLabeling = nullptr;
+    std::unique_ptr<QgsAbstractVectorLayerLabeling> mLabeling;
 
     //! True if labels are enabled
     bool mLabelsEnabled = false;
@@ -3042,13 +3042,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
     QgsVectorLayerJoinBuffer *mJoinBuffer = nullptr;
 
     //! stores information about expression fields on this layer
-    QgsExpressionFieldBuffer *mExpressionFieldBuffer = nullptr;
+    std::unique_ptr<QgsExpressionFieldBuffer> mExpressionFieldBuffer;
 
     //diagram rendering object. 0 if diagram drawing is disabled
-    QgsDiagramRenderer *mDiagramRenderer = nullptr;
+    std::unique_ptr<QgsDiagramRenderer> mDiagramRenderer;
 
     //stores infos about diagram placement (placement type, priority, position distance)
-    QgsDiagramLayerSettings *mDiagramLayerSettings = nullptr;
+    std::unique_ptr<QgsDiagramLayerSettings> mDiagramLayerSettings;
 
     mutable bool mValidExtent2D = false;
     mutable bool mLazyExtent2D = true;

--- a/src/core/vector/qgsvectorlayerexporter.cpp
+++ b/src/core/vector/qgsvectorlayerexporter.cpp
@@ -133,8 +133,6 @@ QgsVectorLayerExporter::QgsVectorLayerExporter(
   QgsFeatureSink::SinkFlags sinkFlags
 )
 {
-  mProvider = nullptr;
-
   QMap<QString, QVariant> modifiedOptions( options );
 
   if ( providerKey == "ogr"_L1
@@ -208,13 +206,11 @@ QgsVectorLayerExporter::QgsVectorLayerExporter(
   }
 
   const QgsDataProvider::ProviderOptions providerOptions;
-  QgsVectorDataProvider *vectorProvider = qobject_cast< QgsVectorDataProvider * >( pReg->createProvider( providerKey, uriUpdated, providerOptions ) );
+  auto vectorProvider = std::unique_ptr<QgsVectorDataProvider>( qobject_cast< QgsVectorDataProvider * >( pReg->createProvider( providerKey, uriUpdated, providerOptions ) ) );
   if ( !vectorProvider || !vectorProvider->isValid() || ( vectorProvider->capabilities() & Qgis::VectorProviderCapability::AddFeatures ) == 0 )
   {
     mError = Qgis::VectorExportResult::ErrorInvalidLayer;
     mErrorMessage = QObject::tr( "Loading of layer failed" );
-
-    delete vectorProvider;
     return;
   }
 
@@ -234,7 +230,7 @@ QgsVectorLayerExporter::QgsVectorLayerExporter(
     }
   }
 
-  mProvider = vectorProvider;
+  mProvider = std::move( vectorProvider );
   mError = Qgis::VectorExportResult::Success;
 }
 
@@ -246,8 +242,6 @@ QgsVectorLayerExporter::~QgsVectorLayerExporter()
   {
     createSpatialIndex();
   }
-
-  delete mProvider;
 }
 
 Qgis::VectorExportResult QgsVectorLayerExporter::errorCode() const

--- a/src/core/vector/qgsvectorlayerexporter.h
+++ b/src/core/vector/qgsvectorlayerexporter.h
@@ -356,7 +356,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
 
     int mErrorCount = 0;
 
-    QgsVectorDataProvider *mProvider = nullptr;
+    std::unique_ptr<QgsVectorDataProvider> mProvider;
 
     //! Map attribute indexes to new field indexes
     QMap<int, int> mOldToNewAttrIdx;


### PR DESCRIPTION
A point of attention on [QgsProperty::setTransformer](https://github.com/qgis/QGIS/compare/master...troopa81:add_unique_ptr_core_new?expand=1#diff-e54a261d52c64cfd64205e8b69139f796e29d8fbae413951444e047f39a3d8fcR880), I think `reset()` is appropriate here because `detach()` has made a deep copy and cloned the previous transformer. So we need to delete it to set the given one. I believe previous implementation was leaking here.

## AI tool usage

None

**Funded by [Security Project For QGIS](https://oslandia.com/en/security-project-for-qgis/)**


