### PR TITLE
Sync the layer trees when reopening closed elevation profiles

### DIFF
--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -785,6 +785,11 @@ void QgsElevationProfileWidget::setupLayerTreeView( bool resetTree )
     {
       copyProjectTree( mLayerTree );
     }
+    else
+    {
+      mLayerTreeView->cleanupDeletedLayers( QgsProject::instance() );
+      mLayerTreeView->populateMissingLayers( QgsProject::instance(), true );
+    }
 
     // Initially populates the tree view using sources from the source registry
     const QList< QgsAbstractProfileSource * > sources = QgsApplication::profileSourceRegistry()->profileSources();

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -482,7 +482,7 @@ void QgsElevationProfileLayerTreeView::setLayerTree( QgsLayerTree *rootNode )
   delete oldModel;
 }
 
-void QgsElevationProfileLayerTreeView::populateMissingLayers( QgsProject *project )
+void QgsElevationProfileLayerTreeView::populateMissingLayers( QgsProject *project, bool forceUnchecked )
 {
   const QList<QgsMapLayer *> layers = project->layers<QgsMapLayer *>().toList();
 
@@ -500,7 +500,11 @@ void QgsElevationProfileLayerTreeView::populateMissingLayers( QgsProject *projec
 
     QgsLayerTreeLayer *node = mLayerTree->addLayer( layer );
 
-    if ( layer->customProperty( u"_include_in_elevation_profiles"_s ).isValid() )
+    if ( forceUnchecked )
+    {
+      node->setItemVisibilityChecked( false );
+    }
+    else if ( layer->customProperty( u"_include_in_elevation_profiles"_s ).isValid() )
     {
       node->setItemVisibilityChecked( layer->customProperty( u"_include_in_elevation_profiles"_s ).toBool() );
     }
@@ -550,6 +554,21 @@ void QgsElevationProfileLayerTreeView::removeNodeForUnregisteredSource( const QS
 QgsElevationProfileLayerTreeProxyModel *QgsElevationProfileLayerTreeView::proxyModel()
 {
   return mProxyModel;
+}
+
+void QgsElevationProfileLayerTreeView::cleanupDeletedLayers( QgsProject *project )
+{
+  const QList<QgsLayerTreeLayer *> profileLayers = mLayerTree->findLayers();
+  const QMap<QString, QgsMapLayer *> projectLayers = project->mapLayers();
+
+  for ( QgsLayerTreeLayer *ltl : profileLayers )
+  {
+    if ( !projectLayers.contains( ltl->layerId() ) )
+    {
+      ltl->parent()->takeChild( ltl );
+      delete ltl;
+    }
+  }
 }
 
 void QgsElevationProfileLayerTreeView::resizeEvent( QResizeEvent *event )

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -190,7 +190,7 @@ class GUI_EXPORT QgsElevationProfileLayerTreeView : public QgsLayerTreeViewBase
     /**
      * Adds any layers from a \a project which currently aren't within the profile's layer tree.
      *
-     * \param forceUnchecked since QGIS 4.4, Optionally force any added layer to be unchecked in the profile's layer tree.
+     * \param forceUnchecked Optionally force any added layer to be unchecked in the profile's layer tree. (since QGIS 4.4)
      * \since QGIS 4.0
      */
     void populateMissingLayers( QgsProject *project, bool forceUnchecked = false );

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -157,6 +157,12 @@ class GUI_EXPORT QgsElevationProfileLayerTreeView : public QgsLayerTreeViewBase
      */
     QgsElevationProfileLayerTreeProxyModel *proxyModel();
 
+    /**
+     * Removes from the layer tree any layers that no longer exist in the \a project.
+     * \since QGIS 4.4
+     */
+    void cleanupDeletedLayers( QgsProject *project );
+
   public slots:
 
     /**
@@ -184,9 +190,10 @@ class GUI_EXPORT QgsElevationProfileLayerTreeView : public QgsLayerTreeViewBase
     /**
      * Adds any layers from a \a project which currently aren't within the profile's layer tree.
      *
+     * \param forceUnchecked since QGIS 4.4, Optionally force any added layer to be unchecked in the profile's layer tree.
      * \since QGIS 4.0
      */
-    void populateMissingLayers( QgsProject *project );
+    void populateMissingLayers( QgsProject *project, bool forceUnchecked = false );
 
   signals:
 

--- a/tests/src/app/testqgselevationprofilewidget.cpp
+++ b/tests/src/app/testqgselevationprofilewidget.cpp
@@ -13,15 +13,19 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <memory>
+
 #include "elevation/qgselevationprofilewidget.h"
 #include "qgisapp.h"
 #include "qgsabstractprofilesource.h"
 #include "qgselevationprofile.h"
 #include "qgselevationprofilecanvas.h"
 #include "qgslayertree.h"
+#include "qgsmaplayerelevationproperties.h"
 #include "qgsprofilesourceregistry.h"
 #include "qgstest.h"
 
+#include <QSignalSpy>
 #include <QString>
 
 using namespace Qt::StringLiterals;
@@ -57,6 +61,9 @@ class TestQgsAppElevationProfileWidget : public QObject
     void registerCustomProfileInSyncMode();
     void registerCustomProfileInNonSyncMode();
     void registerCustomProfileAndToggleSyncMode();
+    void testRemovedProjectLayers();
+    void testAddedProjectLayers();
+    void testChangedLayersWithCustomProfile();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -90,6 +97,8 @@ void TestQgsAppElevationProfileWidget::cleanup()
     QgsApplication::profileSourceRegistry()->unregisterProfileSource( source->profileSourceId() );
   }
   QVERIFY( QgsApplication::profileSourceRegistry()->profileSources().isEmpty() );
+
+  QgsProject::instance()->clear();
 }
 
 void TestQgsAppElevationProfileWidget::registerCustomProfileAddsCustomNode()
@@ -262,6 +271,145 @@ void TestQgsAppElevationProfileWidget::registerCustomProfileAndToggleSyncMode()
 
   // Unregister the custom profile
   QVERIFY( QgsApplication::profileSourceRegistry()->unregisterProfileSource( u"my-dummy-profile"_s ) );
+}
+
+void TestQgsAppElevationProfileWidget::testRemovedProjectLayers()
+{
+  const QString dataDir( TEST_DATA_DIR ); //defined in CmakeLists.txt
+  const QString layerPath = dataDir + u"/points.shp"_s;
+
+  QgsVectorLayer *layer1 = new QgsVectorLayer( layerPath, u"points 1"_s, u"ogr"_s );
+  QgsVectorLayer *layer2 = new QgsVectorLayer( layerPath, u"points 2"_s, u"ogr"_s );
+  QgsVectorLayer *layer3 = new QgsVectorLayer( layerPath, u"points 3"_s, u"ogr"_s );
+
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << layer1 << layer2 << layer3 );
+
+  QgsElevationProfile *profile = new QgsElevationProfile( QgsProject::instance() );
+  QgsElevationProfileWidget::applyDefaultSettingsToProfile( profile );
+  QgsElevationProfileWidget *profileWidget = new QgsElevationProfileWidget( profile, mQgisApp->mapCanvas() );
+  QVERIFY( profileWidget->profile() );
+  QVERIFY( profile->layerTree()->findLayer( layer1 ) );
+  QVERIFY( profile->layerTree()->findLayer( layer2 ) );
+  QVERIFY( profile->layerTree()->findLayer( layer3 ) );
+
+  // close widget and wait for deletion
+  QSignalSpy spy( profileWidget, &QObject::destroyed );
+  profileWidget->close();
+  QVERIFY( spy.wait( 1000 ) );
+  profileWidget = nullptr;
+
+  QgsProject::instance()->removeMapLayers( QList<QgsMapLayer *>() << layer1 << layer2 );
+
+  profileWidget = new QgsElevationProfileWidget( profile, mQgisApp->mapCanvas() );
+  QVERIFY( profileWidget->profile() );
+  QCOMPARE( profile->layerTree()->findLayers().size(), 1 );
+  QVERIFY( profile->layerTree()->findLayer( layer3 ) );
+}
+
+void TestQgsAppElevationProfileWidget::testAddedProjectLayers()
+{
+  const QString dataDir( TEST_DATA_DIR ); //defined in CmakeLists.txt
+  const QString layerPath = dataDir + u"/points.shp"_s;
+
+  QgsVectorLayer *layer1 = new QgsVectorLayer( layerPath, u"points 1"_s, u"ogr"_s );
+
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << layer1 );
+
+  // enable show by default
+  layer1->elevationProperties()->setZOffset( 1.0 );
+  QVERIFY( layer1->elevationProperties()->showByDefaultInElevationProfilePlots() );
+
+  QgsElevationProfile *profile = new QgsElevationProfile( QgsProject::instance() );
+  QgsElevationProfileWidget::applyDefaultSettingsToProfile( profile );
+  QgsElevationProfileWidget *profileWidget = new QgsElevationProfileWidget( profile, mQgisApp->mapCanvas() );
+  QVERIFY( profileWidget->profile() );
+  QVERIFY( profile->layerTree()->findLayer( layer1 ) );
+  QCOMPARE( profile->layerTree()->findLayers().size(), 1 );
+
+  // close widget and wait for deletion
+  QSignalSpy spy( profileWidget, &QObject::destroyed );
+  profileWidget->close();
+  QVERIFY( spy.wait( 1000 ) );
+
+  QgsVectorLayer *layer2 = new QgsVectorLayer( layerPath, u"points 2"_s, u"ogr"_s );
+  QgsVectorLayer *layer3 = new QgsVectorLayer( layerPath, u"points 3"_s, u"ogr"_s );
+
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << layer2 << layer3 );
+  // enable show by default
+  layer2->elevationProperties()->setZOffset( 1.0 );
+  QVERIFY( layer2->elevationProperties()->showByDefaultInElevationProfilePlots() );
+  layer3->elevationProperties()->setZOffset( 1.0 );
+  QVERIFY( layer3->elevationProperties()->showByDefaultInElevationProfilePlots() );
+
+  profileWidget = new QgsElevationProfileWidget( profile, mQgisApp->mapCanvas() );
+  QVERIFY( profileWidget->profile() );
+  QgsLayerTreeLayer *l;
+  l = profile->layerTree()->findLayer( layer1 );
+  QVERIFY( l );
+  QVERIFY( l->itemVisibilityChecked() );
+  l = profile->layerTree()->findLayer( layer2 );
+  QVERIFY( l );
+  QVERIFY( !l->itemVisibilityChecked() );
+  l = profile->layerTree()->findLayer( layer3 );
+  QVERIFY( l );
+  QVERIFY( !l->itemVisibilityChecked() );
+}
+
+void TestQgsAppElevationProfileWidget::testChangedLayersWithCustomProfile()
+{
+  const QString dataDir( TEST_DATA_DIR ); //defined in CmakeLists.txt
+  const QString layerPath = dataDir + u"/points.shp"_s;
+
+  QgsVectorLayer *layer1 = new QgsVectorLayer( layerPath, u"points 1"_s, u"ogr"_s );
+  QgsVectorLayer *layer2 = new QgsVectorLayer( layerPath, u"points 2"_s, u"ogr"_s );
+
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << layer1 << layer2 );
+
+  // enable show by default
+  layer1->elevationProperties()->setZOffset( 1.0 );
+  QVERIFY( layer1->elevationProperties()->showByDefaultInElevationProfilePlots() );
+  layer2->elevationProperties()->setZOffset( 1.0 );
+  QVERIFY( layer2->elevationProperties()->showByDefaultInElevationProfilePlots() );
+
+  QgsElevationProfile *profile = new QgsElevationProfile( QgsProject::instance() );
+  QgsElevationProfileWidget::applyDefaultSettingsToProfile( profile );
+  QgsElevationProfileWidget *profileWidget = new QgsElevationProfileWidget( profile, mQgisApp->mapCanvas() );
+  QVERIFY( profileWidget->profile() );
+  QVERIFY( profile->layerTree()->findLayer( layer1 ) );
+  QCOMPARE( profile->layerTree()->children().size(), 2 );
+
+  // Register a custom profile and check that there is a custom node in the tree view
+  MyDummyProfileSource *source = new MyDummyProfileSource();
+  QVERIFY( QgsApplication::profileSourceRegistry()->registerProfileSource( source ) );
+  QVERIFY( profile->layerTree() );
+  QCOMPARE( profile->layerTree()->children().size(), 3 );
+  QCOMPARE( profile->layerTree()->findCustomNodeIds().size(), 1 );
+
+  // close widget and wait for deletion
+  QSignalSpy spy( profileWidget, &QObject::destroyed );
+  profileWidget->close();
+  QVERIFY( spy.wait( 1000 ) );
+
+  QgsVectorLayer *layer3 = new QgsVectorLayer( layerPath, u"points 3"_s, u"ogr"_s );
+
+  QgsProject::instance()->removeMapLayers( QList<QgsMapLayer *>() << layer2 );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << layer3 );
+
+  // enable show by default
+  layer3->elevationProperties()->setZOffset( 1.0 );
+  QVERIFY( layer3->elevationProperties()->showByDefaultInElevationProfilePlots() );
+
+  // Unregister the custom profile and check that the custom node persists in the closed profile
+  QVERIFY( QgsApplication::profileSourceRegistry()->unregisterProfileSource( u"my-dummy-profile"_s ) );
+
+  profileWidget = new QgsElevationProfileWidget( profile, mQgisApp->mapCanvas() );
+  QVERIFY( profileWidget->profile() );
+
+  QVERIFY( profile->layerTree()->findLayer( layer1 ) );
+  QVERIFY( profile->layerTree()->findLayer( layer3 ) );
+
+  QCOMPARE( profile->layerTree()->findCustomNodeIds().size(), 1 );
+  QCOMPARE( profile->layerTree()->children().size(), 3 );
 }
 
 QGSTEST_MAIN( TestQgsAppElevationProfileWidget )


### PR DESCRIPTION
## Description
When reopening a closed elevation profile view, the profile's layer tree can be out of sync with the actual ToC.
Any layer removed while the view was closed appears as a ghost layerTreeLayer, while new layers added while the view was closed are missing and cannot be added using Add Layer.

With this suggested approach:
- we remove from the profile's layer tree any map layers that have been removed from the project while the view was closed
- we add to the profile's layer tree any (profile compatible) map layers that have been added to the project while the view was closed
- we make sure the added layers are _unchecked_ initially, so that the stored profile view looks as close to the stored state as possible
- we make sure any custom profile sources are untouched (unavailable custom sources should be treated as unavailable layers: don't remove them as they might be available for other users)

Fixes #66889 
Fixes #66890 

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
