### PR TITLE
[browser] Fix long ui hang when opening context menu for stac parquet datasets

### DIFF
--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -128,6 +128,8 @@ QgsStacAssetLayerItem::QgsStacAssetLayerItem(
 {
   updateToolTip();
   setState( Qgis::BrowserItemState::Populated );
+
+  mCapabilities.setFlag( Qgis::BrowserItemCapability::ReadOnly, true );
 }
 
 bool QgsStacAssetLayerItem::hasDragEnabled() const

--- a/src/gui/providers/ogr/qgsogritemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsogritemguiprovider.cpp
@@ -44,7 +44,7 @@ void QgsOgrItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu,
   {
     if ( layerItem->providerKey() == "ogr"_L1 && !qobject_cast<QgsGeoPackageAbstractLayerItem *>( item ) )
     {
-      if ( !( layerItem->capabilities2() & Qgis::BrowserItemCapability::ItemRepresentsFile ) )
+      if ( !layerItem->capabilities2().testFlag( Qgis::BrowserItemCapability::ReadOnly ) && !layerItem->capabilities2().testFlag( Qgis::BrowserItemCapability::ItemRepresentsFile ) )
       {
         // item is a layer which sits inside a collection.
 
@@ -78,7 +78,7 @@ void QgsOgrItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu,
 
   if ( QgsDataCollectionItem *collectionItem = qobject_cast<QgsDataCollectionItem *>( item ) )
   {
-    if ( collectionItem->providerKey() == "ogr"_L1 && !qobject_cast<QgsGeoPackageCollectionItem *>( item ) )
+    if ( !collectionItem->capabilities2().testFlag( Qgis::BrowserItemCapability::ReadOnly ) && collectionItem->providerKey() == "ogr"_L1 && !qobject_cast<QgsGeoPackageCollectionItem *>( item ) )
     {
       const bool isFolder = QFileInfo( collectionItem->path() ).isDir();
       // Messages are different for files and tables


### PR DESCRIPTION
We were trying to open the dataset whenever the context menu was created in order to determine if the manage menu should show a "delete layer" action. But in the case of stac layers, we know they are read-only and can skip this expensive check.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
