### PR TITLE
Bugfix auth storagedb static tables

### DIFF
--- a/src/core/auth/qgsauthconfigurationstoragedb.cpp
+++ b/src/core/auth/qgsauthconfigurationstoragedb.cpp
@@ -1824,8 +1824,7 @@ void QgsAuthConfigurationStorageDb::checkCapabilities()
   }
 
   // Check if each table exist and set capabilities
-
-  static const QStringList existingTables = authDatabaseConnection().tables();
+  const QStringList existingTables = authDatabaseConnection().tables();
   QString schema { mConfiguration.value( u"schema"_s ).toString() };
   if ( !schema.isEmpty() )
   {

--- a/tests/src/python/test_authmanager_storage_base.py
+++ b/tests/src/python/test_authmanager_storage_base.py
@@ -885,12 +885,17 @@ class TestAuthManagerStorageBase:
             self.storage.capabilities()
             & Qgis.AuthConfigurationStorageCapability.UpdateSetting
         ):
-            raise unittest.SkipTest(
-                "Storage does not support reading certificate authorities"
-            )
+            raise unittest.SkipTest("Storage does not support reading settings")
 
         auth_manager = QgsApplication.authManager()
         auth_manager.ensureInitialized()
+
+        # Reset self.storage to point to the instance of QgsAuthConfigurationStorage that is registered with the auth manager
+        self.storage = (
+            QgsApplication.authManager()
+            .authConfigurationStorageRegistry()
+            .storage(self.storage.id())
+        )
 
         temp_dir = QTemporaryDir()
         temp_dir_path = temp_dir.path()

--- a/tests/src/python/test_authmanager_storage_psql.py
+++ b/tests/src/python/test_authmanager_storage_psql.py
@@ -14,6 +14,8 @@ import os
 import unittest
 
 from qgis.core import (
+    Qgis,
+    QgsAuthConfigurationStorage,
     QgsAuthConfigurationStorageDb,
     QgsProviderConnectionException,
     QgsProviderRegistry,
@@ -100,6 +102,8 @@ class TestAuthStoragePsql(AuthManagerStorageBaseTestCase, TestAuthManagerStorage
 
         conn.createSchema(config["schema"])
 
+        cls.config = config
+
         cls.storage = QgsAuthConfigurationStorageDb(config)
 
         assert cls.storage.type().startswith("DB-QPSQL")
@@ -113,6 +117,72 @@ class TestAuthStoragePsql(AuthManagerStorageBaseTestCase, TestAuthManagerStorage
             cls.storage.quotedQualifiedIdentifier(cls.storage.methodConfigTableName())
             == f'{schema}"auth_configs"'
         )
+
+    def testInitialization(self):
+        """Test initialization of the storage"""
+
+        # Use a temporary schema to test initialization, so we don't drop the existing schema
+        init_schema = "qgis_auth_test_init"
+        # Drop the schema if it exists and create it again
+        md = QgsProviderRegistry.instance().providerMetadata("postgres")
+        conn = md.createConnection(
+            f"dbname='{self.config['dbname']}' host={self.config['host']} port={self.config['port']} user='{self.config['user']}' password='{self.config['password']}'",
+            {},
+        )
+
+        try:
+            conn.dropSchema(init_schema, True)
+        except QgsProviderConnectionException:
+            pass
+
+        conn.createSchema(init_schema)
+
+        # Create a new storage with the temporary schema
+        init_config = self.config.copy()
+        init_config["schema"] = init_schema
+        storage = QgsAuthConfigurationStorageDb(init_config)
+        storage.setReadOnly(True)
+        self.assertFalse(
+            storage.capabilities()
+            & Qgis.AuthConfigurationStorageCapability.CreateMasterPassword
+        )
+
+        self.assertTrue(storage.isReadOnly())
+        storage.initialize()
+
+        # Check tables do not exists yet
+        self.assertFalse(conn.tableExists(init_schema, "auth_pass"))
+
+        # Set readonly to False and initialize again
+        storage.setReadOnly(False)
+        self.assertFalse(
+            storage.capabilities()
+            & Qgis.AuthConfigurationStorageCapability.CreateMasterPassword
+        )
+        storage.initialize()
+
+        # Check tables exist now
+        self.assertTrue(conn.tableExists(init_schema, "auth_pass"))
+
+        # Check that capabilities are set correctly
+        self.assertTrue(
+            storage.capabilities()
+            & Qgis.AuthConfigurationStorageCapability.CreateMasterPassword
+        )
+
+        # Set master password and check that capabilities are set correctly
+        pwds = storage.masterPasswords()
+        self.assertEqual(len(pwds), 0)
+
+        pwd_config = QgsAuthConfigurationStorage.MasterPasswordConfig()
+        pwd_config.hash = "hash"
+        pwd_config.salt = "salt"
+        pwd_config.civ = "civ"
+
+        self.assertTrue(storage.storeMasterPassword(pwd_config))
+
+        pwds = storage.masterPasswords()
+        self.assertEqual(len(pwds), 1)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_authmanager_storage_psql.py
+++ b/tests/src/python/test_authmanager_storage_psql.py
@@ -30,12 +30,6 @@ __date__ = "2024-06-24"
 __copyright__ = "Copyright 2024, The QGIS Project"
 
 
-# Skip if driver QPSQL/QPSQL7 is not available
-@unittest.skipIf(
-    not QtSql.QSqlDatabase.isDriverAvailable("QPSQL")
-    and not QtSql.QSqlDatabase.isDriverAvailable("QPSQL7"),
-    "QPSQL/QPSQL7 driver not available",
-)
 class TestAuthStoragePsql(AuthManagerStorageBaseTestCase, TestAuthManagerStorageBase):
     @classmethod
     def setUpClass(cls):
@@ -68,9 +62,7 @@ class TestAuthStoragePsql(AuthManagerStorageBaseTestCase, TestAuthManagerStorage
                 key, value = item.split("=")
                 config[key] = value
 
-        config["driver"] = (
-            "QPSQL" if QtSql.QSqlDatabase.isDriverAvailable("QPSQL") else "QPSQL7"
-        )
+        config["driver"] = "QPSQL"
         config["database"] = config["dbname"]
 
         # Remove single quotes if present in user and password and database
@@ -90,6 +82,13 @@ class TestAuthStoragePsql(AuthManagerStorageBaseTestCase, TestAuthManagerStorage
         # to initialize the application before using the provider registry
         super().setUpClass()
 
+        # This is here because it needs the QT core application to be initialized
+        # Skip if driver QPSQL/QPSQL7 is not available
+        if not QtSql.QSqlDatabase.isDriverAvailable(
+            "QPSQL"
+        ) and not QtSql.QSqlDatabase.isDriverAvailable("QPSQL7"):
+            raise unittest.SkipTest("QPSQL/QPSQL7 driver not available")
+
         # Make sure all tables are dropped by dropping the schema
         md = QgsProviderRegistry.instance().providerMetadata("postgres")
         # connection uri
@@ -103,7 +102,7 @@ class TestAuthStoragePsql(AuthManagerStorageBaseTestCase, TestAuthManagerStorage
 
         cls.storage = QgsAuthConfigurationStorageDb(config)
 
-        assert cls.storage.type() == "DB-QPSQL"
+        assert cls.storage.type().startswith("DB-QPSQL")
 
         if config["schema"]:
             schema = f'"{config["schema"]}".'


### PR DESCRIPTION
Fix unreported issue with auth DB storage initialization where after the auth tables were created the storage capabilities were not updated (because the existing tables list was a static variable).

