### PR TITLE
Corrections to processing grassprovider documentation

### DIFF
--- a/python/plugins/grassprovider/README.md
+++ b/python/plugins/grassprovider/README.md
@@ -62,7 +62,7 @@ The following parameters are supported:
 
 - A file
   ```
-  QgsProcessingParameterFile|[name of GRASS parameter]|[description of parameter to show]|QgsProcessingParameterFile.File|[file extension|[Default value, or None]|[True/False, indicating if the parameter is optional or not]
+  QgsProcessingParameterFile|[name of GRASS parameter]|[description of parameter to show]|QgsProcessingParameterFile.File|[file extension]|[Default value, or None]|[True/False, indicating if the parameter is optional or not]
   ```
   Example: `QgsProcessingParameterFile|input|Name of input E00 file|QgsProcessingParameterFile.File|e00|None|False`
 
@@ -84,7 +84,7 @@ The following parameters are supported:
 
 - A string
   ```
-  QgsProcessingParameterString|[name of GRASS parameter]|[description of parameter to show]|[default value]|[True/False, indicating if the parameter is optional or not]
+  QgsProcessingParameterString|[name of GRASS parameter]|[description of parameter to show]|[default value]|[True/False, indicating whether a multiline string is accepted]|[True/False, indicating if the parameter is optional or not]
   ```
   Example: `QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True`
 
@@ -96,9 +96,9 @@ The following parameters are supported:
   
 - A boolean
   ```  
-  QgsProcessingParameterBoolean|[GRASS flag]|[description of parameter to show]|[default value]|[True/False, indicating if the parameter is optional or not]
+  QgsProcessingParameterBoolean|[GRASS flag]|[description of parameter to show]|[default value]
   ```
-  Example: `QgsProcessingParameterBoolean|-p|Output values as percentages|False|True`
+  Example: `QgsProcessingParameterBoolean|-p|Output values as percentages|False`
 
 - A pair of coordinates
   ```


### PR DESCRIPTION
Three simple corrections to the readme.

The change for QgsProcessingParameterBoolean may not be strictly necessary, but they are consistent with usage in the algorithm definitions we ship with QGIS, and "optional" isn't really meaningful for a boolean parameter.
