### PR TITLE
[feature] Add version argument for uuid expression function

### DIFF
--- a/resources/function_help/json/uuid
+++ b/resources/function_help/json/uuid
@@ -8,6 +8,12 @@
     "optional": true,
     "default": "'WithBraces'",
     "description": "The format, as the UUID will be formatted. 'WithBraces', 'WithoutBraces' or 'Id128'."
+  },
+  {
+    "arg": "version",
+    "optional": true,
+    "default": "4",
+    "description": "The UUID version to create. Supported versions are version 4 or 7."
   }],
   "examples": [{
     "expression": "uuid()",
@@ -18,6 +24,9 @@
   }, {
     "expression": "uuid('Id128')",
     "returns": "'0bd2f60ff1574a6d96afd4ba4cb366a1'"
+  }, {
+    "expression": "uuid(version:=7)",
+    "returns": "'{0bd2f60f-f157-4a6d-96af-d4ba4cb366a1}'"
   }],
   "tags": ["createuuid", "generates", "method", "unique", "quuid", "identifier", "row"]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1929,14 +1929,34 @@ static QVariant fcnRegexpSubstr( const QVariantList &values, const QgsExpression
   }
 }
 
-static QVariant fcnUuid( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
+static QVariant fcnUuid( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QString uuid = QUuid::createUuid().toString();
-  if ( values.at( 0 ).toString().compare( u"WithoutBraces"_s, Qt::CaseInsensitive ) == 0 )
-    uuid = QUuid::createUuid().toString( QUuid::StringFormat::WithoutBraces );
-  else if ( values.at( 0 ).toString().compare( u"Id128"_s, Qt::CaseInsensitive ) == 0 )
-    uuid = QUuid::createUuid().toString( QUuid::StringFormat::Id128 );
-  return uuid;
+  const int version = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
+  QUuid uuid;
+  switch ( version )
+  {
+    case 4:
+      uuid = QUuid::createUuid();
+      break;
+    case 7:
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 9, 0 )
+      uuid = QUuid::createUuidV7();
+#else
+      parent->setEvalErrorString( QObject::tr( "UUid version 7 is not supported on this QGIS build" ) );
+      return QVariant();
+#endif
+      break;
+    default:
+      parent->setEvalErrorString( QObject::tr( "UUid version %1 is not supported" ).arg( version ) );
+      return QVariant();
+  }
+
+  const QString format = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
+  if ( format.compare( u"WithoutBraces"_s, Qt::CaseInsensitive ) == 0 )
+    return QUuid::createUuid().toString( QUuid::StringFormat::WithoutBraces );
+  else if ( format.compare( u"Id128"_s, Qt::CaseInsensitive ) == 0 )
+    return QUuid::createUuid().toString( QUuid::StringFormat::Id128 );
+  return uuid.toString();
 }
 
 static QVariant fcnSubstr( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
@@ -10484,7 +10504,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
 
     QgsStaticExpressionFunction *uuidFunc = new QgsStaticExpressionFunction(
       u"uuid"_s,
-      QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"format"_s, true, u"WithBraces"_s ),
+      { QgsExpressionFunction::Parameter( u"format"_s, true, u"WithBraces"_s ), QgsExpressionFunction::Parameter( u"version"_s, true, 4 ) },
       fcnUuid,
       u"Record and Attributes"_s,
       QString(),

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2975,6 +2975,11 @@ class TestQgsExpression : public QObject
         << u"regexp_match( uuid('invalid-format'), '({[a-zA-Z\\\\d]{8}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{12}})')"_s
         << false
         << QVariant( 1 );
+      QTest::newRow( "uuid version unsupported" ) << u"uuid(version:=1)"_s << true << QVariant();
+      QTest::newRow( "uuid v4" ) << u"regexp_match( uuid(version:=4), '({[a-zA-Z\\\\d]{8}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{12}})')"_s << false << QVariant( 1 );
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 9, 0 )
+      QTest::newRow( "uuid v7" ) << u"regexp_match( uuid(version:=7), '({[a-zA-Z\\\\d]{8}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{4}\\\\-[a-zA-Z\\\\d]{12}})')"_s << false << QVariant( 1 );
+#endif
 
       //exif functions
       QString testDataDir = QStringLiteral( TEST_DATA_DIR ) + '/';


### PR DESCRIPTION
By default version 4 uuids are created. This new 'version' argument allows specifying an alternate uuid version to create.

Supported values are 4 (current default) and 7.

[Replace this with some text explaining the rationale and details about this pull request]

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
