### PR TITLE
Fix QgsVertexId::isValid

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsvertexid.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsvertexid.sip.in
@@ -48,9 +48,13 @@ another vertex ID (i.e. the part, ring number and vertex number are
 equal).
 %End
 
-  bool isValid( const QgsAbstractGeometry *geom ) const /HoldGIL/;
+ bool isValid( const QgsAbstractGeometry *geom ) const /HoldGIL,Deprecated="Since 4.4. Use QgsAbstractGeometry.hasVertex() instead."/;
 %Docstring
 Returns ``True`` if this vertex ID is valid for the specified ``geom``.
+
+.. deprecated:: 4.4
+
+   Use :py:func:`QgsAbstractGeometry.hasVertex()` instead.
 %End
 
   int part;

--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
@@ -110,7 +110,7 @@ void QgsGeometryAngleCheck::fixError( const QMap<QString, QgsFeaturePool *> &fea
   const QgsVertexId vidx = error->vidx();
 
   // Check if point still exists
-  if ( !vidx.isValid( geometry ) )
+  if ( !geometry->hasVertex( vidx ) )
   {
     error->setObsolete();
     return;

--- a/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
@@ -79,7 +79,7 @@ void QgsGeometryAreaCheck::fixError( const QMap<QString, QgsFeaturePool *> &feat
   const double layerToMapUnits = scaleFactor( featurePool->layer() );
 
   // Check if polygon still exists
-  if ( !vidx.isValid( geom ) )
+  if ( !geom->hasVertex( QgsVertexId( vidx.part, 0, 0 ) ) )
   {
     error->setObsolete();
     return;

--- a/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
@@ -53,7 +53,7 @@ QgsGeometryCheck::Result QgsGeometryDegeneratePolygonCheck::collectErrors(
         if ( QgsGeometryCheckerUtils::polyLineSize( geom, iPart, iRing ) < 3 )
         {
           const QgsVertexId vidx( iPart, iRing );
-          errors.append( new QgsGeometryCheckError( this, layerFeature, geom->vertexAt( vidx ), vidx ) );
+          errors.append( new QgsGeometryCheckError( this, layerFeature, geom->vertexAt( QgsVertexId( iPart, iRing, 0 ) ), vidx ) );
         }
       }
     }
@@ -77,7 +77,7 @@ void QgsGeometryDegeneratePolygonCheck::fixError(
   const QgsVertexId vidx = error->vidx();
 
   // Check if ring still exists
-  if ( !vidx.isValid( geom ) )
+  if ( !geom->hasVertex( QgsVertexId( vidx.part, vidx.ring, 0 ) ) )
   {
     error->setObsolete();
     return;

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
@@ -86,7 +86,7 @@ void QgsGeometryDuplicateNodesCheck::fixError(
   const QgsVertexId vidx = error->vidx();
 
   // Check if point still exists
-  if ( !vidx.isValid( geom ) )
+  if ( !geom->hasVertex( vidx ) )
   {
     error->setObsolete();
     return;

--- a/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
@@ -88,7 +88,7 @@ void QgsGeometryHoleCheck::fixError( const QMap<QString, QgsFeaturePool *> &feat
   const QgsVertexId vidx = error->vidx();
 
   // Check if ring still exists
-  if ( !vidx.isValid( geom ) )
+  if ( !geom->hasVertex( QgsVertexId( vidx.part, vidx.ring, 0 ) ) )
   {
     error->setObsolete();
     return;

--- a/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
@@ -94,7 +94,7 @@ void QgsGeometrySegmentLengthCheck::
   const QgsVertexId vidx = error->vidx();
 
   // Check if point still exists
-  if ( !vidx.isValid( geom ) )
+  if ( !geom->hasVertex( vidx ) )
   {
     error->setObsolete();
     return;

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
@@ -90,7 +90,7 @@ void QgsGeometrySelfIntersectionCheck::fixError(
   const QgsVertexId vidx = error->vidx();
 
   // Check if ring still exists
-  if ( !vidx.isValid( geom ) )
+  if ( !geom->hasVertex( QgsVertexId( vidx.part, vidx.ring, 0 ) ) )
   {
     error->setObsolete();
     return;

--- a/src/core/geometry/qgsvertexid.cpp
+++ b/src/core/geometry/qgsvertexid.cpp
@@ -19,5 +19,5 @@ email                : marco.hugentobler at sourcepole dot com
 
 bool QgsVertexId::isValid( const QgsAbstractGeometry *geom ) const
 {
-  return ( part >= 0 && part < geom->partCount() ) && ( ring < geom->ringCount( part ) ) && ( vertex < 0 || vertex < geom->vertexCount( part, ring ) );
+  return geom->hasVertex( *this );
 }

--- a/src/core/geometry/qgsvertexid.h
+++ b/src/core/geometry/qgsvertexid.h
@@ -87,8 +87,10 @@ struct CORE_EXPORT QgsVertexId
 
   /**
    * Returns TRUE if this vertex ID is valid for the specified \a geom.
+   *
+   * \deprecated QGIS 4.4. Use QgsAbstractGeometry::hasVertex() instead.
    */
-  bool isValid( const QgsAbstractGeometry *geom ) const SIP_HOLDGIL;
+  Q_DECL_DEPRECATED bool isValid( const QgsAbstractGeometry *geom ) const SIP_HOLDGIL SIP_DEPRECATED;
 
   //! Part number
   int part = -1;


### PR DESCRIPTION
This PR fixes the issue with the method `isValid` of the `QgsVertexId` - rings could be negative as well as vertices.

But then, there is now no need for this method to exist, because we now have `QgsAbstractGeometry::hasVertex`, so I decided to deprecate this func and fix it by using hasVertex in it.

But then#2, there were several callers which relied on the method being broken...
All of them were geometry checkers and all of them have been updated to use `QgsAbstractGeometry::hasVertex` and checked for correctness.
Some of the callers were only interested in part and/or ring existence.

Test cases exist for `hasVertex`, I don't see a need to add more.

No AI used.