### PR TITLE
Add support for SFCGAL validation engine

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -4017,6 +4017,9 @@ QgsGeometry.ValidatorGeos = Qgis.GeometryValidationEngine.Geos
 QgsGeometry.ValidationMethod.ValidatorGeos = Qgis.GeometryValidationEngine.Geos
 QgsGeometry.ValidatorGeos.is_monkey_patched = True
 QgsGeometry.ValidatorGeos.__doc__ = "Use GEOS validation methods"
+QgsGeometry.Sfcgal = Qgis.GeometryValidationEngine.Sfcgal
+QgsGeometry.Sfcgal.is_monkey_patched = True
+QgsGeometry.Sfcgal.__doc__ = "Use SFCGAL validation methods. Only available for QGIS builds with SFCGAL support enabled. \n.. versionadded:: 4.4"
 Qgis.GeometryValidationEngine.__doc__ = """Available engines for validating geometries.
 
 .. versionadded:: 3.22
@@ -4028,6 +4031,10 @@ Qgis.GeometryValidationEngine.__doc__ = """Available engines for validating geom
 * ``Geos``: Use GEOS validation methods
 
   Available as ``QgsGeometry.ValidatorGeos`` in older QGIS releases.
+
+* ``Sfcgal``: Use SFCGAL validation methods. Only available for QGIS builds with SFCGAL support enabled.
+
+  .. versionadded:: 4.4
 
 
 """

--- a/python/PyQt6/core/auto_additions/qgsgeometryvalidator.py
+++ b/python/PyQt6/core/auto_additions/qgsgeometryvalidator.py
@@ -2,6 +2,7 @@
 try:
     QgsGeometryValidator.__attribute_docs__ = {'errorFound': 'Sent when an error has been found during the validation process.\n\nThe ``error`` contains details about the error.\n', 'validationFinished': 'Sent when the validation is finished.\n\nThe result is in a human readable ``summary``, mentioning if the\nvalidation has been aborted, successfully been validated or how many\nerrors have been found.\n\n.. versionadded:: 3.6\n'}
     QgsGeometryValidator.validateGeometry = staticmethod(QgsGeometryValidator.validateGeometry)
+    QgsGeometryValidator.defaultValidationEngine = staticmethod(QgsGeometryValidator.defaultValidationEngine)
     QgsGeometryValidator.__overridden_methods__ = ['run']
     QgsGeometryValidator.__signal_arguments__ = {'errorFound': ['error: QgsGeometry.Error'], 'validationFinished': ['summary: str']}
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -3252,6 +3252,8 @@ Validates geometry and produces a list of geometry errors. The
 
 The ``flags`` parameter indicates optional flags which control the type
 of validity checking performed.
+
+:raises QgsNotSupportedException: when method is not supported
 %End
 
     void normalize();

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1298,6 +1298,7 @@ The development version
       {
       QgisInternal,
       Geos,
+      Sfcgal,
     };
 
     enum class BufferSide /BaseType=IntEnum/

--- a/python/PyQt6/core/auto_generated/qgsgeometryvalidator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsgeometryvalidator.sip.in
@@ -36,6 +36,16 @@ Validate geometry and produce a list of geometry errors. This method
 blocks the thread until the validation is finished.
 %End
 
+    static Qgis::GeometryValidationEngine defaultValidationEngine();
+%Docstring
+Returns the geometry validation engine configured in the application
+settings.
+
+:return: The geometry validation engine to use.
+
+.. versionadded:: 4.4
+%End
+
   signals:
 
     void errorFound( const QgsGeometry::Error &error );

--- a/src/analysis/processing/qgsalgorithmcheckvalidity.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckvalidity.cpp
@@ -63,7 +63,8 @@ QString QgsCheckValidityAlgorithm::shortHelpString() const
     "lenient validity check will be performed.\n\n"
     "The GEOS method is faster and performs better on larger geometries, but is limited to only "
     "returning the first error encountered in a geometry. The QGIS method will be slower but "
-    "reports all errors encountered in the geometry, not just the first."
+    "reports all errors encountered in the geometry, not just the first. The SFCGAL method "
+    "performs 3D validity checks, and should be used when validating three-dimensional geometries."
   );
 }
 
@@ -84,7 +85,7 @@ void QgsCheckValidityAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( u"INPUT_LAYER"_s, QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorAnyGeometry ) ) );
 
-  const QStringList options = QStringList() << QObject::tr( "The one selected in digitizing settings" ) << u"QGIS"_s << u"GEOS"_s;
+  const QStringList options = QStringList() << QObject::tr( "The one selected in digitizing settings" ) << u"QGIS"_s << u"GEOS"_s << u"SFCGAL"_s;
   auto methodParam = std::make_unique<QgsProcessingParameterEnum>( u"METHOD"_s, QObject::tr( "Method" ), options, false, 2 );
   QVariantMap methodParamMetadata;
   QVariantMap widgetMetadata;
@@ -103,22 +104,33 @@ void QgsCheckValidityAlgorithm::initAlgorithm( const QVariantMap & )
   addOutput( new QgsProcessingOutputNumber( u"ERROR_COUNT"_s, QObject::tr( "Count of errors" ) ) );
 }
 
+bool QgsCheckValidityAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  mValidationMethod = parameterAsEnum( parameters, u"METHOD"_s, context );
+  if ( mValidationMethod == 0 )
+  {
+    const int methodFromSettings = QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() - 1;
+    mValidationMethod = methodFromSettings > 0 ? methodFromSettings : 0;
+  }
+  else
+  {
+    mValidationMethod--;
+  }
+
+  // SFCGAL method selected but SFCGAL support is disabled
+  if ( mValidationMethod == 2 && !Qgis::hasSfcgal() )
+  {
+    throw QgsProcessingException( QObject::tr( "SFCGAL validation method requires a QGIS installation with SFCGAL support enabled. Please use a version of QGIS that includes SFCGAL." ) );
+  }
+
+  return true;
+}
+
 QVariantMap QgsCheckValidityAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   std::unique_ptr<QgsProcessingFeatureSource> source( parameterAsSource( parameters, u"INPUT_LAYER"_s, context ) );
   if ( !source )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT_LAYER"_s ) );
-
-  int method = parameterAsEnum( parameters, u"METHOD"_s, context );
-  if ( method == 0 )
-  {
-    const int methodFromSettings = QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() - 1;
-    method = methodFromSettings > 0 ? methodFromSettings : 0;
-  }
-  else
-  {
-    method--;
-  }
 
   const bool ignoreRingSelfIntersection = parameterAsBool( parameters, u"IGNORE_RING_SELF_INTERSECTION"_s, context );
 
@@ -162,7 +174,7 @@ QVariantMap QgsCheckValidityAlgorithm::processAlgorithm( const QVariantMap &para
     if ( !geom.isNull() && !geom.isEmpty() )
     {
       QVector< QgsGeometry::Error > errors;
-      geom.validateGeometry( errors, Qgis::GeometryValidationEngine( method ), flags );
+      geom.validateGeometry( errors, Qgis::GeometryValidationEngine( mValidationMethod ), flags );
       if ( errors.count() > 0 )
       {
         isValid = false;

--- a/src/analysis/processing/qgsalgorithmcheckvalidity.h
+++ b/src/analysis/processing/qgsalgorithmcheckvalidity.h
@@ -51,7 +51,11 @@ class QgsCheckValidityAlgorithm : public QgsProcessingAlgorithm
     QgsCheckValidityAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+    int mValidationMethod = 0;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/vector/geometry_checker/qgsgeometryisvalidcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryisvalidcheck.cpp
@@ -16,8 +16,6 @@ email                : matthias@opengis.ch
 #include "qgsgeometryisvalidcheck.h"
 
 #include "qgsgeometryvalidator.h"
-#include "qgssettingsentryimpl.h"
-#include "qgssettingsregistrycore.h"
 
 #include <QString>
 
@@ -36,10 +34,7 @@ QList<QgsSingleGeometryCheckError *> QgsGeometryIsValidCheck::processGeometry( c
 {
   QVector<QgsGeometry::Error> errors;
 
-  Qgis::GeometryValidationEngine method = Qgis::GeometryValidationEngine::QgisInternal;
-  if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() == 2 )
-    method = Qgis::GeometryValidationEngine::Geos;
-
+  Qgis::GeometryValidationEngine method = QgsGeometryValidator::defaultValidationEngine();
   QgsGeometryValidator validator( geometry, &errors, method );
 
   QObject::connect( &validator, &QgsGeometryValidator::errorFound, &validator, [&errors]( const QgsGeometry::Error &error ) { errors.append( error ); } );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1164,6 +1164,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mValidateGeometries->addItem( tr( "Off" ) );
   mValidateGeometries->addItem( tr( "QGIS" ) );
   mValidateGeometries->addItem( tr( "GEOS" ) );
+  if ( Qgis::hasSfcgal() )
+  {
+    mValidateGeometries->addItem( tr( "SFCGAL" ) );
+  }
 
   QString markerStyle = QgsSettingsRegistryCore::settingsDigitizingMarkerStyle->value();
   if ( markerStyle == "SemiTransparentCircle"_L1 )

--- a/src/app/vertextool/qgslockedfeature.cpp
+++ b/src/app/vertextool/qgslockedfeature.cpp
@@ -151,9 +151,7 @@ void QgsLockedFeature::validateGeometry( QgsGeometry *g )
     delete vm;
   }
 
-  Qgis::GeometryValidationEngine method = Qgis::GeometryValidationEngine::QgisInternal;
-  if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() == 2 )
-    method = Qgis::GeometryValidationEngine::Geos;
+  Qgis::GeometryValidationEngine method = QgsGeometryValidator::defaultValidationEngine();
   mValidator = new QgsGeometryValidator( *g, nullptr, method );
   connect( mValidator, &QgsGeometryValidator::errorFound, this, &QgsLockedFeature::addError );
   connect( mValidator, &QThread::finished, this, &QgsLockedFeature::validationFinished );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -3201,10 +3201,8 @@ void QgsVertexTool::GeometryValidation::start( QgsGeometry &geom, QgsVertexTool 
 {
   tool = t;
   layer = l;
-  Qgis::GeometryValidationEngine method = Qgis::GeometryValidationEngine::QgisInternal;
-  if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() == 2 )
-    method = Qgis::GeometryValidationEngine::Geos;
 
+  Qgis::GeometryValidationEngine method = QgsGeometryValidator::defaultValidationEngine();
   validator = new QgsGeometryValidator( geom, nullptr, method );
   connect( validator, &QgsGeometryValidator::errorFound, tool, &QgsVertexTool::validationErrorFound );
   connect( validator, &QThread::finished, tool, &QgsVertexTool::validationFinished );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -47,6 +47,12 @@ email                : morb at ozemail dot com dot au
 #include "qgstriangulatedsurface.h"
 #include "qgsvectorlayer.h"
 
+#include <QString>
+
+#ifdef WITH_SFCGAL
+#include "qgssfcgalgeometry.h"
+#endif
+
 #include <QCache>
 #include <QString>
 
@@ -3845,6 +3851,30 @@ void QgsGeometry::validateGeometry( QVector<QgsGeometry::Error> &errors, const Q
         }
         return;
       }
+      break;
+    }
+    case Qgis::GeometryValidationEngine::Sfcgal:
+    {
+#ifdef WITH_SFCGAL
+      QString errorMsg;
+      QgsGeometry errorLoc;
+      const QgsSfcgalGeometry sfcgalGeom( d->geometry.get() );
+      if ( !QgsSfcgalEngine::isValid( sfcgalGeom.sfcgalGeometry().get(), nullptr, &errorMsg, &errorLoc ) )
+      {
+        if ( errorLoc.isNull() )
+        {
+          errors.append( QgsGeometry::Error( errorMsg ) );
+        }
+        else
+        {
+          const QgsPointXY point = errorLoc.asPoint();
+          errors.append( QgsGeometry::Error( errorMsg, point ) );
+        }
+        return;
+      }
+#else
+      throw QgsNotSupportedException( u"This operation requires a QGIS installation with SFCGAL support enabled. Please use a version of QGIS that includes SFCGAL."_s );
+#endif
     }
   }
 }

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -3122,6 +3122,8 @@ class CORE_EXPORT QgsGeometry
      *
      * The \a flags parameter indicates optional flags which control the type of validity checking performed.
      *
+     * \throws QgsNotSupportedException when method is not supported
+     *
      */
     void validateGeometry( QVector<QgsGeometry::Error> &errors SIP_OUT, Qgis::GeometryValidationEngine method = Qgis::GeometryValidationEngine::QgisInternal, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
 

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -592,7 +592,7 @@ bool QgsSfcgalEngine::isEmpty( const sfcgal::geometry *geom, QString *errorMsg )
   return static_cast<bool>( res );
 }
 
-bool QgsSfcgalEngine::isValid( const sfcgal::geometry *geom, QString *errorMsg, QgsGeometry *errorLoc )
+bool QgsSfcgalEngine::isValid( const sfcgal::geometry *geom, QString *errorMsg, QString *reasonMsg, QgsGeometry *errorLoc )
 {
   sfcgal::errorHandler()->clearText( errorMsg );
   CHECK_NOT_NULL( geom, false );
@@ -606,7 +606,10 @@ bool QgsSfcgalEngine::isValid( const sfcgal::geometry *geom, QString *errorMsg, 
 
   if ( reason && strlen( reason ) )
   {
-    sfcgal::errorHandler()->addText( QString( reason ) );
+    if ( reasonMsg )
+    {
+      *reasonMsg = QString( reason );
+    }
     free( reason );
   }
 

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -598,8 +598,8 @@ bool QgsSfcgalEngine::isValid( const sfcgal::geometry *geom, QString *errorMsg, 
   CHECK_NOT_NULL( geom, false );
 
   bool result = false;
-  char *reason;
-  sfcgal::geometry *location;
+  char *reason = nullptr;
+  sfcgal::geometry *location = nullptr;
   result = sfcgal_geometry_is_valid_detail( geom, &reason, &location );
 
   CHECK_SUCCESS( errorMsg, false );

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -406,13 +406,14 @@ class CORE_EXPORT QgsSfcgalEngine
     /**
      * Checks if \a geom is valid.
      *
-     * If the geometry is invalid, \a errorMsg will be filled with the reported geometry error.
+     * If the geometry is invalid, \a reasonMsg will be filled with the reported geometry error.
      *
      * \param geom geometry to perform the operation
-     * \param errorMsg Error message returned by SFGCAL
+     * \param errorMsg Error message returned by SFGCAL if the operation fails
+     * \param reasonMsg If the geometry is invalid, reasonMsg will be filled with the reported geometry error.
      * \param errorLoc if specified, it will be set to the geometry of the error location.
      */
-    static bool isValid( const sfcgal::geometry *geom, QString *errorMsg = nullptr, QgsGeometry *errorLoc = nullptr );
+    static bool isValid( const sfcgal::geometry *geom, QString *errorMsg = nullptr, QString *reasonMsg = nullptr, QgsGeometry *errorLoc = nullptr );
 
     /**
      * Checks if \a geom is simple.

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2219,6 +2219,7 @@ int QgisEvent = QEvent::User + 1;
       {
       QgisInternal SIP_MONKEYPATCH_COMPAT_NAME( ValidatorQgisInternal ), //!< Use internal QgsGeometryValidator method
       Geos SIP_MONKEYPATCH_COMPAT_NAME( ValidatorGeos ), //!< Use GEOS validation methods
+      Sfcgal, //!< Use SFCGAL validation methods. Only available for QGIS builds with SFCGAL support enabled. \since QGIS 4.4
     };
     Q_ENUM( GeometryValidationEngine )
 

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -22,6 +22,8 @@ email                : jef at norbit dot de
 #include "qgsgeometrycollection.h"
 #include "qgsgeos.h"
 #include "qgslogger.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsvertexid.h"
 
 #include <QString>
@@ -426,7 +428,7 @@ void QgsGeometryValidator::run()
         }
       }
 #else
-      QgsDebugError( u"Cannot use SFCGAL validation method in this QGIS build."_s ) );
+      QgsDebugError( u"Cannot use SFCGAL validation method in this QGIS build."_s );
 #endif
 
       break;
@@ -523,4 +525,12 @@ bool QgsGeometryValidator::ringInRing( const QgsCurve *inside, const QgsCurve *o
   }
 
   return true;
+}
+
+Qgis::GeometryValidationEngine QgsGeometryValidator::defaultValidationEngine()
+{
+  if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() == 2 )
+    return Qgis::GeometryValidationEngine::Geos;
+
+  return Qgis::GeometryValidationEngine::QgisInternal;
 }

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -24,6 +24,14 @@ email                : jef at norbit dot de
 #include "qgslogger.h"
 #include "qgsvertexid.h"
 
+#include <QString>
+
+using namespace Qt::StringLiterals;
+
+#ifdef WITH_SFCGAL
+#include "qgssfcgalgeometry.h"
+#endif
+
 #include "moc_qgsgeometryvalidator.cpp"
 
 QgsGeometryValidator::QgsGeometryValidator( const QgsGeometry &geometry, QVector<QgsGeometry::Error> *errors, Qgis::GeometryValidationEngine method )
@@ -388,6 +396,39 @@ void QgsGeometryValidator::run()
       {
         emit validationFinished( QObject::tr( "Geometry is valid." ) );
       }
+      break;
+    }
+
+    case Qgis::GeometryValidationEngine::Sfcgal:
+    {
+      // avoid calling SFCGAL for trivial point geometries
+      if ( QgsWkbTypes::geometryType( mGeometry.wkbType() ) == Qgis::GeometryType::Point )
+      {
+        return;
+      }
+
+#ifdef WITH_SFCGAL
+      QString errorMsg;
+      QgsGeometry errorLoc;
+      const QgsSfcgalGeometry sfcgalGeom( mGeometry.constGet() );
+      if ( !QgsSfcgalEngine::isValid( sfcgalGeom.sfcgalGeometry().get(), nullptr, &errorMsg, &errorLoc ) )
+      {
+        if ( errorLoc.isNull() )
+        {
+          emit errorFound( QgsGeometry::Error( errorMsg ) );
+          mErrorCount++;
+        }
+        else
+        {
+          const QgsPointXY point = errorLoc.asPoint();
+          emit errorFound( QgsGeometry::Error( errorMsg, point ) );
+          mErrorCount++;
+        }
+      }
+#else
+      QgsDebugError( u"Cannot use SFCGAL validation method in this QGIS build."_s ) );
+#endif
+
       break;
     }
   }

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -530,7 +530,13 @@ bool QgsGeometryValidator::ringInRing( const QgsCurve *inside, const QgsCurve *o
 Qgis::GeometryValidationEngine QgsGeometryValidator::defaultValidationEngine()
 {
   if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() == 2 )
+  {
     return Qgis::GeometryValidationEngine::Geos;
+  }
+  else if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() == 3 )
+  {
+    return Qgis::GeometryValidationEngine::Sfcgal;
+  }
 
   return Qgis::GeometryValidationEngine::QgisInternal;
 }

--- a/src/core/qgsgeometryvalidator.h
+++ b/src/core/qgsgeometryvalidator.h
@@ -49,6 +49,14 @@ class CORE_EXPORT QgsGeometryValidator : public QThread
      */
     static void validateGeometry( const QgsGeometry &geometry, QVector<QgsGeometry::Error> &errors SIP_OUT, Qgis::GeometryValidationEngine method = Qgis::GeometryValidationEngine::QgisInternal );
 
+    /**
+     * Returns the geometry validation engine configured in the application settings.
+     *
+     * \returns The geometry validation engine to use.
+     * \since QGIS 4.4
+     */
+    static Qgis::GeometryValidationEngine defaultValidationEngine();
+
   signals:
 
     /**

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -1501,9 +1501,7 @@ void QgsMapToolCapture::validateGeometry()
   if ( geom.isNull() )
     return;
 
-  Qgis::GeometryValidationEngine method = Qgis::GeometryValidationEngine::QgisInternal;
-  if ( QgsSettingsRegistryCore::settingsDigitizingValidateGeometries->value() == 2 )
-    method = Qgis::GeometryValidationEngine::Geos;
+  Qgis::GeometryValidationEngine method = QgsGeometryValidator::defaultValidationEngine();
   mValidator = new QgsGeometryValidator( geom, nullptr, method );
   connect( mValidator, &QgsGeometryValidator::errorFound, this, &QgsMapToolCapture::addError );
   mValidator->start();

--- a/tests/src/analysis/testqgsprocessingalgspt2.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt2.cpp
@@ -2482,6 +2482,22 @@ void TestQgsProcessingAlgsPt2::checkValidity()
   it = invalidLayer->getFeatures();
   it.nextFeature( f );
   QCOMPARE( f.attributes(), QgsAttributes() << 1 << u"Self-intersection"_s );
+
+#ifdef WITH_SFCGAL
+  // SFCGAL method
+  parameters.insert( u"METHOD"_s, 3 );
+
+  ok = false;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  invalidLayer = qobject_cast<QgsVectorLayer *>( context->getMapLayer( results.value( u"INVALID_OUTPUT"_s ).toString() ) );
+  QCOMPARE( invalidLayer->fields().at( invalidLayer->fields().size() - 1 ).name(), u"_errors"_s );
+  QCOMPARE( invalidLayer->featureCount(), 1 );
+  it = invalidLayer->getFeatures();
+  it.nextFeature( f );
+  QCOMPARE( f.attributes(), QgsAttributes() << 1 << u"ring 0 self intersects"_s );
+#endif
 }
 
 void TestQgsProcessingAlgsPt2::hypsometricCurves()

--- a/tests/src/core/geometry/testqgssfcgal.cpp
+++ b/tests/src/core/geometry/testqgssfcgal.cpp
@@ -75,6 +75,7 @@ class TestQgsSfcgal : public QgsTest
 
     void fromWkt();
     void isEqual();
+    void isValid();
     void boundary();
     void centroid();
     void dropZ();
@@ -491,6 +492,34 @@ void TestQgsSfcgal::isEqual()
   QVERIFY2( *cubeSmallTranslate.get() != *cube.get(), "cubes should not be equals" );
   QVERIFY2( cubeSmallTranslate->fuzzyEqual( *( cube.get() ), 0.01 ), "Cubes Should be fuzzy equals" );
 #endif
+}
+
+void TestQgsSfcgal::isValid()
+{
+  bool isValid = false;
+  QString errorMsg;
+  QString reasonMsg;
+
+  // valid polygon
+  auto sfcgalPolygon3D = std::make_unique<QgsSfcgalGeometry>( mSfcgalPolygonZA );
+  isValid = sfcgalPolygon3D->isValid();
+  QVERIFY( isValid );
+
+  isValid = QgsSfcgalEngine::isValid( sfcgalPolygon3D->sfcgalGeometry().get(), &errorMsg, &reasonMsg );
+  QVERIFY( isValid );
+  QVERIFY( errorMsg.isEmpty() );
+  QVERIFY( reasonMsg.isEmpty() );
+
+  // invalid polygon
+  QString invalid_polygon_wkt = u"POLYGON((0 0, 4 0, 4 4, 0 4, 0 0),(4 2, 5 2, 5 3, 4 3, 4 2))"_s;
+  QgsSfcgalGeometry sfcgalInvalidPolygon( invalid_polygon_wkt );
+  isValid = sfcgalInvalidPolygon.isValid();
+  QVERIFY( !isValid );
+
+  isValid = QgsSfcgalEngine::isValid( sfcgalInvalidPolygon.sfcgalGeometry().get(), &errorMsg, &reasonMsg );
+  QVERIFY( !isValid );
+  QVERIFY( errorMsg.isEmpty() );
+  QCOMPARE( reasonMsg, u"exterior ring and interior ring 0 have the same orientation"_s );
 }
 
 void TestQgsSfcgal::boundary()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -12768,13 +12768,14 @@ class TestQgsGeometry(QgisTestCase):
 
     def testValidateGeometry(self):
         tests = [
-            ["", [], [], []],
-            ["Point (100 100)", [], [], []],
-            ["MultiPoint (100 100, 100 200)", [], [], []],
-            ["LINESTRING (0 0, 0 100, 100 100)", [], [], []],
-            ["POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))", [], [], []],
+            ["", [], [], [], []],
+            ["Point (100 100)", [], [], [], []],
+            ["MultiPoint (100 100, 100 200)", [], [], [], []],
+            ["LINESTRING (0 0, 0 100, 100 100)", [], [], [], []],
+            ["POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))", [], [], [], []],
             [
                 "MULTIPOLYGON(Polygon((-1 -1, 4 0, 4 2, 0 2, -1 -1)),Polygon((100 100, 200 100, 200 200, 100 200, 100 100)))",
+                [],
                 [],
                 [],
                 [],
@@ -12784,6 +12785,7 @@ class TestQgsGeometry(QgisTestCase):
                 [QgsGeometry.Error("Ring self-intersection", QgsPointXY(300, 200))],
                 [],
                 [],
+                [QgsGeometry.Error("ring 0 self intersects")],
             ],
             [
                 "MultiPolygon (((159865.14786298031685874 6768656.31838363595306873, 159858.97975336571107619 6769211.44824895076453686, 160486.07089751763851382 6769211.44824895076453686, 160481.95882444124436006 6768658.37442017439752817, 160163.27316101978067309 6768658.37442017439752817, 160222.89822062765597366 6769116.87056819349527359, 160132.43261294672265649 6769120.98264127038419247, 160163.27316101978067309 6768658.37442017439752817, 159865.14786298031685874 6768656.31838363595306873)))",
@@ -12795,6 +12797,7 @@ class TestQgsGeometry(QgisTestCase):
                 ],
                 [],
                 [],
+                [QgsGeometry.Error("Polygon 0 is invalid: ring 0 self intersects")],
             ],
             [
                 "Polygon((0 3, 3 0, 3 3, 0 0, 0 3))",
@@ -12806,9 +12809,18 @@ class TestQgsGeometry(QgisTestCase):
                         QgsPointXY(1.5, 1.5),
                     )
                 ],
+                [QgsGeometry.Error("ring 0 self intersects")],
+            ],
+            [
+                "POLYGON Z ((0 0 0, 1 0 0, 1 1 0.001, 0 1 0, 0 0 0))",
+                [],
+                [],
+                [],
+                [QgsGeometry.Error("points don't lie in the same plane")],
             ],
         ]
         for t in tests:
+            # Geos
             g1 = QgsGeometry.fromWkt(t[0])
             res = g1.validateGeometry(QgsGeometry.ValidationMethod.ValidatorGeos)
             self.assertEqual(
@@ -12818,6 +12830,8 @@ class TestQgsGeometry(QgisTestCase):
                     t[0], t[1], res[0].where() if res else ""
                 ),
             )
+
+            # Geos - allows self touching holes
             res = g1.validateGeometry(
                 QgsGeometry.ValidationMethod.ValidatorGeos,
                 QgsGeometry.ValidityFlag.FlagAllowSelfTouchingHoles,
@@ -12829,6 +12843,8 @@ class TestQgsGeometry(QgisTestCase):
                     t[0], t[2], res[0].where() if res else ""
                 ),
             )
+
+            # QGIS
             res = g1.validateGeometry(
                 QgsGeometry.ValidationMethod.ValidatorQgisInternal
             )
@@ -12839,6 +12855,17 @@ class TestQgsGeometry(QgisTestCase):
                     t[0], t[3], res[0].where() if res else ""
                 ),
             )
+
+            # SFCGAL
+            if Qgis.hasSfcgal():
+                res = g1.validateGeometry(QgsGeometry.ValidationMethod.Sfcgal)
+                self.assertEqual(
+                    res,
+                    t[4],
+                    "mismatch for {}, expected:\n{}\nGot:\n{}\n".format(
+                        t[0], t[4], res[0].where() if res else ""
+                    ),
+                )
 
     def testCollectDuplicateNodes(self):
         g = QgsGeometry.fromWkt(

--- a/tests/src/python/test_qgsgeometryvalidator.py
+++ b/tests/src/python/test_qgsgeometryvalidator.py
@@ -12,7 +12,7 @@ __copyright__ = "Copyright 2016, The QGIS Project"
 
 import unittest
 
-from qgis.core import QgsGeometry, QgsGeometryValidator, QgsPointXY
+from qgis.core import Qgis, QgsGeometry, QgsGeometryValidator, QgsPointXY
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.testing import QgisTestCase, start_app
 
@@ -418,6 +418,27 @@ class TestQgsGeometryValidator(QgisTestCase):
             spy[0][0].what(),
             "ring 1 of polygon 0 not in exterior ring",
         )
+
+    def test_polygon_z_coplanar(self):
+        # The polygon is valid in 2D (its XY projection is a valid polygon), so
+        # QGIS and GEOS do not report any errors. However,
+        # SFCGAL performs a 3D validity checks and reports an error.
+        geom = QgsGeometry.fromWkt(
+            "POLYGON Z ((0 0 0, 1 0 0, 1 1 0.001, 0 1 0, 0 0 0))"
+        )
+        tests = [
+            (Qgis.GeometryValidationEngine.QgisInternal, 0),
+            (Qgis.GeometryValidationEngine.Geos, 0),
+        ]
+
+        if Qgis.hasSfcgal():
+            tests.append((Qgis.GeometryValidationEngine.Sfcgal, 1))
+
+        for method, expected_spy in tests:
+            validator = QgsGeometryValidator(geom, method=method)
+            spy = QSignalSpy(validator.errorFound)
+            validator.run()
+            self.assertEqual(len(spy), expected_spy)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This adds support for SFCGAL geometry validation backend. This is mostly useful for 3D geometries such as Polygon and PolyhedralSurface, which GEOS validation engine is not able to properly inspect at the moment. 

This adds the following support:
- Add support for SFCGAL engine in `QgsGeometryValidator`
- Add support for SFCGAL engine in `QgsGeometry::validateGeometry`
- Expose a new `SFCGAL` option in `DigitizingValidateGeometries` settings
- Add support for SFCGAL engine in `checkvalidity` processing

## AI tool usage

No AI tool used

