### PR TITLE
fix(qgstest.h): add gzip support in checkLongStr

### DIFF
--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -42,6 +42,7 @@
 #include "qgssurface.h"
 #include "qgstriangle.h"
 #include "qgsunittypes.h"
+#include "qgsziputils.h"
 
 #include <QDesktopServices>
 #include <QDir>
@@ -284,13 +285,31 @@ class TEST_EXPORT QgsTest : public QObject
       QString header = QString( "checkLongStr (%1, %2):" ).arg( name, referenceName );
       QString subPath = "control_files/" + mControlPathPrefix + "/expected_" + name + "/" + "expected_" + referenceName;
       QString expectedPath = testDataPath( subPath );
+
+      QByteArray expectedStr;
       QFile expectedFile( expectedPath );
-      if ( !expectedFile.open( QFile::ReadOnly | QIODevice::Text ) )
+      if ( expectedFile.open( QFile::ReadOnly | QIODevice::Text ) )
       {
-        qWarning() << header.toStdString().c_str() << "Unable to open expected data file" << expectedPath;
-        return false;
+        expectedStr = expectedFile.readAll();
       }
-      QByteArray expectedStr = expectedFile.readAll();
+      else
+      {
+        // Using gzip helps in limiting code base size when using big data files.
+        QFile expectedFileGZ( expectedPath + ".gz" );
+        if ( expectedFileGZ.open( QFile::ReadOnly ) )
+        {
+          if ( !QgsZipUtils::decodeGzip( expectedFileGZ.readAll(), expectedStr ) )
+          {
+            qWarning() << header.toStdString().c_str() << "Unable to open expected GZip data file" << expectedPath;
+            return false;
+          }
+        }
+        else
+        {
+          qWarning() << header.toStdString().c_str() << "Unable to open expected data file" << expectedPath;
+          return false;
+        }
+      }
 
       if ( actualStr.size() != expectedStr.size() )
       {


### PR DESCRIPTION
In the test function `checkLongStr`, we currently look for a file with the expected data to compare with. 

This PR add gzip support: if the expected data file does not exist it will also look for a gzip data file with the same name but with ".gz" extension. 

Using gzip helps in limiting code base size when using big data files.