### PR TITLE
Fix QgsCircle::from3TangentsMulti and getFirstPointOnParallels in QgsMapToolShapeCircle3Tangents

### DIFF
--- a/src/app/maptools/qgsmaptoolshapecircle3tangents.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircle3tangents.cpp
@@ -69,10 +69,14 @@ static QgsPoint getFirstPointOnParallels(
   QgsPoint intersection;
   bool isInter;
 
-  if ( ( !QgsGeometryUtils::segmentIntersection( p1_line1, p2_line1, p1_line2, p2_line2, intersection, isInter, true ) )
-       || ( !QgsGeometryUtils::segmentIntersection( p1_line1, p2_line1, p1_line3, p2_line3, intersection, isInter, true ) ) )
+  QgsGeometryUtils::segmentIntersection( p1_line1, p2_line1, p1_line2, p2_line2, intersection, isInter );
+  if ( !isInter )
     return pos_line1;
-  if ( !QgsGeometryUtils::segmentIntersection( p1_line2, p2_line2, p1_line3, p2_line3, intersection, isInter, true ) )
+  QgsGeometryUtils::segmentIntersection( p1_line1, p2_line1, p1_line3, p2_line3, intersection, isInter );
+  if ( !isInter )
+    return pos_line1;
+  QgsGeometryUtils::segmentIntersection( p1_line2, p2_line2, p1_line3, p2_line3, intersection, isInter );
+  if ( !isInter )
     return pos_line2;
 
   return QgsPoint();

--- a/src/core/geometry/qgscircle.cpp
+++ b/src/core/geometry/qgscircle.cpp
@@ -290,7 +290,7 @@ QVector<QgsCircle> QgsCircle::from3TangentsMulti(
   else if ( !isIntersect_tg1tg3 )
     return from2ParallelsLine( pt1_tg1, pt2_tg1, pt1_tg3, pt2_tg3, pt1_tg2, pt2_tg2, pos, epsilon );
   else if ( !isIntersect_tg2tg3 )
-    return from2ParallelsLine( pt1_tg2, pt2_tg2, pt1_tg3, pt2_tg3, pt1_tg1, pt1_tg1, pos, epsilon );
+    return from2ParallelsLine( pt1_tg2, pt2_tg2, pt1_tg3, pt2_tg3, pt1_tg1, pt2_tg1, pos, epsilon );
 
   if ( p1.is3D() )
   {

--- a/tests/src/core/geometry/testqgscircle.cpp
+++ b/tests/src/core/geometry/testqgscircle.cpp
@@ -149,7 +149,32 @@ void TestQgsCircle::from3tangentsMulti()
   QVector<QgsCircle> circles;
   QgsCircle circ;
 
+  // the 1st tangent and the 2nd tangent are parallel
   circles = QgsCircle::from3TangentsMulti( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ), QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ) );
+  QCOMPARE( circles.count(), 2 );
+
+  circ = circles.at( 0 );
+  QGSCOMPARENEARPOINT( circ.center(), QgsPoint( 8.5355, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ.radius(), 2.5, 0.0001 );
+
+  circ = circles.at( 1 );
+  QGSCOMPARENEARPOINT( circ.center(), QgsPoint( 1.4645, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ.radius(), 2.5, 0.0001 );
+
+  // the 1st tangent and the 3rd tangent are parallel
+  circles = QgsCircle::from3TangentsMulti( QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ) );
+  QCOMPARE( circles.count(), 2 );
+
+  circ = circles.at( 0 );
+  QGSCOMPARENEARPOINT( circ.center(), QgsPoint( 8.5355, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ.radius(), 2.5, 0.0001 );
+
+  circ = circles.at( 1 );
+  QGSCOMPARENEARPOINT( circ.center(), QgsPoint( 1.4645, 2.5000 ), 0.0001 );
+  QGSCOMPARENEAR( circ.radius(), 2.5, 0.0001 );
+
+  // the 2nd tangent and the 3rd tangent are parallel
+  circles = QgsCircle::from3TangentsMulti( QgsPoint( 2.5, 0 ), QgsPoint( 7.5, 5 ), QgsPoint( 0, 0 ), QgsPoint( 5, 0 ), QgsPoint( 5, 5 ), QgsPoint( 10, 5 ) );
   QCOMPARE( circles.count(), 2 );
 
   circ = circles.at( 0 );


### PR DESCRIPTION
## Description

This PR fixes some oversights in `QgsCircle::from3TangentsMulti` and `getFirstPointOnParallels` in `QgsMapToolShapeCircle3Tangents` spotted while reviewing https://github.com/qgis/QGIS/pull/66875.

In particular

- in `QgsCircle::from3TangentsMulti`, the call to `from2ParallelsLine` in the lines
```cpp
else if ( !isIntersect_tg2tg3 )
    return from2ParallelsLine( pt1_tg2, pt2_tg2, pt1_tg3, pt2_tg3, pt1_tg1, pt1_tg1, pos, epsilon );
```
incorrectly passes two time the same point pt1_tg1, instead of the points pt1_tg1 and pt2_tg1.

Such oversight prevents `QgsCircle::from3TangentsMulti` and `QgsCircle::from3Tangents` to correctly handle the case where the the second and the third tangents are parallel.

In fact, the following Python code

```python
circles = QgsCircle.from3TangentsMulti(
    QgsPoint(2.5,0),  QgsPoint(7.5,5),
    QgsPoint(0, 0), QgsPoint(5, 0),
    QgsPoint(5, 5),  QgsPoint(10, 5),
)
print( circles )
```
executed before the fix, incorrectly returns

```python
[<QgsCircle: Circle (Center: Point EMPTY, Radius: 2.5, Azimuth: 0)>, <QgsCircle: Circle (Center: Point EMPTY, Radius: 2.5, Azimuth: 0)>]
```

after the fix, correctly returns

```python
[<QgsCircle: Circle (Center: Point (8.53553390593273775 2.5), Radius: 2.5, Azimuth: 0)>, <QgsCircle: Circle (Center: Point (1.46446609406726203 2.49999999999999911), Radius: 2.5, Azimuth: 0)>]
```

- in `QgsMapToolShapeCircle3Tangents`, the function `getFirstPointOnParallels` contains incorrect calls to QgsGeometryUtils::segmentIntersection, where the last parameter used is a bool intended to be the `acceptImproperIntersection` parameter, while it is incorrectly used in the place of the `tolerance` parameter.
Such oversight prevents the function to correctly select the point on the first parallel in some circumstances.

Before the fixes:

https://github.com/user-attachments/assets/9ae23662-a496-4600-8096-0607b51eee84

After the fixes:

https://github.com/user-attachments/assets/64b60f66-c887-4c6c-8644-964f4687ad9f

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
