### PR TITLE
Add reload postgres raster provider data

### DIFF
--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -348,6 +348,15 @@ void QgsRasterLayer::reload()
   if ( mDataProvider )
   {
     mDataProvider->reloadData();
+
+    if ( mDataProvider->isValid() )
+    {
+      const QgsRectangle extent = mDataProvider->extent();
+      if ( !extent.isNull() )
+      {
+        setExtent( extent );
+      }
+    }
   }
 }
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -348,6 +348,12 @@ void QgsRasterLayer::reload()
   if ( mDataProvider )
   {
     mDataProvider->reloadData();
+
+    const QgsRectangle extent = mDataProvider->extent();
+    if ( mDataProvider->isValid() && !extent.isNull() )
+    {
+      setExtent( extent );
+    }
   }
 }
 

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -889,14 +889,20 @@ bool QgsPostgresRasterProvider::setSubsetString( const QString &subset, bool upd
     return false;
   }
 
-  mStatistics.clear();
-  mShared->invalidateCache();
-
   // Update datasource uri too
   mUri.setSql( subset );
   setDataSourceUri( mUri.uri( false ) );
 
   return true;
+}
+
+void QgsPostgresRasterProvider::reloadProviderData()
+{
+  mValid = init();
+  if ( !mValid )
+  {
+    QgsMessageLog::logMessage( tr( "Unable to reload the PostgreSQL raster layer, the data source may no longer be available." ), tr( "PostGIS" ) );
+  }
 }
 
 QString QgsPostgresRasterProvider::subsetStringWithTemporalRange() const
@@ -969,6 +975,13 @@ bool QgsPostgresRasterProvider::init()
   // WARNING: multiple failure and return points!
 
   mOverViews.clear();
+  mDataTypes.clear();
+  mDataSizes.clear();
+  mSrcNoDataValue.clear();
+  mSrcHasNoDataValue.clear();
+  mUseSrcNoDataValue.clear();
+  mStatistics.clear();
+  mShared->invalidateCache();
 
   if ( !determinePrimaryKey() )
   {
@@ -1284,6 +1297,8 @@ bool QgsPostgresRasterProvider::init()
   if ( PGRES_TUPLES_OK == result.PQresultStatus() && result.PQntuples() > 0 )
   {
     // These may have been filled with defaults in the fast track
+    mDataTypes.clear();
+    mDataSizes.clear();
     mSrcNoDataValue.clear();
     mSrcHasNoDataValue.clear();
     mUseSrcNoDataValue.clear();

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -899,6 +899,19 @@ bool QgsPostgresRasterProvider::setSubsetString( const QString &subset, bool upd
   return true;
 }
 
+void QgsPostgresRasterProvider::reloadProviderData()
+{
+  mValid = init();
+
+  mStatistics.clear();
+  mShared->invalidateCache();
+
+  if ( !mValid )
+  {
+    QgsMessageLog::logMessage( tr( "Unable to reload the PostgreSQL raster layer, the data source may no longer be available." ), tr( "PostGIS" ) );
+  }
+}
+
 QString QgsPostgresRasterProvider::subsetStringWithTemporalRange() const
 {
   // Temporal
@@ -969,6 +982,11 @@ bool QgsPostgresRasterProvider::init()
   // WARNING: multiple failure and return points!
 
   mOverViews.clear();
+  mDataTypes.clear();
+  mDataSizes.clear();
+  mSrcNoDataValue.clear();
+  mSrcHasNoDataValue.clear();
+  mUseSrcNoDataValue.clear();
 
   if ( !determinePrimaryKey() )
   {
@@ -1284,6 +1302,8 @@ bool QgsPostgresRasterProvider::init()
   if ( PGRES_TUPLES_OK == result.PQresultStatus() && result.PQntuples() > 0 )
   {
     // These may have been filled with defaults in the fast track
+    mDataTypes.clear();
+    mDataSizes.clear();
     mSrcNoDataValue.clear();
     mSrcHasNoDataValue.clear();
     mUseSrcNoDataValue.clear();

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.h
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.h
@@ -196,6 +196,8 @@ class QgsPostgresRasterProvider : public QgsRasterDataProvider
     //! Initialize fields and temporal capabilities
     bool initFieldsAndTemporal();
 
+    void reloadProviderData() override;
+
     //! Search for overviews and store a map
     void findOverviews();
     //! Initialize spatial indexes

--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -47,6 +47,17 @@ TEST_DATA_DIR = unitTestDataPath()
 
 class TestPyQgsPostgresRasterProvider(QgisTestCase):
     @classmethod
+    def _execute_sql_file(cls, basename):
+        """Run SQL from tests/testdata/provider/postgresraster/<basename>.sql"""
+
+        md = QgsProviderRegistry.instance().providerMetadata("postgres")
+        conn = md.createConnection(cls.dbconn + " sslmode=disable ", {})
+        with open(
+            os.path.join(TEST_DATA_DIR, "provider", "postgresraster", basename + ".sql")
+        ) as f:
+            conn.executeSql(f.read())
+
+    @classmethod
     def _load_test_table(cls, schemaname, tablename, basename=None):
 
         postgres_conn = cls.dbconn + " sslmode=disable "
@@ -57,13 +68,7 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
             basename = tablename
 
         if tablename not in [n.tableName() for n in conn.tables(schemaname)]:
-            with open(
-                os.path.join(
-                    TEST_DATA_DIR, "provider", "postgresraster", basename + ".sql"
-                )
-            ) as f:
-                sql = f.read()
-                conn.executeSql(sql)
+            cls._execute_sql_file(basename)
             assert tablename in [n.tableName() for n in conn.tables(schemaname)], (
                 tablename + " not found!"
             )
@@ -1278,6 +1283,59 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
                     self.assertFalse(block.isNoData(row, col))
                 # no cells with value 0 should exist
                 self.assertNotEqual(block.value(row, col), 0.0)
+
+    def testReloadReflectsDataChanges(self):
+        """Reloading the layer must reflect changes made to the underlying
+        table: extent, raster size and data. GH #59381"""
+
+        # Setup test data on every run to make sure we have a clean state
+        self._execute_sql_file("raster_3035_reload")
+
+        rl = QgsRasterLayer(
+            self.dbconn
+            + ' sslmode=disable key=\'pk\' srid=3035 table="public"."raster_3035_reload" sql=',
+            "test_reload",
+            "postgresraster",
+        )
+        self.assertTrue(rl.isValid())
+
+        # Initial state: a single 2x2 tile, all pixels = 100
+        self.assertEqual(rl.extent(), QgsRectangle(4080050, 2430700, 4080100, 2430750))
+        self.assertEqual(rl.dataProvider().xSize(), 2)
+        self.assertEqual(rl.dataProvider().ySize(), 2)
+
+        block = rl.dataProvider().block(1, rl.extent(), 2, 2)
+        data = []
+        for i in range(2):
+            for j in range(2):
+                data.append(int(block.value(i, j)))
+        self.assertEqual(data, [100, 100, 100, 100])
+
+        # Add a second tile
+        self._execute_sql_file("raster_3035_reload_update")
+
+        # No reload, cached extent
+        self.assertEqual(rl.extent(), QgsRectangle(4080050, 2430700, 4080100, 2430750))
+
+        rl.reload()
+
+        self.assertEqual(rl.extent(), QgsRectangle(4080050, 2430700, 4080150, 2430750))
+        self.assertEqual(rl.dataProvider().xSize(), 4)
+        self.assertEqual(rl.dataProvider().ySize(), 2)
+
+        block = rl.dataProvider().block(1, rl.extent(), 4, 2)
+        data = []
+        for i in range(2):
+            for j in range(4):
+                data.append(int(block.value(i, j)))
+        self.assertEqual(data, [100, 100, 200, 200, 100, 100, 200, 200])
+
+        # Reloading with no data changes should be a no-op
+        rl.reload()
+        self.assertEqual(rl.extent(), QgsRectangle(4080050, 2430700, 4080150, 2430750))
+        self.assertEqual(rl.dataProvider().bandCount(), 1)
+        self.assertEqual(rl.dataProvider().dataType(1), Qgis.DataType.Float32)
+        self.assertEqual(rl.dataProvider().sourceNoDataValue(1), -9999)
 
 
 if __name__ == "__main__":

--- a/tests/testdata/provider/postgresraster/raster_3035_reload.sql
+++ b/tests/testdata/provider/postgresraster/raster_3035_reload.sql
@@ -1,0 +1,22 @@
+--
+-- in-db float32 raster used to test QgsRasterLayer reload:
+-- Companion update: raster_3035_reload_update.sql
+--
+
+DROP TABLE IF EXISTS "public"."raster_3035_reload";
+
+CREATE TABLE "public"."raster_3035_reload" (
+    "pk" SERIAL PRIMARY KEY,
+    "rast" raster
+);
+
+INSERT INTO "public"."raster_3035_reload" ("rast")
+VALUES (
+    ST_AddBand(
+        ST_MakeEmptyRaster(2, 2, 4080050, 2430750, 25, -25, 0, 0, 3035),
+        '32BF'::text, 100, -9999
+    )
+);
+
+CREATE INDEX ON "public"."raster_3035_reload" USING gist (st_convexhull("rast"));
+ANALYZE "public"."raster_3035_reload";

--- a/tests/testdata/provider/postgresraster/raster_3035_reload_update.sql
+++ b/tests/testdata/provider/postgresraster/raster_3035_reload_update.sql
@@ -1,0 +1,12 @@
+--
+-- Update for raster_3035_reload: add a tile, so that the layer extent, size and
+-- data must all change after reload.
+--
+
+INSERT INTO "public"."raster_3035_reload" ("rast")
+VALUES (
+    ST_AddBand(
+        ST_MakeEmptyRaster(2, 2, 4080100, 2430750, 25, -25, 0, 0, 3035),
+        '32BF'::text, 200, -9999
+    )
+);


### PR DESCRIPTION
Fixes #59381

## Description

- `QgsPostgresRasterProvider::reloadProviderData()` re-runs `init()` to re-read metadata and refresh
  validity, then drops the band statistics and the shared tile cache.
- `QgsPostgresRasterProvider::init()` now also clears `mDataTypes`, `mDataSizes` and the source nodata lists, to which it appends new values. Without clearing, the stale values are used and nodata changes
  are never picked up.
- `QgsRasterLayer::reload()` refreshes the layer extent from the provider. This change touches all
  raster providers but is additive: the extent is only updated when the provider is valid and the
  new extent is non-null.

The new behaviour is covered by a test in `test_provider_postgresraster.py`.

A backport to 4.2 would be appreciated if possible.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
