### PR TITLE
allow negative spinbox values if default is negative

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -254,7 +254,8 @@ QList<QPair<QLabel *, QWidget *>> QgsVectorLayerSaveAsDialog::createControls( co
         {
           QSpinBox *sb = new QSpinBox();
           sb->setObjectName( it.key() );
-          sb->setMaximum( std::numeric_limits<int>::max() ); // the default is 99
+          sb->setMaximum( std::numeric_limits<int>::max() );  // the default is 99
+          sb->setMinimum( std::min( 0, opt->defaultValue ) ); // allow negative (default) values i.e. ZSTD default compression level -1
           sb->setValue( opt->defaultValue );
           control = sb;
         }


### PR DESCRIPTION
i.e. default ZSTD compression level is -1

Hotfix for #66822 (OTOH the range isn't fully dynamically parametrized yet)

## Description

[Replace this with some text explaining the rationale and details about this pull request]

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
