### PR TITLE
Fix stop editing for vpcs with no subindexes loaded

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -1057,7 +1057,11 @@ bool QgsPointCloudLayer::rollBack()
   if ( mIsVpc )
   {
     if ( mEditingIndexes.isEmpty() )
-      return false;
+    {
+      mEditable = false;
+      emit editingStopped();
+      return true;
+    }
 
     QVector<QPair<int, QList<QgsPointCloudNodeId>>> queuedUpdates;
     queuedUpdates.reserve( mEditingIndexes.size() );

--- a/tests/src/core/testqgspointcloudediting.cpp
+++ b/tests/src/core/testqgspointcloudediting.cpp
@@ -591,6 +591,19 @@ void TestQgsPointCloudEditing::testVPCStarStopEditing()
   QVERIFY( !layer->index() );
   QVERIFY( layer->isVpc() );
 
+  // check if start/stop works when no sub index is loaded
+  QVector< QgsPointCloudSubIndex > subIndexes = layer->subIndexes();
+  QVERIFY( !subIndexes.at( 0 ).index().isValid() );
+  QVERIFY( !subIndexes.at( 1 ).index().isValid() );
+  QVERIFY( !subIndexes.at( 2 ).index().isValid() );
+  QVERIFY( !subIndexes.at( 3 ).index().isValid() );
+  QVERIFY( layer->startEditing() );
+  QVERIFY( layer->isEditable() );
+  QVERIFY( !layer->isModified() );
+  QVERIFY( layer->rollBack() );
+  QVERIFY( !layer->isEditable() );
+  QVERIFY( !layer->isModified() );
+
   QgsVirtualPointCloudProvider *vpcProvider = qobject_cast<QgsVirtualPointCloudProvider *>( layer->dataProvider() );
   QVERIFY( vpcProvider );
 
@@ -610,7 +623,7 @@ void TestQgsPointCloudEditing::testVPCStarStopEditing()
   QCOMPARE( spyStop.size(), 0 );
   QCOMPARE( spyModify.size(), 0 );
 
-  QVector< QgsPointCloudSubIndex > subIndexes = layer->subIndexes();
+  subIndexes = layer->subIndexes();
   QVERIFY( !subIndexes.at( 0 ).index().isValid() );
   QVERIFY( !subIndexes.at( 1 ).index().isValid() );
   QVERIFY( dynamic_cast<QgsPointCloudEditingIndex *>( subIndexes.at( 2 ).index().get() ) );


### PR DESCRIPTION
## Description
When starting editing on a VPC layer that _has no subindexes loaded yet_ (ie never zoomed in enough), then one could not stop editing, until at least one subindex has been loaded.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
