### PR TITLE
[SipDeprecated] Restore sip deprecated for SIP >= 6.11

### DIFF
--- a/cmake/SIPMacros.cmake
+++ b/cmake/SIPMacros.cmake
@@ -54,7 +54,7 @@ MACRO(GENERATE_SIP_PYTHON_MODULE_CODE MODULE_NAME MODULE_SIP SIP_FILES CPP_FILES
     # Deprecated annotation supports message (without crashes) only since version 6.11.0
     if(${SIP_VERSION_STR} VERSION_LESS 6.11.0)
 
-      # For now disabling SIP deprecated because it crashes the application
+      # Disable SIP deprecated because it crashes the application on these older SIP versions
       file(READ ${_out_sip_file} _content)
       string(REGEX REPLACE "([/,])Deprecated=\"[^\"]*\"([/,])" "\\1Deprecated\\2" _content "${_content}")
       file(GENERATE OUTPUT ${_out_sip_file} CONTENT "${_content}")

--- a/cmake/SIPMacros.cmake
+++ b/cmake/SIPMacros.cmake
@@ -51,15 +51,15 @@ MACRO(GENERATE_SIP_PYTHON_MODULE_CODE MODULE_NAME MODULE_SIP SIP_FILES CPP_FILES
     SET(_out_sip_file "${CMAKE_CURRENT_BINARY_DIR}/${_sip_file_relpath}.sip")
     CONFIGURE_FILE(${_sip_file} ${_out_sip_file})
 
-    # Deprecated annotation supports message only since version 6.9.0
-    # if(${SIP_VERSION_STR} VERSION_LESS 6.9.0)
+    # Deprecated annotation supports message (without crashes) only since version 6.11.0
+    if(${SIP_VERSION_STR} VERSION_LESS 6.11.0)
 
-    # For now disabling SIP deprecated because it crashes the application
-    file(READ ${_out_sip_file} _content)
-    string(REGEX REPLACE "([/,])Deprecated=\"[^\"]*\"([/,])" "\\1Deprecated\\2" _content "${_content}")
-    file(GENERATE OUTPUT ${_out_sip_file} CONTENT "${_content}")
+      # For now disabling SIP deprecated because it crashes the application
+      file(READ ${_out_sip_file} _content)
+      string(REGEX REPLACE "([/,])Deprecated=\"[^\"]*\"([/,])" "\\1Deprecated\\2" _content "${_content}")
+      file(GENERATE OUTPUT ${_out_sip_file} CONTENT "${_content}")
 
-    # endif()
+    endif()
 
   ENDFOREACH (_sip_file)
 


### PR DESCRIPTION
## Description

There were an issue in Sip 6.9.0 which is now [fixed](https://github.com/Python-SIP/sip/pull/67) and have been integrated in [6.11](https://github.com/Python-SIP/sip/commits/6.11.0) (commit: *[Deprecated] Correctly write messages exceeding 100 characters (#67)* ).

So I propose to re-enabled the sip deprecated feature (disabled in #60363) for all SIP versions greater or equal than 6.11

## AI tool usage

None