### PR TITLE
[OAuth2] Don't send client_secret parameter if empty

### DIFF
--- a/external/o2/src/o2.cpp
+++ b/external/o2/src/o2.cpp
@@ -368,9 +368,7 @@ void O2::onVerificationReceived(const QMap<QString, QString> response) {
         QMap<QString, QString> parameters;
         parameters.insert(O2_OAUTH2_GRANT_TYPE_CODE, code());
         parameters.insert(O2_OAUTH2_CLIENT_ID, clientId_);
-        //No client secret with PKCE
-        if ( grantFlow_ != GrantFlowPkce )
-        {
+        if (!clientSecret_.isEmpty()) {
             parameters.insert(O2_OAUTH2_CLIENT_SECRET, clientSecret_);
         }
         parameters.insert(O2_OAUTH2_REDIRECT_URI, redirectUri_);

--- a/external/o2/src/o2.cpp
+++ b/external/o2/src/o2.cpp
@@ -592,7 +592,9 @@ void O2::refresh() {
     refreshRequest.setHeader(QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM);
     QMap<QString, QString> parameters;
     parameters.insert(O2_OAUTH2_CLIENT_ID, clientId_);
-    parameters.insert(O2_OAUTH2_CLIENT_SECRET, clientSecret_);
+    if (!clientSecret_.isEmpty()) {
+        parameters.insert(O2_OAUTH2_CLIENT_SECRET, clientSecret_);
+    }
     parameters.insert(O2_OAUTH2_REFRESH_TOKEN, refreshToken());
     parameters.insert(O2_OAUTH2_GRANT_TYPE, O2_OAUTH2_REFRESH_TOKEN);
 

--- a/src/auth/oauth2/core/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2config.cpp
@@ -336,11 +336,7 @@ void QgsAuthOAuth2Config::validateConfigId( bool needsId )
 {
   const bool oldvalid = mValid;
 
-  if ( mGrantFlow == GrantFlow::AuthCode || mGrantFlow == GrantFlow::Implicit )
-  {
-    mValid = ( !requestUrl().isEmpty() && !tokenUrl().isEmpty() && !clientId().isEmpty() && ( ( mGrantFlow == GrantFlow::AuthCode || mGrantFlow == GrantFlow::Pkce ) ? !clientSecret().isEmpty() : true ) && redirectPort() > 0 && ( needsId ? !id().isEmpty() : true ) );
-  }
-  else if ( mGrantFlow == GrantFlow::Pkce ) // No client secret for PKCE
+  if ( mGrantFlow == GrantFlow::AuthCode || mGrantFlow == GrantFlow::Implicit || mGrantFlow == GrantFlow::Pkce )
   {
     mValid = ( !requestUrl().isEmpty() && !tokenUrl().isEmpty() && !clientId().isEmpty() && redirectPort() > 0 && ( needsId ? !id().isEmpty() : true ) );
   }

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -454,8 +454,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
     QMap<QString, QString> parameters;
     parameters.insert( O2_OAUTH2_GRANT_TYPE_CODE, code() );
     parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
-    //No client secret with PKCE
-    if ( grantFlow_ != GrantFlowPkce )
+    if ( !clientSecret_.isEmpty() )
     {
       parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
     }
@@ -551,8 +550,8 @@ void QgsO2::refreshSynchronous()
   refreshRequest.setHeader( QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM );
   QMap<QString, QString> parameters;
   parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
-  // No secret with PKCE
-  if ( grantFlow_ != GrantFlowPkce )
+  // No secret with PKCE, and don't send an empty secret (public clients may have none)
+  if ( grantFlow_ != GrantFlowPkce && !clientSecret_.isEmpty() )
   {
     parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
   }

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -550,8 +550,8 @@ void QgsO2::refreshSynchronous()
   refreshRequest.setHeader( QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM );
   QMap<QString, QString> parameters;
   parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
-  // No secret with PKCE, and don't send an empty secret (public clients may have none)
-  if ( grantFlow_ != GrantFlowPkce && !clientSecret_.isEmpty() )
+  // Don't send an empty client secret (RFC 6749 sec. 2.3.1).
+  if ( !clientSecret_.isEmpty() )
   {
     parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
   }

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -455,8 +455,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
     QMap<QString, QString> parameters;
     parameters.insert( O2_OAUTH2_GRANT_TYPE_CODE, code() );
     parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
-    //No client secret with PKCE
-    if ( grantFlow_ != GrantFlowPkce )
+    if ( !clientSecret_.isEmpty() )
     {
       parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
     }
@@ -552,8 +551,8 @@ void QgsO2::refreshSynchronous()
   refreshRequest.setHeader( QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM );
   QMap<QString, QString> parameters;
   parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
-  // No secret with PKCE
-  if ( grantFlow_ != GrantFlowPkce )
+  // No secret with PKCE, and don't send an empty secret (public clients may have none)
+  if ( grantFlow_ != GrantFlowPkce && !clientSecret_.isEmpty() )
   {
     parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
   }

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -551,8 +551,8 @@ void QgsO2::refreshSynchronous()
   refreshRequest.setHeader( QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM );
   QMap<QString, QString> parameters;
   parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
-  // No secret with PKCE, and don't send an empty secret (public clients may have none)
-  if ( grantFlow_ != GrantFlowPkce && !clientSecret_.isEmpty() )
+  // Don't send an empty client secret (RFC 6749 sec. 2.3.1).
+  if ( !clientSecret_.isEmpty() )
   {
     parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
   }

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -745,17 +745,16 @@ void QgsAuthOAuth2Edit::updateGrantFlow( int indx )
   lblRedirectUrl->setVisible( !resowner && !ccredentials );
   frameRedirectUrl->setVisible( !resowner && !ccredentials );
 
-  lblClientSecret->setVisible( !implicit );
-  leClientSecret->setVisible( !implicit );
+  lblClientSecret->setVisible( !implicit && !pkce );
+  leClientSecret->setVisible( !implicit && !pkce );
   if ( implicit )
     leClientSecret->setText( QString() );
 
   leClientId->setPlaceholderText( resowner ? tr( "Optional" ) : tr( "Required" ) );
 
-  // No client secret with PKCE
-  lblClientSecret->setVisible( !pkce );
-  leClientSecret->setVisible( !pkce );
-  leClientSecret->setPlaceholderText( resowner ? tr( "Optional" ) : tr( "Required" ) );
+  // Client secret is only mandatory for the client credentials flow (RFC 6749 sec. 2.3.1)
+  // otherwise an empty string is allowed
+  leClientSecret->setPlaceholderText( ccredentials ? tr( "Required" ) : tr( "Optional" ) );
 
   lblUsername->setVisible( resowner );
   leUsername->setVisible( resowner );

--- a/tests/src/auth/testqgsauthoauth2method.cpp
+++ b/tests/src/auth/testqgsauthoauth2method.cpp
@@ -298,6 +298,12 @@ void TestQgsAuthOAuth2Method::testOAuth2Config()
 
   config3->deleteLater();
 
+  qDebug() << "Verify validity without client secret (public client, RFC 6749 sec. 2.1)";
+  QgsAuthOAuth2Config *config3b = baseConfig( true );
+  config3b->setClientSecret( QString() );
+  QVERIFY( config3b->isValid() );
+  config3b->deleteLater();
+
   qDebug() << "Validate equality";
   QgsAuthOAuth2Config *config4 = baseConfig( true );
   QgsAuthOAuth2Config *config5 = baseConfig( true );

--- a/tests/src/auth/testqgsauthoauth2method.cpp
+++ b/tests/src/auth/testqgsauthoauth2method.cpp
@@ -298,7 +298,6 @@ void TestQgsAuthOAuth2Method::testOAuth2Config()
 
   config3->deleteLater();
 
-  qDebug() << "Verify validity without client secret (public client, RFC 6749 sec. 2.1)";
   QgsAuthOAuth2Config *config3b = baseConfig( true );
   config3b->setClientSecret( QString() );
   QVERIFY( config3b->isValid() );

--- a/tests/src/auth/testqgsauthoauth2method.cpp
+++ b/tests/src/auth/testqgsauthoauth2method.cpp
@@ -17,16 +17,21 @@
 #include "qgsapplication.h"
 #include "qgsauthmanager.h"
 #include "qgsauthoauth2config.h"
+#include "qgsnetworkaccessmanager.h"
+#include "qgso2.h"
 #include "qgstest.h"
 
 #include <QApplication>
 #include <QDateTime>
 #include <QDebug>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
 #include <QObject>
 #include <QSignalSpy>
 #include <QString>
 #include <QStringList>
 #include <QTemporaryFile>
+#include <QUrl>
 #include <QtTest/QTest>
 
 using namespace Qt::StringLiterals;
@@ -34,6 +39,19 @@ using namespace Qt::StringLiterals;
 #ifdef HAVE_GUI
 #include "qgsauthoauth2edit.h"
 #endif
+
+namespace
+{
+  // Subclass QgsO2 to enable using protected methods in tests
+  class TestableQgsO2 : public QgsO2
+  {
+    public:
+      using QgsO2::onVerificationReceived;
+      using QgsO2::QgsO2;
+      void setTestAuthCode( const QString &value ) { setCode( value ); }
+      void setTestRefreshToken( const QString &value ) { setRefreshToken( value ); }
+  };
+} // namespace
 
 /**
  * \ingroup UnitTests
@@ -55,6 +73,7 @@ class TestQgsAuthOAuth2Method : public QObject
     void testDynamicRegistration();
     void testDynamicRegistrationJwt();
     void testDynamicRegistrationNoEndpoint();
+    void testDoesNotSendEmptyClientSecret();
 
   private:
     QgsAuthOAuth2Config *baseConfig( bool loaded = false );
@@ -518,6 +537,58 @@ void TestQgsAuthOAuth2Method::testDynamicRegistrationJwt()
 #endif
 }
 
+
+void TestQgsAuthOAuth2Method::testDoesNotSendEmptyClientSecret()
+{
+  QTemporaryFile responseFile;
+  QVERIFY( responseFile.open() );
+  responseFile.write( R"({"access_token":"new_token","refresh_token":"new_refresh","expires_in":3600})" );
+  responseFile.close();
+
+  const QString refreshUrl = u"http://example.invalid/refresh"_s;
+  const QString tokenUrl = u"http://example.invalid/token"_s;
+  QByteArray capturedBody;
+
+  const QString preprocessorId = QgsNetworkAccessManager::setAdvancedRequestPreprocessor( [refreshUrl, tokenUrl, &responseFile, &capturedBody]( QNetworkRequest *request, int &op, QByteArray *data ) {
+    if ( request->url().toString() != refreshUrl && request->url().toString() != tokenUrl )
+      return;
+    capturedBody = *data;
+    request->setUrl( QUrl::fromLocalFile( responseFile.fileName() ) );
+    op = static_cast<int>( QNetworkAccessManager::GetOperation );
+  } );
+
+  TestableQgsO2 o2( u"testauthcfg"_s );
+  o2.setClientId( u"my_client_id"_s );
+  o2.setRefreshTokenUrl( refreshUrl );
+  o2.setTestRefreshToken( u"my_refresh_token"_s );
+
+  // RFC 6749 sec. 2.3.1: an empty client secret should not be sent
+  o2.setClientSecret( QString() );
+  o2.refreshSynchronous();
+  QVERIFY( capturedBody.contains( "refresh_token=my_refresh_token" ) );
+  QVERIFY( !capturedBody.contains( "client_secret" ) );
+
+  // Sanity check when a client_secret is actually set
+  capturedBody.clear();
+  o2.setClientSecret( u"my_secret"_s );
+  o2.refreshSynchronous();
+  QVERIFY( capturedBody.contains( "client_secret=my_secret" ) );
+
+  o2.setTokenUrl( tokenUrl );
+  o2.setClientSecret( QString() );
+  o2.setTestAuthCode( u"my_auth_code"_s );
+  capturedBody.clear();
+  o2.onVerificationReceived( { { u"code"_s, u"my_auth_code"_s } } );
+  QVERIFY( capturedBody.contains( "code=my_auth_code" ) );
+  QVERIFY( !capturedBody.contains( "client_secret" ) );
+
+  o2.setClientSecret( u"my_secret"_s );
+  capturedBody.clear();
+  o2.onVerificationReceived( { { u"code"_s, u"my_auth_code"_s } } );
+  QVERIFY( capturedBody.contains( "client_secret=my_secret" ) );
+
+  QgsNetworkAccessManager::removeAdvancedRequestPreprocessor( preprocessorId );
+}
 
 QGSTEST_MAIN( TestQgsAuthOAuth2Method )
 #include "testqgsauthoauth2method.moc"

--- a/tests/src/auth/testqgsauthoauth2method.cpp
+++ b/tests/src/auth/testqgsauthoauth2method.cpp
@@ -23,7 +23,6 @@
 
 #include <QApplication>
 #include <QDateTime>
-#include <QDebug>
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QObject>
@@ -64,8 +63,6 @@ class TestQgsAuthOAuth2Method : public QObject
   private slots:
     void initTestCase();
     void cleanupTestCase();
-    void init();
-    void cleanup();
 
     void testOAuth2Config();
     void testOAuth2ConfigIO();
@@ -89,9 +86,7 @@ class TestQgsAuthOAuth2Method : public QObject
 
 QString TestQgsAuthOAuth2Method::sTestDataDir = QStringLiteral( TEST_DATA_DIR ) + "/auth_system/oauth2";
 
-
 QString TestQgsAuthOAuth2Method::smHashes = "#####################";
-//QObject *TestQgsAuthOAuth2Method::smParentObj = new QObject();
 
 void TestQgsAuthOAuth2Method::initTestCase()
 {
@@ -100,23 +95,11 @@ void TestQgsAuthOAuth2Method::initTestCase()
   QgsApplication::initQgis();
   if ( QgsApplication::authManager()->isDisabled() )
     QSKIP( "Auth system is disabled, skipping test case", SkipAll );
-
-  //qDebug() << QgsApplication::showSettings().toUtf8().constData();
 }
 
 void TestQgsAuthOAuth2Method::cleanupTestCase()
 {
   QgsApplication::exitQgis();
-}
-
-void TestQgsAuthOAuth2Method::init()
-{
-  qDebug() << "\n************ Start " << QTest::currentTestFunction() << " ************";
-}
-
-void TestQgsAuthOAuth2Method::cleanup()
-{
-  qDebug() << "\n************ End " << QTest::currentTestFunction() << " ************";
 }
 
 QgsAuthOAuth2Config *TestQgsAuthOAuth2Method::baseConfig( bool loaded )
@@ -273,11 +256,11 @@ QByteArray TestQgsAuthOAuth2Method::baseVariantTxt()
 
 void TestQgsAuthOAuth2Method::testOAuth2Config()
 {
-  qDebug() << "Verify base object config";
+  // Verify base object config
   QgsAuthOAuth2Config *config1 = new QgsAuthOAuth2Config( qApp );
   QVERIFY( !config1->isValid() );
 
-  qDebug() << "Verify base object validity";
+  // Verify base object validity
   QgsAuthOAuth2Config *config2 = baseConfig();
   QVERIFY( !config2->isValid() );
   config2->deleteLater();
@@ -285,7 +268,7 @@ void TestQgsAuthOAuth2Method::testOAuth2Config()
   QgsAuthOAuth2Config *config3 = baseConfig( true );
   QVERIFY( config3->isValid() );
 
-  qDebug() << "Verify base object internal signals";
+  // Verify base object internal signals
   const QSignalSpy spy_config( config3, SIGNAL( configChanged() ) );
   QSignalSpy spy_valid( config3, SIGNAL( validityChanged( bool ) ) );
 
@@ -322,7 +305,6 @@ void TestQgsAuthOAuth2Method::testOAuth2Config()
   QVERIFY( config3b->isValid() );
   config3b->deleteLater();
 
-  qDebug() << "Validate equality";
   QgsAuthOAuth2Config *config4 = baseConfig( true );
   QgsAuthOAuth2Config *config5 = baseConfig( true );
   QgsAuthOAuth2Config *config6 = baseConfig();
@@ -339,7 +321,7 @@ void TestQgsAuthOAuth2Method::testOAuth2Config()
 
 void TestQgsAuthOAuth2Method::testOAuth2ConfigIO()
 {
-  qDebug() << "Verify saving config to text";
+  // Verify saving config to text
   QgsAuthOAuth2Config *config1 = baseConfig( true );
   bool ok = false;
   QByteArray cfgtxt = config1->saveConfigTxt( QgsAuthOAuth2Config::ConfigFormat::JSON, true, &ok );
@@ -356,8 +338,7 @@ void TestQgsAuthOAuth2Method::testOAuth2ConfigIO()
   //qDebug() << "baseConfigTxt: \n" << baseConfigTxt( false );
   QCOMPARE( baseConfigTxt( false ), cfgtxt );
 
-  qDebug() << "Verify loading config from text";
-  // from base
+  // Verify loading config from text
   QgsAuthOAuth2Config *config2 = new QgsAuthOAuth2Config( qApp );
   QVERIFY( config2->loadConfigTxt( baseConfigTxt( true ), QgsAuthOAuth2Config::ConfigFormat::JSON ) );
   QVERIFY( *config1 == *config2 );
@@ -376,7 +357,7 @@ void TestQgsAuthOAuth2Method::testOAuth2ConfigIO()
   //qDebug() << "baseConfigTxt: \n" << baseConfigTxt( true );
   QCOMPARE( baseConfigTxt( true ), cfgtxt );
 
-  qDebug() << "Verify writing config to file";
+  // Verify writing config to file
   const QString rndsuffix = QgsApplication::authManager()->uniqueConfigId();
   const QString dirname = QString( "oauth2_configs_%1" ).arg( rndsuffix );
   const QDir tmpdir = QDir::temp();
@@ -387,15 +368,13 @@ void TestQgsAuthOAuth2Method::testOAuth2ConfigIO()
   config5->setName( "Blah blah" );
   config5->setRedirectPort( 2222 );
 
-  qDebug() << QDir::tempPath() + "/" + dirname;
-
   const QString config4path( QDir::tempPath() + "/" + dirname + "/config4.json" );
   const QString config5path( QDir::tempPath() + "/" + dirname + "/config5.json" );
 
   QVERIFY( QgsAuthOAuth2Config::writeOAuth2Config( config4path, config4, QgsAuthOAuth2Config::ConfigFormat::JSON, true ) );
   QVERIFY( QgsAuthOAuth2Config::writeOAuth2Config( config5path, config5, QgsAuthOAuth2Config::ConfigFormat::JSON, true ) );
 
-  qDebug() << "Verify reading config files from directory";
+  // Verify reading config files from directory
   ok = false;
   QList<QgsAuthOAuth2Config *> configs = QgsAuthOAuth2Config::loadOAuth2Configs( QDir::tempPath() + "/" + dirname, qApp, QgsAuthOAuth2Config::ConfigFormat::JSON, &ok );
   QVERIFY( ok );
@@ -423,14 +402,14 @@ void TestQgsAuthOAuth2Method::testOAuth2ConfigUtils()
   const QVariantMap basevmap = baseVariantMap();
   bool ok = false;
 
-  qDebug() << "Verify serializeFromVariant";
+  // Verify serializeFromVariant
   const QByteArray vtxt = QgsAuthOAuth2Config::serializeFromVariant( basevmap, QgsAuthOAuth2Config::ConfigFormat::JSON, true, &ok );
   QVERIFY( ok );
   //qDebug() << vtxt;
   //qDebug() << baseConfigTxt( true );
   QCOMPARE( vtxt, baseConfigTxt( true ) );
 
-  qDebug() << "Verify variantFromSerialized";
+  // Verify variantFromSerialized
   const QVariantMap vmap = QgsAuthOAuth2Config::variantFromSerialized( baseConfigTxt( true ), QgsAuthOAuth2Config::ConfigFormat::JSON, &ok );
   QVERIFY( ok );
   QCOMPARE( vmap.value( "name" ).toString(), QString( "MyConfig" ) );


### PR DESCRIPTION
## Description

As per OAuth2 specification [RFC 6749 section 2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) the client_secret parameter may be omitted if it is an empty string.
In practice I encountered an Arcgis server enterprise refusing authorization for an empty parameter, and accepting authorization when the parameter was omitted.

This pull request re-align the code in this regards with the [PR 22 of qgis/o2](https://github.com/qgis/o2/pull/22), and additionally ads the same logic for the O2::refresh function.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
