### PR TITLE
fix: add Windows application manifest for correct OS version reporting

### DIFF
--- a/platform/windows/rc/qgis.manifest
+++ b/platform/windows/rc/qgis.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -421,6 +421,17 @@ if (WIN32)
 
   win32_icon(QGIS_APPMAIN_SRCS)
   win32_version_info("QGIS Desktop" ${QGIS_APP_NAME} QGIS_APPMAIN_SRCS)
+
+  set(_manifest ${CMAKE_SOURCE_DIR}/platform/windows/rc/qgis.manifest)
+  if (MSVC)
+    list(APPEND QGIS_APPMAIN_SRCS ${_manifest})
+  else()
+    # MinGW: CMake doesn't handle .manifest files natively.
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/23244
+    file(CONFIGURE OUTPUT qgis-manifest.rc
+      CONTENT "1 24 \"${_manifest}\"")
+    list(APPEND QGIS_APPMAIN_SRCS ${CMAKE_CURRENT_BINARY_DIR}/qgis-manifest.rc)
+  endif()
 else()
   set (QGIS_APPMAIN_SRCS main.cpp ${TEST_RCCS})
 endif()


### PR DESCRIPTION
## Description

`qgis-bin.exe` ships without a Windows application manifest declaring `supportedOS` compatibility. This causes `GetVersionEx()` to return Windows 8 (6.2 build 9200) instead of the real OS version — even on Windows 11.

CPython's `_socket` module uses a runtime version check ([`remove_unusable_flags()`](https://github.com/python/cpython/blob/3.12/Modules/socketmodule.c) in `socketmodule.c`) to decide which TCP constants to expose. Because the reported build (9200) is below the threshold (16299), `TCP_KEEPIDLE`, `TCP_KEEPINTVL`, `TCP_KEEPCNT`, and `TCP_FASTOPEN` are silently removed. This breaks any Python library relying on modern TCP keepalive via `setsockopt`.

Since QGIS 4.x requires Qt 6 (Windows 10+), declaring Windows 10 support has no downside.

### Reproduce

QGIS → Plugins → Python Console:

```python
import sys, socket
print(sys.getwindowsversion())          # → 6.2.9200 (should be 10.0.26200)
print(hasattr(socket, 'TCP_KEEPIDLE'))   # → False (should be True)
```

Running the same `python.exe` standalone reports the correct version.

### Fix

- New `platform/windows/rc/qgis.manifest` declaring Windows 10 `supportedOS`
- `src/app/CMakeLists.txt`: embed manifest via CMake builtin support (MSVC) with MinGW `.rc` fallback per [CMake #23244](https://gitlab.kitware.com/cmake/cmake/-/issues/23244)

Approach follows [Bitcoin Core PR #33585](https://github.com/bitcoin/bitcoin/pull/33585).

### Verification

| Check | Status |
|-------|--------|
| CMake ≥ 3.22 (QGIS requires 3.22+) | ✅ Above 3.4 minimum for `.manifest` support |
| MSVC + Ninja (CI toolchain) | ✅ CMake builtin handling |
| MinGW compat | ✅ `.rc` file fallback |
| No conflict with existing linker flags | ✅ No manifest-related settings in codebase |
| No conflict with VERSIONINFO `.rc` | ✅ Separate resource types |
| DPI awareness side effects | ⚠️ Manifest only declares `supportedOS`, no `dpiAware` — Qt6 handles DPI itself |

### References

- [Microsoft: Targeting your application for Windows](https://learn.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1)
- [CPython 3.12 socketmodule.c — `win_runtime_flags[]`](https://github.com/python/cpython/blob/3.12/Modules/socketmodule.c)
- [QGIS #18143 — earlier missing manifest report](https://github.com/qgis/QGIS/issues/18143)

Fixes #66825

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.