### PR TITLE
Fix add part crash with avoid overlaps

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1431,6 +1431,8 @@ Adds a new polygon part to a multipart feature.
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 
 
+
+.. versionadded:: 4.4
 %End
 
     int translateFeature( QgsFeatureId featureId, double dx, double dy );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1419,6 +1419,20 @@ Adds a new ring to a multipart feature.
 
 %End
 
+    Qgis::GeometryOperationResult addPart( QgsCurvePolygon *polygon /Transfer/ ) /PyName=addPolygonPart/;
+%Docstring
+Adds a new polygon part to a multipart feature.
+
+.. note::
+
+   Calls to :py:func:`~QgsVectorLayer.addPart` are only valid for layers in which edits have been enabled
+   by a call to :py:func:`~QgsVectorLayer.startEditing`. Changes made to features using this method are not committed
+   to the underlying data provider until a :py:func:`~QgsVectorLayer.commitChanges` call is made. Any uncommitted
+   changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+
+
+%End
+
     int translateFeature( QgsFeatureId featureId, double dx, double dy );
 %Docstring
 Translates feature by dx, dy

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -194,6 +194,8 @@ Adds a new polygon part to a multipart or geometryless feature
          - :py:class:`QgsGeometry`.InvalidInput
 
 
+
+.. versionadded:: 4.4
 %End
 
     int translateFeature( QgsFeatureId featureId, double dx, double dy );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -169,7 +169,22 @@ Adds a new part polygon to a multipart feature
 
     Qgis::GeometryOperationResult addPart( QgsCurve *ring /Transfer/, QgsFeatureId featureId ) /PyName=addCurvedPart/;
 %Docstring
-Adds a new part polygon to a multipart feature
+Adds a new polygon part consisting of an exterior ``ring`` only to a
+multipart or geometryless feature
+
+:return: - :py:class:`QgsGeometry`.Success
+
+         - :py:class:`QgsGeometry`.AddPartSelectedGeometryNotFound
+         - :py:class:`QgsGeometry`.AddPartNotMultiGeometry
+         - :py:class:`QgsGeometry`.InvalidBaseGeometry
+         - :py:class:`QgsGeometry`.InvalidInput
+
+
+%End
+
+    Qgis::GeometryOperationResult addPart( QgsCurvePolygon *polygon /Transfer/, QgsFeatureId featureId ) /PyName=addPolygonPart/;
+%Docstring
+Adds a new polygon part to a multipart or geometryless feature
 
 :return: - :py:class:`QgsGeometry`.Success
 

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -80,37 +80,50 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   QgsMapToolCapture::cadCanvasReleaseEvent( e );
 }
 
-void QgsMapToolAddPart::layerPointCaptured( const QgsPoint &point )
+void QgsMapToolAddPart::layerGeometryCaptured( const QgsGeometry &geometry )
 {
   QgsVectorLayer *layer = getLayerAndCheckSelection();
   if ( !layer )
     return;
+
   layer->beginEditCommand( tr( "Part added" ) );
-  Qgis::GeometryOperationResult errorCode = layer->addPart( QgsPointSequence() << point );
-  finalizeEditCommand( layer, errorCode );
+
+
+  const QVector<QgsGeometry> geomCollection = geometry.asGeometryCollection();
+
+  Qgis::GeometryOperationResult errorCode = Qgis::GeometryOperationResult::NothingHappened;
+  for ( const QgsGeometry &item : geomCollection )
+  {
+    switch ( item.type() )
+    {
+      case Qgis::GeometryType::Point:
+      {
+        auto pt = *qgsgeometry_cast<const QgsPoint *>( item.constGet() );
+        errorCode = layer->addPart( QgsPointSequence() << pt );
+        break;
+      }
+      case Qgis::GeometryType::Line:
+      {
+        auto line = qgsgeometry_cast<const QgsCurve *>( item.constGet() );
+        errorCode = layer->addPart( line->clone() );
+        break;
+      }
+      case Qgis::GeometryType::Polygon:
+      {
+        auto polygon = qgsgeometry_cast<const QgsCurvePolygon *>( item.constGet() );
+        errorCode = layer->addPart( polygon->clone() );
+        break;
+      }
+      case Qgis::GeometryType::Null:
+      case Qgis::GeometryType::Unknown:
+        break;
+    }
+  }
+
+  finalizeEditCommand( layer, geometry, errorCode );
 }
 
-void QgsMapToolAddPart::layerLineCaptured( const QgsCurve *line )
-{
-  QgsVectorLayer *layer = getLayerAndCheckSelection();
-  if ( !layer )
-    return;
-  layer->beginEditCommand( tr( "Part added" ) );
-  Qgis::GeometryOperationResult errorCode = layer->addPart( line->clone() );
-  finalizeEditCommand( layer, errorCode );
-}
-
-void QgsMapToolAddPart::layerPolygonCaptured( const QgsCurvePolygon *polygon )
-{
-  QgsVectorLayer *layer = getLayerAndCheckSelection();
-  if ( !layer )
-    return;
-  layer->beginEditCommand( tr( "Part added" ) );
-  Qgis::GeometryOperationResult errorCode = layer->addPart( polygon->exteriorRing()->clone() );
-  finalizeEditCommand( layer, errorCode );
-}
-
-void QgsMapToolAddPart::finalizeEditCommand( QgsVectorLayer *layer, Qgis::GeometryOperationResult errorCode )
+void QgsMapToolAddPart::finalizeEditCommand( QgsVectorLayer *layer, const QgsGeometry &topologicalCandidates, Qgis::GeometryOperationResult errorCode )
 {
   QString errorMessage;
   switch ( errorCode )
@@ -124,7 +137,7 @@ void QgsMapToolAddPart::finalizeEditCommand( QgsVectorLayer *layer, Qgis::Geomet
       const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
       if ( topologicalEditing )
       {
-        addTopologicalPoints( pointsZM() );
+        ( void ) layer->addTopologicalPoints( topologicalCandidates );
       }
 
       layer->endEditCommand();

--- a/src/app/qgsmaptooladdpart.h
+++ b/src/app/qgsmaptooladdpart.h
@@ -43,11 +43,9 @@ class APP_EXPORT QgsMapToolAddPart : public QgsMapToolCaptureLayerGeometry
      */
     QgsVectorLayer *getLayerAndCheckSelection();
 
-    void layerPointCaptured( const QgsPoint &point ) override;
-    void layerLineCaptured( const QgsCurve *line ) override;
-    void layerPolygonCaptured( const QgsCurvePolygon *polygon ) override;
+    void layerGeometryCaptured( const QgsGeometry &geometry ) final;
 
-    void finalizeEditCommand( QgsVectorLayer *layer, Qgis::GeometryOperationResult errorCode );
+    void finalizeEditCommand( QgsVectorLayer *layer, const QgsGeometry &topologicalCandidates, Qgis::GeometryOperationResult errorCode );
 };
 
 #endif // QGSMAPTOOLADDPART_H

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -34,6 +34,7 @@
 #include "qgsconditionalstyle.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgscurve.h"
+#include "qgscurvepolygon.h"
 #include "qgsdatasourceuri.h"
 #include "qgsdiagramrenderer.h"
 #include "qgsexpressioncontext.h"
@@ -1683,6 +1684,36 @@ Qgis::GeometryOperationResult QgsVectorLayer::addPart( QgsCurve *ring )
 
   QgsVectorLayerEditUtils utils( this );
   Qgis::GeometryOperationResult result = utils.addPart( ring, *mSelectedFeatureIds.constBegin() );
+
+  if ( result == Qgis::GeometryOperationResult::Success )
+    updateExtents();
+  return result;
+}
+
+Qgis::GeometryOperationResult QgsVectorLayer::addPart( QgsCurvePolygon *polygon )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  std::unique_ptr<QgsCurvePolygon> uniquePtrPolygon( polygon );
+
+  if ( !isValid() || !mEditBuffer || !mDataProvider )
+    return Qgis::GeometryOperationResult::LayerNotEditable;
+
+  //number of selected features must be 1
+
+  if ( mSelectedFeatureIds.empty() )
+  {
+    QgsDebugMsgLevel( u"Number of selected features <1"_s, 3 );
+    return Qgis::GeometryOperationResult::SelectionIsEmpty;
+  }
+  else if ( mSelectedFeatureIds.size() > 1 )
+  {
+    QgsDebugMsgLevel( u"Number of selected features >1"_s, 3 );
+    return Qgis::GeometryOperationResult::SelectionIsGreaterThanOne;
+  }
+
+  QgsVectorLayerEditUtils utils( this );
+  Qgis::GeometryOperationResult result = utils.addPart( uniquePtrPolygon.release(), *mSelectedFeatureIds.constBegin() );
 
   if ( result == Qgis::GeometryOperationResult::Success )
     updateExtents();

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -1430,6 +1430,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * changes can be discarded by calling rollBack().
      *
      * \note available in Python as addPolygonPart
+     * \since QGIS 4.4
      */
     Q_INVOKABLE Qgis::GeometryOperationResult addPart( QgsCurvePolygon *polygon SIP_TRANSFER ) SIP_PYNAME( addPolygonPart );
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -55,6 +55,7 @@ class QgsAbstractGeometrySimplifier;
 class QgsActionManager;
 class QgsConditionalLayerStyles;
 class QgsCurve;
+class QgsCurvePolygon;
 class QgsDiagramLayerSettings;
 class QgsDiagramRenderer;
 class QgsEditorWidgetWrapper;
@@ -1419,6 +1420,18 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \note available in Python as addCurvedPart
      */
     Q_INVOKABLE Qgis::GeometryOperationResult addPart( QgsCurve *ring SIP_TRANSFER ) SIP_PYNAME( addCurvedPart );
+
+    /**
+     * Adds a new polygon part to a multipart feature.
+     *
+     * \note Calls to addPart() are only valid for layers in which edits have been enabled
+     * by a call to startEditing(). Changes made to features using this method are not committed
+     * to the underlying data provider until a commitChanges() call is made. Any uncommitted
+     * changes can be discarded by calling rollBack().
+     *
+     * \note available in Python as addPolygonPart
+     */
+    Q_INVOKABLE Qgis::GeometryOperationResult addPart( QgsCurvePolygon *polygon SIP_TRANSFER ) SIP_PYNAME( addPolygonPart );
 
     /**
      * Translates feature by dx, dy

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -18,6 +18,7 @@
 
 #include "qgis.h"
 #include "qgsabstractgeometry.h"
+#include "qgscurvepolygon.h"
 #include "qgsfeatureiterator.h"
 #include "qgsgeometryoptions.h"
 #include "qgslinestring.h"
@@ -429,6 +430,56 @@ Qgis::GeometryOperationResult QgsVectorLayerEditUtils::addPart( QgsCurve *ring, 
     }
   }
   Qgis::GeometryOperationResult errorCode = geometry.addPartV2( ring, mLayer->wkbType() );
+
+  if ( errorCode == Qgis::GeometryOperationResult::Success )
+  {
+    if ( firstPart && QgsWkbTypes::isSingleType( mLayer->wkbType() ) && mLayer->dataProvider()->doesStrictFeatureTypeCheck() )
+    {
+      //convert back to single part if required by layer
+      geometry.convertToSingleType();
+    }
+    mLayer->changeGeometry( featureId, geometry );
+  }
+  return errorCode;
+}
+
+Qgis::GeometryOperationResult QgsVectorLayerEditUtils::addPart( QgsCurvePolygon *polygon, QgsFeatureId featureId )
+{
+  std::unique_ptr<QgsCurvePolygon> uniquePtrPoly( polygon );
+
+  if ( !mLayer->isSpatial() )
+    return Qgis::GeometryOperationResult::AddPartSelectedGeometryNotFound;
+
+  if ( mLayer->geometryType() != Qgis::GeometryType::Polygon )
+    return Qgis::GeometryOperationResult::InvalidInputGeometryType;
+
+  QgsGeometry geometry;
+  bool firstPart = false;
+  QgsFeature f;
+  if ( !mLayer->getFeatures( QgsFeatureRequest().setFilterFid( featureId ).setNoAttributes() ).nextFeature( f ) )
+    return Qgis::GeometryOperationResult::AddPartSelectedGeometryNotFound;
+
+  if ( !f.hasGeometry() )
+  {
+    //no existing geometry, so adding first part to null geometry
+    firstPart = true;
+  }
+  else
+  {
+    geometry = f.geometry();
+    switch ( geometry.polygonOrientation() )
+    {
+      case Qgis::AngularDirection::Clockwise:
+        polygon->forceClockwise();
+        break;
+      case Qgis::AngularDirection::CounterClockwise:
+        polygon->forceCounterClockwise();
+        break;
+      case Qgis::AngularDirection::NoOrientation:
+        break;
+    }
+  }
+  Qgis::GeometryOperationResult errorCode = geometry.addPartV2( uniquePtrPoly.release(), mLayer->wkbType() );
 
   if ( errorCode == Qgis::GeometryOperationResult::Success )
   {

--- a/src/core/vector/qgsvectorlayereditutils.h
+++ b/src/core/vector/qgsvectorlayereditutils.h
@@ -175,6 +175,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      * - QgsGeometry::InvalidInput
      *
      * \note available in python bindings as addPolygonPart
+     * \since QGIS 4.4
      */
     Qgis::GeometryOperationResult addPart( QgsCurvePolygon *polygon SIP_TRANSFER, QgsFeatureId featureId ) SIP_PYNAME( addPolygonPart );
 

--- a/src/core/vector/qgsvectorlayereditutils.h
+++ b/src/core/vector/qgsvectorlayereditutils.h
@@ -151,7 +151,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     Qgis::GeometryOperationResult addPart( const QgsPointSequence &ring, QgsFeatureId featureId );
 
     /**
-     * Adds a new part polygon to a multipart feature
+     * Adds a new polygon part consisting of an exterior \a ring only to a multipart or geometryless feature
      *
      * \returns - QgsGeometry::Success
      *
@@ -163,6 +163,20 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      * \note available in python bindings as addCurvedPart
      */
     Qgis::GeometryOperationResult addPart( QgsCurve *ring SIP_TRANSFER, QgsFeatureId featureId ) SIP_PYNAME( addCurvedPart );
+
+    /**
+     * Adds a new polygon part to a multipart or geometryless feature
+     *
+     * \returns - QgsGeometry::Success
+     *
+     * - QgsGeometry::AddPartSelectedGeometryNotFound
+     * - QgsGeometry::AddPartNotMultiGeometry
+     * - QgsGeometry::InvalidBaseGeometry
+     * - QgsGeometry::InvalidInput
+     *
+     * \note available in python bindings as addPolygonPart
+     */
+    Qgis::GeometryOperationResult addPart( QgsCurvePolygon *polygon SIP_TRANSFER, QgsFeatureId featureId ) SIP_PYNAME( addPolygonPart );
 
     /**
      * Translates feature by dx, dy

--- a/tests/src/app/testqgsmaptooladdpart.cpp
+++ b/tests/src/app/testqgsmaptooladdpart.cpp
@@ -88,7 +88,7 @@ void TestQgsMapToolAddPart::initTestCase()
 
   mLayerMultiPolygon->startEditing();
   QgsFeature f;
-  const QString wkt( "MultiPolygon (((2 2, 4 2, 4 4, 2 4)))" );
+  const QString wkt( "MultiPolygon (((2 2, 4 2, 4 4, 2 4, 2 2)))" );
   f.setGeometry( QgsGeometry::fromWkt( wkt ) );
   mLayerMultiPolygon->dataProvider()->addFeatures( QgsFeatureList() << f );
   QCOMPARE( mLayerMultiPolygon->featureCount(), ( long ) 1 );
@@ -141,8 +141,10 @@ void TestQgsMapToolAddPart::testAddPart()
   event = std::make_unique<QgsMapMouseEvent>( mCanvas, QEvent::MouseButtonRelease, mapToPoint( 5, 5 ), Qt::RightButton );
   mCaptureTool->cadCanvasReleaseEvent( event.get() );
 
-  const QString wkt = "MultiPolygon (((2 2, 4 2, 4 4, 2 4)),((5 5, 5 5, 6 5, 6 6, 5 6, 5 5)))";
+  const QString wkt = "MultiPolygon (((2 2, 4 2, 4 4, 2 4, 2 2)),((5 5, 5 5, 6 5, 6 6, 5 6, 5 5)))";
   QCOMPARE( mLayerMultiPolygon->getFeature( 1 ).geometry().asWkt(), wkt );
+
+  mLayerMultiPolygon->undoStack()->undo();
 }
 
 void TestQgsMapToolAddPart::testAddPartClockWise()
@@ -165,8 +167,10 @@ void TestQgsMapToolAddPart::testAddPartClockWise()
   event = std::make_unique<QgsMapMouseEvent>( mCanvas, QEvent::MouseButtonRelease, mapToPoint( 15, 15 ), Qt::RightButton );
   mCaptureTool->cadCanvasReleaseEvent( event.get() );
 
-  const QString wkt = "MultiPolygon (((2 2, 4 2, 4 4, 2 4)),((5 5, 5 5, 6 5, 6 6, 5 6, 5 5)),((15 15, 16 15, 16 16, 15 16, 15 15)))";
+  const QString wkt = "MultiPolygon (((2 2, 4 2, 4 4, 2 4, 2 2)),((15 15, 16 15, 16 16, 15 16, 15 15)))";
   QCOMPARE( mLayerMultiPolygon->getFeature( 1 ).geometry().asWkt(), wkt );
+
+  mLayerMultiPolygon->undoStack()->undo();
 }
 
 void TestQgsMapToolAddPart::testAddPartToSingleGeometryLess()

--- a/tests/src/app/testqgsmaptooladdpart.cpp
+++ b/tests/src/app/testqgsmaptooladdpart.cpp
@@ -48,6 +48,7 @@ class TestQgsMapToolAddPart : public QObject
     void testAddPartClockWise();
     void testAddPartToSingleGeometryLess();
     void testAddPartToMultiLineString();
+    void testAddPartAvoidOverlap();
 
   private:
     QPoint mapToPoint( double x, double y );
@@ -245,6 +246,43 @@ void TestQgsMapToolAddPart::testAddPartToMultiLineString()
   // Cleanup
   mCanvas->setCurrentLayer( mLayerMultiPolygon );
   QgsProject::instance()->removeMapLayers( QList<QgsMapLayer *>() << layerMultiLine );
+}
+
+void TestQgsMapToolAddPart::testAddPartAvoidOverlap()
+{
+  QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsCurrentLayer );
+
+  QgsFeature f;
+  const QString wkt( "MultiPolygon (((5 0, 5 5, 6 5, 6 0, 5 0)))" );
+  f.setGeometry( QgsGeometry::fromWkt( wkt ) );
+  mLayerMultiPolygon->dataProvider()->addFeatures( QgsFeatureList() << f );
+  QCOMPARE( mLayerMultiPolygon->featureCount(), ( long ) 2 );
+  QCOMPARE( mLayerMultiPolygon->getFeature( 2 ).geometry().asWkt(), wkt );
+
+  auto event = std::make_unique<QgsMapMouseEvent>( mCanvas, QEvent::MouseButtonRelease, mapToPoint( 1, 1 ), Qt::LeftButton );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event = std::make_unique<QgsMapMouseEvent>( mCanvas, QEvent::MouseButtonRelease, mapToPoint( 7, 1 ), Qt::LeftButton );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event = std::make_unique<QgsMapMouseEvent>( mCanvas, QEvent::MouseButtonRelease, mapToPoint( 7, 5 ), Qt::LeftButton );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event = std::make_unique<QgsMapMouseEvent>( mCanvas, QEvent::MouseButtonRelease, mapToPoint( 1, 5 ), Qt::LeftButton );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  event = std::make_unique<QgsMapMouseEvent>( mCanvas, QEvent::MouseButtonRelease, mapToPoint( 1, 5 ), Qt::RightButton );
+  mCaptureTool->cadCanvasReleaseEvent( event.get() );
+
+  // Added part should have an inner ring (hole)
+  const QString expectedWkt = "MultiPolygon (((2 2, 4 2, 4 4, 2 4, 2 2)),((1 1, 5 1, 5 5, 1 5, 1 1),(2 2, 2 4, 4 4, 4 2, 2 2)),((7 5, 6 5, 6 1, 7 1, 7 5)))";
+  QCOMPARE( mLayerMultiPolygon->getFeature( 1 ).geometry().asWkt( 1 ), expectedWkt );
+
+  // Cleanup
+  mLayerMultiPolygon->undoStack()->undo();
+  mLayerMultiPolygon->dataProvider()->deleteFeatures( { 2 } );
+  QCOMPARE( mLayerMultiPolygon->featureCount(), ( long ) 1 );
+  QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AllowIntersections );
 }
 
 QGSTEST_MAIN( TestQgsMapToolAddPart )


### PR DESCRIPTION
## Description
The add part map tool would crash if adding a multi polygon part would result in two parts being added due to overlap avoidance.

`layerPointCaptured()`, `layerLineCaptured()` and `layerPolygonCaptured()` virtual methods were used by the tool to perform its geometry type dependent logic.
These methods do not cover the multi polygon case. I contemplated adding a `layerMultiPolygonCaptured()` but it does not feel correct so these were replaced by the generic `layerGeometryCaptured()`. The individual geometry type methods are no longer used in QGIS code, they're still available for python tools.

On a side-fix, when the added part is modified by overlap avoidance the final geometry is now used for topological points.
Topo points are still only added to the active layer only, but fixing this is out of scope here.

Fixes #66661

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
