### PR TITLE
debian packaging: don't disable internal nlohmann on plucky and trixie (nlohmann 3.11.3 too old; take II: followup 9ff14a2ee)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -71,7 +71,6 @@ CONTROL_EXPRESSIONS = $(DISTRIBUTION) grass$(GRASSVER)
 
 shlibs = -Xqgis-plugin-grass -Xlibqgis-customwidgets
 
-
 ifneq (,$(filter oracle,$(DEB_BUILD_OPTIONS)))
 CONTROL_EXPRESSIONS += oracle
 shlibs += -Xqgis-provider-oracle
@@ -168,7 +167,7 @@ CMAKE_OPTS := \
 	-DWITH_SFCGAL=TRUE \
 	-DWITH_GEOGRAPHICLIB=TRUE
 
-ifneq (,$(filter $(DISTRIBUTION),trixie plucky))
+ifeq (,$(filter $(DISTRIBUTION),trixie plucky))
 	CMAKE_OPTS += -DWITH_INTERNAL_NLOHMANN_JSON=OFF
 else
 	CMAKE_OPTS += -DWITH_INTERNAL_NLOHMANN_JSON=ON


### PR DESCRIPTION
followup #66835