### PR TITLE
Fix PROJ warnings when requesting topocentric origin 

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -3259,6 +3259,9 @@ bool QgsCoordinateReferenceSystem::topocentricOrigin( double &latDeg, double &lo
   if ( !pj )
     return false;
 
+  if ( !proj_crs_is_derived( ctx, pj ) )
+    return false;
+
   QgsProjUtils::proj_pj_unique_ptr conversion( proj_crs_get_coordoperation( ctx, pj ) );
   if ( !conversion )
     return false;


### PR DESCRIPTION
`proj_crs_get_coordoperation` checks if the crs is derived or bound and outputs a warning if not.

This PR fixes those annoying msgs in console.
Since topocentric is derived, we can check for it and exit early.

Edit: should be backported!