### PR TITLE
Fix crash in simplify tool when switching layers (fixes #66893)

### DIFF
--- a/src/app/qgsmaptoolsimplify.cpp
+++ b/src/app/qgsmaptoolsimplify.cpp
@@ -256,7 +256,7 @@ void QgsMapToolSimplify::createUserInputWidget()
   connect( mSimplifyUserWidget, &QgsSimplifyUserInputWidget::rejected, this, &QgsMapToolSimplify::clearSelection );
 
   mSimplifyUserWidget->setTargetLayer( currentVectorLayer() );
-  connect( canvas(), &QgsMapCanvas::currentLayerChanged, this, [this]( QgsMapLayer *layer ) { mSimplifyUserWidget->setTargetLayer( layer ); } );
+  connect( canvas(), &QgsMapCanvas::currentLayerChanged, mSimplifyUserWidget, &QgsSimplifyUserInputWidget::setTargetLayer );
 
   QgisApp::instance()->addUserInputWidget( mSimplifyUserWidget );
   mSimplifyUserWidget->setFocus( Qt::TabFocusReason );


### PR DESCRIPTION
## Description

Fixes a fatal access violation in the Simplify Feature tool when the active layer changes after the tool has already been used ([#66893](https://github.com/qgis/QGIS/issues/66893)).

**Problem**
After simplifying a feature (or cancelling the simplify UI), switching to another layer in the Layers panel crashed QGIS. The stack pointed at QgsSimplifyUserInputWidget::setTargetLayer. This is a QGIS 4 regression; it does not occur on 3.44 LTR.

**Root cause**
Introduced by 094fbf3 (“Show actual layer/map units in combo box for simplify tool”), which listens for layer changes so the “Layer Units (…)” combo label stays up to date:

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
