### PR TITLE
Display fixed user profile menu items first, before the list of profi…

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3539,6 +3539,17 @@ void QgisApp::refreshProfileMenu()
     return;
 
   mConfigMenu->clear();
+
+  QAction *openProfileFolderAction = mConfigMenu->addAction( tr( "Open Active Profile Folder" ) );
+  openProfileFolderAction->setObjectName( "mActionOpenActiveProfileFolder" );
+  connect( openProfileFolderAction, &QAction::triggered, this, [this]() { QDesktopServices::openUrl( QUrl::fromLocalFile( userProfileManager()->userProfile()->folder() ) ); } );
+
+  QAction *newProfileAction = mConfigMenu->addAction( tr( "New Profile…" ) );
+  newProfileAction->setObjectName( "mActionNewProfile" );
+  connect( newProfileAction, &QAction::triggered, this, &QgisApp::newProfile );
+
+  mConfigMenu->addSeparator();
+
   QgsUserProfile *profile = userProfileManager()->userProfile();
   QString activeName = profile->name();
   mConfigMenu->setTitle( tr( "&User Profiles" ) );
@@ -3573,16 +3584,6 @@ void QgisApp::refreshProfileMenu()
       } );
     }
   }
-
-  mConfigMenu->addSeparator();
-
-  QAction *openProfileFolderAction = mConfigMenu->addAction( tr( "Open Active Profile Folder" ) );
-  openProfileFolderAction->setObjectName( "mActionOpenActiveProfileFolder" );
-  connect( openProfileFolderAction, &QAction::triggered, this, [this]() { QDesktopServices::openUrl( QUrl::fromLocalFile( userProfileManager()->userProfile()->folder() ) ); } );
-
-  QAction *newProfileAction = mConfigMenu->addAction( tr( "New Profile…" ) );
-  newProfileAction->setObjectName( "mActionNewProfile" );
-  connect( newProfileAction, &QAction::triggered, this, &QgisApp::newProfile );
 }
 
 void QgisApp::createProfileMenu()


### PR DESCRIPTION
…le names.

## Description

When having many user profiles, for example for developing plugins or teaching courses, the list in the User Profiles menu gets quite long and navigating to the "Open Active Profile Folder" is a bit time wasting. So I moved the fixed menu items, "Add User Profile" as well, to the top of the menu.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

I did not add any new code, just re-ordered existing code. Compiled it and tested it manually.

before:
<img width="670" height="285" alt="Screenshot From 2026-07-24 20-41-39" src="https://github.com/user-attachments/assets/9ef95fa1-5bfa-4acf-becb-a0881257b9ba" />

after:
<img width="670" height="285" alt="Screenshot From 2026-07-24 20-42-56" src="https://github.com/user-attachments/assets/77edd8cc-5d79-464e-9a9f-0c3e05075793" />

There's no screenshot in the documentation, so no need to change anything there:
https://docs.qgis.org/3.44/en/docs/user_manual/introduction/qgis_configuration.html#working-with-user-profiles
