### PR TITLE
ci: fix labeler indentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,220 +1,213 @@
 "3D":
-- changed-files:
-  - any-glob-to-any-file: [
-    'resources/3d/**/*',
-    'src/3d/**/*',
-    'src/app/3d/**/*',
-    'src/core/3d/**/*',
-    'src/ui/3d/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "resources/3d/**/*",
+            "src/3d/**/*",
+            "src/app/3d/**/*",
+            "src/core/3d/**/*",
+            "src/ui/3d/**/*",
+          ]
 
 "Annotations":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/app/annotations/**/*',
-    'src/core/annotations/**/*',
-    'src/gui/annotations/**/*',
-    'src/ui/annotations/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/app/annotations/**/*",
+            "src/core/annotations/**/*",
+            "src/gui/annotations/**/*",
+            "src/ui/annotations/**/*",
+          ]
 
 "ArcGIS REST provider":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/core/providers/argisrest/**/*',
-    'src/providers/arcgisrest/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          ["src/core/providers/argisrest/**/*", "src/providers/arcgisrest/**/*"]
 
 "Authentication":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/auth/**/*',
-    'src/core/auth/**/*',
-    'src/gui/auth/**/*',
-    'src/ui/auth/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/auth/**/*",
+            "src/core/auth/**/*",
+            "src/gui/auth/**/*",
+            "src/ui/auth/**/*",
+          ]
 
 "Build/Install":
-- changed-files:
-  - any-glob-to-any-file: [
-    'cmake/**/*',
-    'debian/**/*',
-    'linux/**/*',
-    'ms-windows/**/*',
-    'nix/**/*',
-    'postinstall/**/*',
-    'rpm/**/*',
-    'vcpkg/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "cmake/**/*",
+            "debian/**/*",
+            "linux/**/*",
+            "ms-windows/**/*",
+            "nix/**/*",
+            "postinstall/**/*",
+            "rpm/**/*",
+            "vcpkg/**/*",
+          ]
 
 "Chore":
-- changed-files:
-  - any-glob-to-any-file: [
-    '.ci/**/*',
-    '.docker/**/*',
-    '.github/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file: [".ci/**/*", ".docker/**/*", ".github/**/*"]
 
 "Digitizing":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/app/maptools/**/*',
-    'src/app/vertextool/**/*',
-    'src/gui/maptools/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/app/maptools/**/*",
+            "src/app/vertextool/**/*",
+            "src/gui/maptools/**/*",
+          ]
 
 "Expressions":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/core/expression/**/*',
-    'resources/function_help/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          ["src/core/expression/**/*", "resources/function_help/**/*"]
 
 "Form":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/core/editform/**/*',
-    'src/gui/attributeformconfig/**/*',
-    'src/gui/editorwidgets/**/*',
-    'src/ui/attributeformconfig/**/*',
-    'src/ui/editorwidgets/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/core/editform/**/*",
+            "src/gui/attributeformconfig/**/*",
+            "src/gui/editorwidgets/**/*",
+            "src/ui/attributeformconfig/**/*",
+            "src/ui/editorwidgets/**/*",
+          ]
 
 "GRASS":
-- changed-files:
-  - any-glob-to-any-file: [
-    'python/plugins/grassprovider/**/*',
-    'src/providers/grass/**/*'
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          ["python/plugins/grassprovider/**/*", "src/providers/grass/**/*"]
 
 "GUI/UX":
-- changed-files:
-  - any-glob-to-any-file: [
-    'images/**/*',
-    'resources/themes/**/*',
-#    'src/gui/**/*', too broad
-    'src/ui/**/*.ui'
-  ]
+  - changed-files:
+      - any-glob-to-any-file: [
+            "images/**/*",
+            "resources/themes/**/*",
+            #    'src/gui/**/*', too broad
+            "src/ui/**/*.ui",
+          ]
 
 "HANA data provider":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/providers/hana/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file: ["src/providers/hana/**/*"]
 
 "Labeling":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/app/labeling/**/*',
-    'src/core/labeling/**/*',
-    'src/core/pal/**/*',
-    'src/gui/labeling/**/*',
-    'src/ui/labeling/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/app/labeling/**/*",
+            "src/core/labeling/**/*",
+            "src/core/pal/**/*",
+            "src/gui/labeling/**/*",
+            "src/ui/labeling/**/*",
+          ]
 
 "Locator":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/app/locator/**/*',
-    'src/core/locator/**/*',
-    'src/gui/locator/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/app/locator/**/*",
+            "src/core/locator/**/*",
+            "src/gui/locator/**/*",
+          ]
 
 "Mesh":
-- changed-files:
-  - any-glob-to-any-file: [
-    'external/mdal/**/*',
-    'src/analysis/mesh/**/*',
-    'src/app/mesh/**/*',
-    'src/core/mesh/**/*',
-    'src/gui/mesh/**/*',
-    'src/ui/mesh/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "external/mdal/**/*",
+            "src/analysis/mesh/**/*",
+            "src/app/mesh/**/*",
+            "src/core/mesh/**/*",
+            "src/gui/mesh/**/*",
+            "src/ui/mesh/**/*",
+          ]
 
 "Metasearch":
-- changed-files:
-  - any-glob-to-any-file: ['python/plugins/MetaSearch/**/*']
+  - changed-files:
+      - any-glob-to-any-file: ["python/plugins/MetaSearch/**/*"]
 
 "MS SQL data provider":
-- changed-files:
-  - any-glob-to-any-file: ['src/providers/mssql/**/*']
+  - changed-files:
+      - any-glob-to-any-file: ["src/providers/mssql/**/*"]
 
 "Oracle data provider":
-- changed-files:
-  - any-glob-to-any-file: ['src/providers/oracle/**/*']
+  - changed-files:
+      - any-glob-to-any-file: ["src/providers/oracle/**/*"]
 
 "Point Clouds":
-- changed-files:
-  - any-glob-to-any-file: [
-    'external/pdal_wrench/**/*',
-    'src/app/pointcloud/**/*',
-    'src/core/pointcloud/**/*',
-    'src/gui/pointcloud/**/*',
-    'src/providers/pdal/**/*',
-    'src/ui/pointcloud/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "external/pdal_wrench/**/*",
+            "src/app/pointcloud/**/*",
+            "src/core/pointcloud/**/*",
+            "src/gui/pointcloud/**/*",
+            "src/providers/pdal/**/*",
+            "src/ui/pointcloud/**/*",
+          ]
 
 "PostGIS data provider":
-- changed-files:
-  - any-glob-to-any-file: ['src/providers/postgres/**/*']
+  - changed-files:
+      - any-glob-to-any-file: ["src/providers/postgres/**/*"]
 
 "Print Layouts":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/app/layout/**/*',
-    'src/core/layout/**/*',
-    'src/gui/layout/**/*',
-    'src/ui/layout/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/app/layout/**/*",
+            "src/core/layout/**/*",
+            "src/gui/layout/**/*",
+            "src/ui/layout/**/*",
+          ]
 
 "Processing":
-- changed-files:
-  - any-glob-to-any-file: [
-    'python/plugins/processing/**/*',
-    'src/analysis/**/*',
-    'src/core/processing/**/*',
-    'src/process/**/*',
-    'src/ui/processing/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "python/plugins/processing/**/*",
+            "src/analysis/**/*",
+            "src/core/processing/**/*",
+            "src/process/**/*",
+            "src/ui/processing/**/*",
+          ]
 
 "Profile tool":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/app/elevation/**/*',
-    'src/core/elevation/**/*',
-    'src/gui/elevation/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/app/elevation/**/*",
+            "src/core/elevation/**/*",
+            "src/gui/elevation/**/*",
+          ]
 
 "Python Console":
-- changed-files:
-  - any-glob-to-any-file: [
-    'python/console/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file: ["python/console/**/*"]
 
 "Quick":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/quickgui/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file: ["src/quickgui/**/*"]
 
 "Rasters":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/app/raster/**/*',
-    'src/core/raster/**/*',
-    'src/gui/raster/**/*',
-    'src/ui/raster/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "src/app/raster/**/*",
+            "src/core/raster/**/*",
+            "src/gui/raster/**/*",
+            "src/ui/raster/**/*",
+          ]
 
 "Server":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/server/**/*',
-    'resources/server/**/*'
-  ]
+  - changed-files:
+      - any-glob-to-any-file: ["src/server/**/*", "resources/server/**/*"]
 
 "Vector tiles":
-- changed-files:
-  - any-glob-to-any-file: [
-    'src/core/vectortile/**/*',
-    'src/gui/vectortile/**/*',
-  ]
+  - changed-files:
+      - any-glob-to-any-file:
+          ["src/core/vectortile/**/*", "src/gui/vectortile/**/*"]

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,8 +1,8 @@
 name: "🌈 Triage"
 
 on:
-  pull_request_target:   # zizmor: ignore[dangerous-triggers]
-    types: [ opened, synchronize, reopened ]
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -15,6 +15,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13  # v7.0.0
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fix CI error:

```raw
The configuration file (path: .github/labeler.yml) was not found locally, fetching via the api
Error: YAMLException: deficient indentation (4:5)

 1 | "3D":
 2 | - changed-files:
 3 |   - any-glob-to-any-file: [
 4 |     'resources/3d/**/*',
---------^
 5 |     'src/3d/**/*',
 6 |     'src/app/3d/**/*',
Error: deficient indentation (4:5)

 1 | "3D":
 2 | - changed-files:
 3 |   - any-glob-to-any-file: [
 4 |     'resources/3d/**/*',
---------^
 5 |     'src/3d/**/*',
 6 |     'src/app/3d/**/*',
```

The job fails because the existing file is poorly indented; it worked in version 6.1.0, but updating the job to version 7.0 is what caused the failures. This PR is only a linter/format pass on the labeler.yml file.

This change will be only available on new PR as the action/labeler read the labeler.yml file from the master. The current changes have no effect on this branch/PR (see https://github.com/actions/labeler?tab=readme-ov-file#updating-major-version-of-the-labeler).