### PR TITLE
Fix ArcGIS MapServer preview OOM at LOD boundaries 🤖🤖🤖

### DIFF
--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -545,7 +545,11 @@ QImage QgsAmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int
     }
 
     auto getRequests = [&levelToResMap, &viewExtent, tileWidth, tileHeight, ox, oy, targetRes, &dataSource]( int level, TileRequests &requests ) {
-      const double resolution = levelToResMap.value( level );
+      const auto resolutionIt = levelToResMap.constFind( level );
+      if ( resolutionIt == levelToResMap.constEnd() || resolutionIt.value() <= 0 || targetRes <= 0 )
+        return;
+
+      const double resolution = resolutionIt.value();
 
       // Get necessary tiles to fill extent
       // tile_x = ox + i * (resolution * tileWidth)

--- a/tests/src/python/test_provider_ams.py
+++ b/tests/src/python/test_provider_ams.py
@@ -19,7 +19,10 @@ import unittest
 from qgis.core import (
     Qgis,
     QgsCoordinateReferenceSystem,
+    QgsNetworkAccessManager,
+    QgsRasterBlockFeedback,
     QgsRasterLayer,
+    QgsRectangle,
     QgsSettings,
 )
 from qgis.testing import QgisTestCase, start_app
@@ -865,6 +868,90 @@ class TestPyQgsAMSProvider(QgisTestCase, RasterProviderTestCase):
         self.assertAlmostEqual(rl.extent().yMinimum(), -20.0, 5)
         self.assertAlmostEqual(rl.extent().xMaximum(), 30.0, 5)
         self.assertAlmostEqual(rl.extent().yMaximum(), 40.0, 5)
+
+    def test_preview_single_lod_service(self):
+        """
+        Previewing a service at its LOD boundary must not request invalid levels.
+        """
+        endpoint = self.basetestpath + "/single_lod_preview_fake_qgis_http_endpoint"
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""{
+  "currentVersion": 11.1,
+  "mapName": "Layers",
+  "layers": [],
+  "spatialReference": {
+    "wkid": 4326,
+    "latestWkid": 4326
+  },
+  "singleFusedMapCache": true,
+  "fullExtent": {
+    "xmin": 0,
+    "ymin": 0,
+    "xmax": 10,
+    "ymax": 10,
+    "spatialReference": {
+      "wkid": 4326,
+      "latestWkid": 4326
+    }
+  },
+  "tileInfo": {
+    "rows": 2,
+    "cols": 2,
+    "format": "PNG",
+    "origin": {
+      "x": 0,
+      "y": 10
+    },
+    "spatialReference": {
+      "wkid": 4326,
+      "latestWkid": 4326
+    },
+    "lods": [
+      {
+        "level": 0,
+        "resolution": 5,
+        "scale": 10000
+      }
+    ]
+  },
+  "capabilities": "Map,TilesOnly"
+}"""
+            )
+
+        layer = QgsRasterLayer(
+            "url='http://" + endpoint + "'",
+            "test",
+            "arcgismapserver",
+        )
+        self.assertTrue(layer.isValid())
+
+        tile_levels = []
+
+        def record_tile_level(request):
+            path = request.url().path()
+            if "/tile/" in path:
+                tile_levels.append(int(path.split("/tile/", 1)[1].split("/", 1)[0]))
+
+        preprocessor_id = QgsNetworkAccessManager.setRequestPreprocessor(
+            record_tile_level
+        )
+        feedback = QgsRasterBlockFeedback()
+        feedback.setPreviewOnly(True)
+        try:
+            block = layer.dataProvider().block(
+                1,
+                QgsRectangle(0, 0, 10, 10),
+                2,
+                2,
+                feedback,
+            )
+        finally:
+            QgsNetworkAccessManager.removeRequestPreprocessor(preprocessor_id)
+
+        self.assertTrue(block.isValid())
+        self.assertTrue(tile_levels)
+        self.assertEqual(set(tile_levels), {0})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This supersedes #66856. The verified replacement commit was force-pushed after I closed the original PR, and GitHub consequently does not allow that PR to be reopened.

Tiled ArcGIS MapServer previews try to reuse cached tiles from the two lower LODs and one higher LOD while the requested tiles are loading. At the first or last advertised LOD, these adjacent levels may not exist.

`getRequests()` previously used `QMap::value()` for an unadvertised level, which returned a zero resolution. That zero then fed the tile-index calculations and produced invalid request ranges. In a macOS QGIS 3.44.12 reproduction, QGIS grew from 1.4 GB to 9.7 GB RSS in 14 seconds; `footprint` reached 29 GB, and a live stack sample showed `QgsAmsProvider::draw()` repeatedly appending `TileRequest` objects from the preview fallback.

This change:

- skips request generation when the LOD is not advertised or its resolution is non-positive;
- rejects a non-positive target resolution before performing tile index calculations;
- adds a fake-endpoint regression test which records tile-cache lookups for a single-LOD service and verifies that preview rendering only accesses the advertised level.

The normal selected LOD and valid adjacent LOD behavior are unchanged.

Fixes #64344

### Testing

Built against QGIS master using QGIS's `qgis3-build-deps-ubuntu-qt6:master` image (Qt 6.10.2, GDAL 3.12.2):

```text
ninja -C build-docker provider_arcgismapserver python_module_qgis__core
```

The provider and Python core bindings compile successfully.

```text
ctest --test-dir build-docker -R PyQgsAMSProvider -V --output-on-failure
```

Result with the fix: all 8 `PyQgsAMSProvider` tests pass.

I also performed a red/green control by rebuilding the provider with only the guard removed while retaining the regression test. The test failed because preview rendering accessed unadvertised levels `-2`, `-1`, and `1`. Rebuilding with the guard restored made the full targeted suite pass.

```text
pre-commit run --files \
  src/providers/arcgisrest/qgsamsprovider.cpp \
  tests/src/python/test_provider_ams.py
```

All configured hooks pass.

This fix should be suitable for backporting to affected supported release branches.

## AI tool usage

- [x] AI tool(s) (OpenAI Codex) supported my development of this PR. I reviewed the diagnosis, code, test, commit, and this description, and remain accountable for the contribution.
