### PR TITLE
Fix QgsCircle::fromExtent

### DIFF
--- a/src/core/geometry/qgscircle.cpp
+++ b/src/core/geometry/qgscircle.cpp
@@ -376,7 +376,7 @@ int QgsCircle::innerTangents( const QgsCircle &other, QgsPointXY &line1P1, QgsPo
 QgsCircle QgsCircle::fromExtent( const QgsPoint &pt1, const QgsPoint &pt2 ) // cppcheck-suppress duplInheritedMember
 {
   const double delta_x = std::fabs( pt1.x() - pt2.x() );
-  const double delta_y = std::fabs( pt1.x() - pt2.y() );
+  const double delta_y = std::fabs( pt1.y() - pt2.y() );
   if ( !qgsDoubleNear( delta_x, delta_y ) )
   {
     return QgsCircle();

--- a/tests/src/core/geometry/testqgscircle.cpp
+++ b/tests/src/core/geometry/testqgscircle.cpp
@@ -84,6 +84,7 @@ void TestQgsCircle::fromExtent()
 {
   QVERIFY( QgsCircle().fromExtent( QgsPoint( -5, -5 ), QgsPoint( 5, 5 ) ) == QgsCircle( QgsPoint( 0, 0 ), 5, 0 ) );
   QVERIFY( QgsCircle().fromExtent( QgsPoint( -7.5, -2.5 ), QgsPoint( 2.5, 200.5 ) ).isEmpty() );
+  QVERIFY( QgsCircle().fromExtent( QgsPoint( 0, 1 ), QgsPoint( 6, 7 ) ) == QgsCircle( QgsPoint( 3, 4 ), 3, 0 ) );
 }
 
 void TestQgsCircle::from3Points()


### PR DESCRIPTION
Simple fix, x and y were swapped for delta_y calc.
Test added to check for this.

Not used in the codebase, just exposed to SIP.

No AI used.