### PR TITLE
fix: Set project.license as a table

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -200,7 +200,7 @@ name = \"QGIS\"
 version = \"${COMPLETE_VERSION}\"
 description = \"Python bindings for QGIS\"
 authors = [ \{name = \"The QGIS Community\"\} ]
-license = \"GPL-2.0-Only\"
+license = [\"GPL-2.0-Only\"]
 license-files = [\"${CMAKE_SOURCE_DIR}/COPYING\"]
 dependencies = [\"${pyqtdist}\"]
 


### PR DESCRIPTION
fixing build error: 
>sip-build: pyproject.toml: 'project.license': value must be a table
[8/5574] Building CXX object src/core/CMakeFiles/qgis_core.dir/cmake_pch.hxx.gch
ninja: build stopped: subcommand failed.
