### PR TITLE
QgsQuick: Drop AndroidExtras

### DIFF
--- a/src/quickgui/CMakeLists.txt
+++ b/src/quickgui/CMakeLists.txt
@@ -60,9 +60,6 @@ target_link_libraries(qgis_quick
     ${QT_VERSION_BASE}::Positioning
     qgis_core)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-  target_link_libraries(qgis_quick ${QT_VERSION_BASE}::AndroidExtras)
-endif()
 target_compile_definitions(qgis_quick PRIVATE "-DQT_NO_FOREACH")
 
 GENERATE_EXPORT_HEADER(


### PR DESCRIPTION
## Description

[`AndroidExtras` does not exist for Qt 6 anymore](https://qt-project.atlassian.net/browse/QTBUG-84382), but was still referenced in the QgsQuick CMakeLists.txt. This change removes the dependency.

 - [x] The Android build of QGIS 4.2 was tested locally with NDK 28

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


