### PR TITLE
Report OpenGL version and renderer

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -40,6 +40,9 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QObject>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFunctions>
 #include <QPainter>
 #include <QPixmap>
 #include <QPoint>
@@ -64,6 +67,7 @@ using namespace Qt::StringLiterals;
 #endif
 #include <QStatusBar>
 #include <QStringList>
+#include <QSurfaceFormat>
 #include <QSysInfo>
 #include <QTcpSocket>
 #include <QTextStream>
@@ -5555,6 +5559,48 @@ void QgisApp::about()
   mAboutDialog->activateWindow();
 }
 
+QString QgisApp::openGlReportString()
+{
+#if defined( QT_NO_OPENGL )
+  return tr( "No support" );
+#else
+
+  QOpenGLContext context;
+  context.setFormat( QSurfaceFormat::defaultFormat() );
+  if ( !context.create() )
+    return tr( "No support" );
+
+  const QSurfaceFormat format = context.format();
+  QString profile;
+  switch ( format.profile() )
+  {
+    case QSurfaceFormat::CoreProfile:
+      profile = tr( "Core Profile" );
+      break;
+    case QSurfaceFormat::CompatibilityProfile:
+      profile = tr( "Compatibility Profile" );
+      break;
+    case QSurfaceFormat::NoProfile:
+      profile = tr( "No Profile" );
+      break;
+  }
+  QString result = u"%1.%2 (%3)"_s.arg( format.majorVersion() ).arg( format.minorVersion() ).arg( profile );
+
+  QOffscreenSurface surface;
+  surface.setFormat( format );
+  surface.create();
+  if ( context.makeCurrent( &surface ) )
+  {
+    const char *glRenderer = reinterpret_cast<const char *>( context.functions()->glGetString( GL_RENDERER ) );
+    if ( glRenderer )
+      result += u", %1"_s.arg( QString::fromUtf8( glRenderer ) );
+    context.doneCurrent();
+  }
+
+  return result;
+#endif
+}
+
 QString QgisApp::getVersionString()
 {
   QString versionString = u"<table width='100%' align='center'>"_s;
@@ -5732,6 +5778,10 @@ QString QgisApp::getVersionString()
 
   // QScintilla
   versionString += u"<td>%1</td><td>%2</td>"_s.arg( tr( "QScintilla2 version" ), QSCINTILLA_VERSION_STR );
+  versionString += "</tr><tr>"_L1;
+
+  // OpenGL
+  versionString += u"<td>%1</td><td>%2</td>"_s.arg( tr( "OpenGL version" ), openGlReportString() );
   versionString += "</tr><tr>"_L1;
 
   // Operating system

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2395,6 +2395,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Deletes all the layout designer windows
     void deleteLayoutDesigners();
 
+    //! Returns the OpenGL version and GL renderer string if available
+    static QString openGlReportString();
+
     void setupLayoutManagerConnections();
 
     void setupAtlasMapLayerAction( QgsPrintLayout *layout, bool enableAction );


### PR DESCRIPTION
This PR adds OpenGL version reporting in the About dialog.

Other than OpenGL version, GL_RENDERER is also reported. One of the good things it reports is if we are using software or hardware rendering (or virtualized).

https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetString.xhtml

output examples:

(no mods)
```
OpenGL version
4.6 (Core Profile), AMD Radeon 780M Graphics (radeonsi, phoenix, ACO, DRM 3.64, 7.0.10-201.fc44.x86_64)
```


export LIBGL_ALWAYS_SOFTWARE=1
```
OpenGL version
4.6 (Core Profile), llvmpipe (LLVM 22.1.8, 256 bits)
```

Oracle VirtualBox 7 (guest Win11, VBoxSVGA with 3D accellaration enabled)
```
OpenGL version
 4.1 (Compatibility Profile), SVGA3D; build: RELEASE;

```


</body></html>

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.