### PR TITLE
[WMS][GetCapabilities] Don't expose root group if skip name for group

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -801,19 +801,23 @@ namespace QgsWms
 
     QDomElement layerParentElem = doc.createElement( u"Layer"_s );
 
-    // Root Layer name
-    QString rootLayerName = QgsServerProjectUtils::wmsRootName( *project );
-    if ( rootLayerName.isEmpty() && !project->title().isEmpty() )
+    const bool skipNameForGroup = QgsServerProjectUtils::wmsSkipNameForGroup( *project );
+    if ( !skipNameForGroup )
     {
-      rootLayerName = project->title();
-    }
+      // Root Layer name
+      QString rootLayerName = QgsServerProjectUtils::wmsRootName( *project );
+      if ( rootLayerName.isEmpty() && !project->title().isEmpty() )
+      {
+        rootLayerName = project->title();
+      }
 
-    if ( !rootLayerName.isEmpty() )
-    {
-      QDomElement layerParentNameElem = doc.createElement( u"Name"_s );
-      QDomText layerParentNameText = doc.createTextNode( rootLayerName );
-      layerParentNameElem.appendChild( layerParentNameText );
-      layerParentElem.appendChild( layerParentNameElem );
+      if ( !rootLayerName.isEmpty() )
+      {
+        QDomElement layerParentNameElem = doc.createElement( u"Name"_s );
+        QDomText layerParentNameText = doc.createTextNode( rootLayerName );
+        layerParentNameElem.appendChild( layerParentNameText );
+        layerParentElem.appendChild( layerParentNameElem );
+      }
     }
 
     // Root Layer title

--- a/tests/src/python/test_qgsserver_wms_getcapabilities_group_name.py
+++ b/tests/src/python/test_qgsserver_wms_getcapabilities_group_name.py
@@ -43,6 +43,12 @@ class TestQgsServerWMSGetCapabilities(QgsServerTestBase):
             "attribute <name> should be specified for a layer group",
         )
 
+        self.assertIn(
+            b"<Name>title</Name>",
+            r,
+            "attribute <name> should be specified for project root group",
+        )
+
     def test_wms_getmap_with(self):
         r = make_map_request(self, self.project_with_name)
         self.assertNotIn(
@@ -57,6 +63,12 @@ class TestQgsServerWMSGetCapabilities(QgsServerTestBase):
             b"<Name>layer_group</Name>",
             r,
             "attribute <name> should NOT be specified for a layer group",
+        )
+
+        self.assertNotIn(
+            b"<Name>title</Name>",
+            r,
+            "attribute <name> should NOT be specified for project root group",
         )
 
     def test_wms_getmap_without(self):

--- a/tests/testdata/qgis_server/wms_group_test1.qgs
+++ b/tests/testdata/qgis_server/wms_group_test1.qgs
@@ -1,7 +1,7 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis saveDateTime="2023-11-26T13:46:18" projectname="" saveUserFull="Tomas" version="3.33.0-Master" saveUser="tomas">
   <homePath path=""/>
-  <title></title>
+  <title>title</title>
   <transaction mode="Disabled"/>
   <projectFlags set=""/>
   <projectCrs>

--- a/tests/testdata/qgis_server/wms_group_test2.qgs
+++ b/tests/testdata/qgis_server/wms_group_test2.qgs
@@ -1,7 +1,7 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis saveDateTime="2023-11-26T15:41:43" projectname="" saveUserFull="Tomas" version="3.33.0-Master" saveUser="tomas">
   <homePath path=""/>
-  <title></title>
+  <title>title</title>
   <transaction mode="Disabled"/>
   <projectFlags set=""/>
   <projectCrs>


### PR DESCRIPTION
## Description

a GetMap on project root is already returning LayerNotDefined exception if skip name for group is set. So we need to be consistent on GetCapabilities and not expose root group name in such scenario.

## AI tool usage

None

**Funded by ANFSI**