### PR TITLE
Add "Rename Item" to the Legend Node menu

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -951,7 +951,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
     if ( node->flags() & Qt::ItemIsEditable )
     {
-      QAction *renameAction = new QAction( tr( "Rename Item" ), menu );
+      QAction *renameAction = new QAction( tr( "Rename Item…" ), menu );
       connect( renameAction, &QAction::triggered, this, [this] { mView->edit( mView->currentIndex() ); } );
       menu->addAction( renameAction );
       menu->addSeparator()->setObjectName( "RenameItemSeparator"_L1 );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -949,6 +949,14 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       menu->addSeparator()->setObjectName( "UserCheckableSeparator"_L1 );
     }
 
+    if ( node->flags() & Qt::ItemIsEditable )
+    {
+      QAction *renameAction = new QAction( tr( "Rename Item" ), menu );
+      connect( renameAction, &QAction::triggered, this, [this] { mView->edit( mView->currentIndex() ); } );
+      menu->addAction( renameAction );
+      menu->addSeparator()->setObjectName( "RenameItemSeparator"_L1 );
+    }
+
     if ( QgsSymbolLegendNode *symbolNode = qobject_cast<QgsSymbolLegendNode *>( node ) )
     {
       // symbology item


### PR DESCRIPTION
## Description

A small follow up to the #66238 that adds "Rename Item" to the menu for `QgsLayerTreeModelLegendNode` if the node is editable.

<img width="277" height="447" alt="2026-07-14-10-55-15" src="https://github.com/user-attachments/assets/d2bcf0c0-ae17-4276-a9d9-54897e11844d" />


## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 

