### PR TITLE
[expressions] Fix lpad/rpad misbehaving with an empty fill character

### DIFF
--- a/resources/function_help/json/lpad
+++ b/resources/function_help/json/lpad
@@ -11,6 +11,8 @@
     "description": "length of new string"
   }, {
     "arg": "fill",
+    "optional": true,
+    "default":"' '",
     "description": "character to pad the remaining space with"
   }],
   "examples": [{

--- a/resources/function_help/json/lpad
+++ b/resources/function_help/json/lpad
@@ -2,7 +2,7 @@
   "name": "lpad",
   "type": "function",
   "groups": ["String"],
-  "description": "Returns a string padded on the left to the specified width, using a fill character. If the target width is smaller than the string's length, the string is truncated.",
+  "description": "Returns a string padded on the left to the specified width, using a fill character. If the target width is smaller than the string's length, the string is truncated. If the fill parameter is omitted, the function will default to a space character.",
   "arguments": [{
     "arg": "string",
     "description": "string to pad"
@@ -18,6 +18,9 @@
   "examples": [{
     "expression": "lpad('Hello', 10, 'x')",
     "returns": "'xxxxxHello'"
+  }, {
+    "expression": "lpad('Hello', 10)",
+    "returns": "'     Hello'"
   }, {
     "expression": "lpad('Hello', 3, 'x')",
     "returns": "'Hel'"

--- a/resources/function_help/json/rpad
+++ b/resources/function_help/json/rpad
@@ -11,6 +11,8 @@
     "description": "length of new string"
   }, {
     "arg": "fill",
+    "optional": true,
+    "default":"' '",
     "description": "character to pad the remaining space with"
   }],
   "examples": [{

--- a/resources/function_help/json/rpad
+++ b/resources/function_help/json/rpad
@@ -2,7 +2,7 @@
   "name": "rpad",
   "type": "function",
   "groups": ["String"],
-  "description": "Returns a string padded on the right to the specified width, using a fill character. If the target width is smaller than the string's length, the string is truncated.",
+  "description": "Returns a string padded on the right to the specified width, using a fill character. If the target width is smaller than the string's length, the string is truncated. If the fill parameter is omitted, the function will default to a space character.",
   "arguments": [{
     "arg": "string",
     "description": "string to pad"
@@ -18,6 +18,9 @@
   "examples": [{
     "expression": "rpad('Hello', 10, 'x')",
     "returns": "'Helloxxxxx'"
+  }, {
+    "expression": "rpad('Hello', 10)",
+    "returns": "'Hello     '"
   }, {
     "expression": "rpad('Hello', 3, 'x')",
     "returns": "'Hel'"

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2956,17 +2956,25 @@ static QVariant fcnLeft( const QVariantList &values, const QgsExpressionContext 
 
 static QVariant fcnRPad( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
-  int length = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+  const QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
+  const int length = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
   QString fill = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
+  if ( fill.isEmpty() )
+  {
+    fill = u" "_s;
+  }
   return string.leftJustified( length, fill.at( 0 ), true );
 }
 
 static QVariant fcnLPad( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
-  int length = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
+  const QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
+  const int length = QgsExpressionUtils::getNativeIntValue( values.at( 1 ), parent );
   QString fill = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
+  if ( fill.isEmpty() )
+  {
+    fill = u" "_s;
+  }
   return string.rightJustified( length, fill.at( 0 ), true );
 }
 
@@ -9634,8 +9642,18 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
       << new QgsStaticExpressionFunction( u"strpos"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"haystack"_s ) << QgsExpressionFunction::Parameter( u"needle"_s ), fcnStrpos, u"String"_s )
       << new QgsStaticExpressionFunction( u"left"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"string"_s ) << QgsExpressionFunction::Parameter( u"length"_s ), fcnLeft, u"String"_s )
       << new QgsStaticExpressionFunction( u"right"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"string"_s ) << QgsExpressionFunction::Parameter( u"length"_s ), fcnRight, u"String"_s )
-      << new QgsStaticExpressionFunction( u"rpad"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"string"_s ) << QgsExpressionFunction::Parameter( u"width"_s ) << QgsExpressionFunction::Parameter( u"fill"_s ), fcnRPad, u"String"_s )
-      << new QgsStaticExpressionFunction( u"lpad"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"string"_s ) << QgsExpressionFunction::Parameter( u"width"_s ) << QgsExpressionFunction::Parameter( u"fill"_s ), fcnLPad, u"String"_s )
+      << new QgsStaticExpressionFunction(
+           u"rpad"_s,
+           QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"string"_s ) << QgsExpressionFunction::Parameter( u"width"_s ) << QgsExpressionFunction::Parameter( u"fill"_s, true, u" "_s ),
+           fcnRPad,
+           u"String"_s
+         )
+      << new QgsStaticExpressionFunction(
+           u"lpad"_s,
+           QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"string"_s ) << QgsExpressionFunction::Parameter( u"width"_s ) << QgsExpressionFunction::Parameter( u"fill"_s, true, u" "_s ),
+           fcnLPad,
+           u"String"_s
+         )
       << new QgsStaticExpressionFunction( u"format"_s, -1, fcnFormatString, u"String"_s )
       << new QgsStaticExpressionFunction(
            u"format_number"_s,

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2258,8 +2258,12 @@ class TestQgsExpression : public QObject
       QTest::newRow( "right" ) << "right('Hello World', 5)" << false << QVariant( "World" );
       QTest::newRow( "rpad" ) << "rpad('Hello', 10, 'x')" << false << QVariant( "Helloxxxxx" );
       QTest::newRow( "rpad truncate" ) << "rpad('Hello', 4, 'x')" << false << QVariant( "Hell" );
+      QTest::newRow( "rpad no fill parameter" ) << "rpad('Hello', 10)" << false << QVariant( "Hello     " );
+      QTest::newRow( "rpad empty fill character" ) << "rpad('Hello', 10, '')" << false << QVariant( "Hello     " );
       QTest::newRow( "lpad" ) << "lpad('Hello', 10, 'x')" << false << QVariant( "xxxxxHello" );
       QTest::newRow( "lpad truncate" ) << "lpad('Hello', 4, 'x')" << false << QVariant( "Hell" );
+      QTest::newRow( "lpad no fill parameter" ) << "lpad('Hello', 10)" << false << QVariant( "     Hello" );
+      QTest::newRow( "lpad empty fill character" ) << "lpad('Hello', 10, '')" << false << QVariant( "     Hello" );
       QTest::newRow( "title" ) << "title(' HeLlO   WORLD ')" << false << QVariant( " Hello   World " );
       QTest::newRow( "trim" ) << "trim('   Test String ')" << false << QVariant( "Test String" );
       QTest::newRow( "trim empty string" ) << "trim('')" << false << QVariant( "" );


### PR DESCRIPTION
## Description

This PR fixes the lpad and pad expression functions' handling of an empty fill character. ATM, the following expression crashes QGIS on a debug build (due to a Qt assert), and outputs garbage characters on a non-debug build: lpad('12345', 10, '')

The PR fixes that by making the fill parameter optional, using a ' ' space as default fill character (matching postgresql behavior), and treating an empty string the same as not providing a fill parameter (i.e., using a ' ' space).

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
