### PR TITLE
[Elevation Profile] fix zooming full when scale ratio is locked

### DIFF
--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -690,23 +690,6 @@ bool QgsElevationProfileCanvas::lockAxisScales() const
 void QgsElevationProfileCanvas::setLockAxisScales( bool lock )
 {
   mLockAxisScales = lock;
-  if ( mLockAxisScales )
-  {
-    double xMinimum = mPlotItem->xMinimum() * mPlotItem->mXScaleFactor;
-    double xMaximum = mPlotItem->xMaximum() * mPlotItem->mXScaleFactor;
-    double yMinimum = mPlotItem->yMinimum();
-    double yMaximum = mPlotItem->yMaximum();
-    adjustRangeForAxisScaleLock( xMinimum, xMaximum, yMinimum, yMaximum );
-    mPlotItem->setXMinimum( xMinimum / mPlotItem->mXScaleFactor );
-    mPlotItem->setXMaximum( xMaximum / mPlotItem->mXScaleFactor );
-    mPlotItem->setYMinimum( yMinimum );
-    mPlotItem->setYMaximum( yMaximum );
-
-    refineResults();
-    mPlotItem->updatePlot();
-    emit plotAreaChanged();
-    emit scaleChanged();
-  }
 }
 
 double QgsElevationProfileCanvas::axisScaleRatio() const
@@ -720,13 +703,19 @@ void QgsElevationProfileCanvas::setAxisScaleRatio( double scale )
 {
   mLockedAxisScale = scale;
 
-  double xMinimum = mPlotItem->xMinimum() * mPlotItem->mXScaleFactor;
-  double xMaximum = mPlotItem->xMaximum() * mPlotItem->mXScaleFactor;
+  const double xMinimum = mPlotItem->xMinimum();
+  const double xMaximum = mPlotItem->xMaximum();
   double yMinimum = mPlotItem->yMinimum();
   double yMaximum = mPlotItem->yMaximum();
-  adjustRangeForAxisScaleLock( xMinimum, xMaximum, yMinimum, yMaximum );
-  mPlotItem->setXMinimum( xMinimum / mPlotItem->mXScaleFactor );
-  mPlotItem->setXMaximum( xMaximum / mPlotItem->mXScaleFactor );
+  const double horizontalScale = ( xMaximum - xMinimum ) / mPlotItem->plotArea().width();
+
+  // When setting the axis scale ratio, we keep the horizontal range fixed and adjust the
+  // vertical range so that their ratio matches the locked scale value
+  const double height = horizontalScale * mPlotItem->plotArea().height() / mLockedAxisScale;
+  const double deltaHeight = height - ( yMaximum - yMinimum );
+  yMinimum -= deltaHeight / 2;
+  yMaximum += deltaHeight / 2;
+
   mPlotItem->setYMinimum( yMinimum );
   mPlotItem->setYMaximum( yMaximum );
 

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -612,19 +612,19 @@ void QgsElevationProfileCanvas::adjustRangeForAxisScaleLock( double &xMinimum, d
 
   const double currentRatio = horizontalScale / verticalScale;
 
-  if ( currentRatio <= mLockedAxisScale )
+  if ( currentRatio > mLockedAxisScale )
   {
     const double height = horizontalScale * mPlotItem->plotArea().height() / mLockedAxisScale;
-    const double deltaHeight = ( yMaximum - yMinimum ) - height;
-    yMinimum += deltaHeight / 2;
-    yMaximum -= deltaHeight / 2;
+    const double deltaHeight = height - ( yMaximum - yMinimum );
+    yMinimum -= deltaHeight / 2;
+    yMaximum += deltaHeight / 2;
   }
   else
   {
     const double width = verticalScale * mPlotItem->plotArea().width() * mLockedAxisScale;
-    const double deltaWidth = ( ( xMaximum - xMinimum ) - width );
-    xMinimum += deltaWidth / 2;
-    xMaximum -= deltaWidth / 2;
+    const double deltaWidth = width - ( xMaximum - xMinimum );
+    xMinimum -= deltaWidth / 2;
+    xMaximum += deltaWidth / 2;
   }
 }
 

--- a/tests/src/python/test_qgselevationprofilecanvas.py
+++ b/tests/src/python/test_qgselevationprofilecanvas.py
@@ -293,24 +293,24 @@ class TestQgsElevationProfileCanvas(QgisTestCase):
 
         canvas.setAxisScaleRatio(0.5)
         self.assertAlmostEqual(canvas.axisScaleRatio(), 0.5, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, delta=1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, delta=1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 50.0, delta=1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 150.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 100.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 500.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), -100.0, delta=8)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 300.0, delta=8)
 
         canvas.setAxisScaleRatio(1.0)
         self.assertAlmostEqual(canvas.axisScaleRatio(), 1.0, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, delta=1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, delta=1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 75.0, delta=1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 125.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 100.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 500.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 0.0, delta=5)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 200.0, delta=5)
 
         canvas.setAxisScaleRatio(2.0)
         self.assertAlmostEqual(canvas.axisScaleRatio(), 2.0, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, delta=1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, delta=1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 87.5, delta=1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 112.5, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 100.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 500.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 50, delta=2)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 150.0, delta=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Comparison operator was flipped (`<=` instead of `>`) resulting in wrong updated extents.

Also updated the `deltaHeight`/`deltaWidth` definitions to clarify the intention: delta is positive and used to decrease minimums and increase maximums.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
