### PR TITLE
[api] Add label engine flags to permit super-quick labeling engine run

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -5525,6 +5525,9 @@ QgsLabelingEngineSettings.IgnoreObstacles.__doc__ = "Disable obstacle handling \
 QgsLabelingEngineSettings.SingleCandidateOnly = Qgis.LabelingFlag.SingleCandidateOnly
 QgsLabelingEngineSettings.SingleCandidateOnly.is_monkey_patched = True
 QgsLabelingEngineSettings.SingleCandidateOnly.__doc__ = "Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews. \n.. versionadded:: 4.4"
+QgsLabelingEngineSettings.IgnoreOverlaps = Qgis.LabelingFlag.IgnoreOverlaps
+QgsLabelingEngineSettings.IgnoreOverlaps.is_monkey_patched = True
+QgsLabelingEngineSettings.IgnoreOverlaps.__doc__ = "Disable overlap detection and search solver, immediately returning lowest cost candidate per feature \n.. versionadded:: 4.4"
 QgsLabelingEngineSettings.DisableSearchTree = Qgis.LabelingFlag.DisableSearchTree
 QgsLabelingEngineSettings.DisableSearchTree.is_monkey_patched = True
 QgsLabelingEngineSettings.DisableSearchTree.__doc__ = "Disable the creation of the label search tree \n.. versionadded:: 4.4"
@@ -5553,6 +5556,10 @@ Prior to QGIS 3.30 this was available as :py:class:`QgsLabelingEngineSettings`.F
   .. versionadded:: 4.4
 
 * ``SingleCandidateOnly``: Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews.
+
+  .. versionadded:: 4.4
+
+* ``IgnoreOverlaps``: Disable overlap detection and search solver, immediately returning lowest cost candidate per feature
 
   .. versionadded:: 4.4
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -5519,6 +5519,9 @@ QgsLabelingEngineSettings.CollectUnplacedLabels.__doc__ = "Whether unplaced labe
 QgsLabelingEngineSettings.DrawLabelMetrics = Qgis.LabelingFlag.DrawLabelMetrics
 QgsLabelingEngineSettings.DrawLabelMetrics.is_monkey_patched = True
 QgsLabelingEngineSettings.DrawLabelMetrics.__doc__ = "Whether to render label metric guides (for debugging) \n.. versionadded:: 3.30"
+QgsLabelingEngineSettings.IgnoreObstacles = Qgis.LabelingFlag.IgnoreObstacles
+QgsLabelingEngineSettings.IgnoreObstacles.is_monkey_patched = True
+QgsLabelingEngineSettings.IgnoreObstacles.__doc__ = "Disable obstacle handling \n.. versionadded:: 4.4"
 QgsLabelingEngineSettings.SingleCandidateOnly = Qgis.LabelingFlag.SingleCandidateOnly
 QgsLabelingEngineSettings.SingleCandidateOnly.is_monkey_patched = True
 QgsLabelingEngineSettings.SingleCandidateOnly.__doc__ = "Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews. \n.. versionadded:: 4.4"
@@ -5544,6 +5547,10 @@ Prior to QGIS 3.30 this was available as :py:class:`QgsLabelingEngineSettings`.F
 * ``DrawLabelMetrics``: Whether to render label metric guides (for debugging)
 
   .. versionadded:: 3.30
+
+* ``IgnoreObstacles``: Disable obstacle handling
+
+  .. versionadded:: 4.4
 
 * ``SingleCandidateOnly``: Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews.
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -5519,6 +5519,9 @@ QgsLabelingEngineSettings.CollectUnplacedLabels.__doc__ = "Whether unplaced labe
 QgsLabelingEngineSettings.DrawLabelMetrics = Qgis.LabelingFlag.DrawLabelMetrics
 QgsLabelingEngineSettings.DrawLabelMetrics.is_monkey_patched = True
 QgsLabelingEngineSettings.DrawLabelMetrics.__doc__ = "Whether to render label metric guides (for debugging) \n.. versionadded:: 3.30"
+QgsLabelingEngineSettings.SingleCandidateOnly = Qgis.LabelingFlag.SingleCandidateOnly
+QgsLabelingEngineSettings.SingleCandidateOnly.is_monkey_patched = True
+QgsLabelingEngineSettings.SingleCandidateOnly.__doc__ = "Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews. \n.. versionadded:: 4.4"
 Qgis.LabelingFlag.__doc__ = """Various flags that affect drawing and placement of labels.
 
 Prior to QGIS 3.30 this was available as :py:class:`QgsLabelingEngineSettings`.Flag
@@ -5538,6 +5541,10 @@ Prior to QGIS 3.30 this was available as :py:class:`QgsLabelingEngineSettings`.F
 * ``DrawLabelMetrics``: Whether to render label metric guides (for debugging)
 
   .. versionadded:: 3.30
+
+* ``SingleCandidateOnly``: Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews.
+
+  .. versionadded:: 4.4
 
 
 """

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -5522,6 +5522,9 @@ QgsLabelingEngineSettings.DrawLabelMetrics.__doc__ = "Whether to render label me
 QgsLabelingEngineSettings.SingleCandidateOnly = Qgis.LabelingFlag.SingleCandidateOnly
 QgsLabelingEngineSettings.SingleCandidateOnly.is_monkey_patched = True
 QgsLabelingEngineSettings.SingleCandidateOnly.__doc__ = "Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews. \n.. versionadded:: 4.4"
+QgsLabelingEngineSettings.DisableSearchTree = Qgis.LabelingFlag.DisableSearchTree
+QgsLabelingEngineSettings.DisableSearchTree.is_monkey_patched = True
+QgsLabelingEngineSettings.DisableSearchTree.__doc__ = "Disable the creation of the label search tree \n.. versionadded:: 4.4"
 Qgis.LabelingFlag.__doc__ = """Various flags that affect drawing and placement of labels.
 
 Prior to QGIS 3.30 this was available as :py:class:`QgsLabelingEngineSettings`.Flag
@@ -5543,6 +5546,10 @@ Prior to QGIS 3.30 this was available as :py:class:`QgsLabelingEngineSettings`.F
   .. versionadded:: 3.30
 
 * ``SingleCandidateOnly``: Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews.
+
+  .. versionadded:: 4.4
+
+* ``DisableSearchTree``: Disable the creation of the label search tree
 
   .. versionadded:: 4.4
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1762,6 +1762,7 @@ The development version
       DrawLabelMetrics,
       IgnoreObstacles,
       SingleCandidateOnly,
+      IgnoreOverlaps,
       DisableSearchTree,
     };
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1760,6 +1760,7 @@ The development version
       DrawUnplacedLabels,
       CollectUnplacedLabels,
       DrawLabelMetrics,
+      SingleCandidateOnly,
     };
 
     typedef QFlags<Qgis::LabelingFlag> LabelingFlags;

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1761,6 +1761,7 @@ The development version
       CollectUnplacedLabels,
       DrawLabelMetrics,
       SingleCandidateOnly,
+      DisableSearchTree,
     };
 
     typedef QFlags<Qgis::LabelingFlag> LabelingFlags;

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1760,6 +1760,7 @@ The development version
       DrawUnplacedLabels,
       CollectUnplacedLabels,
       DrawLabelMetrics,
+      IgnoreObstacles,
       SingleCandidateOnly,
       DisableSearchTree,
     };

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -899,8 +899,7 @@ void QgsDxfExport::prepareRenderers()
   mRenderContext.expressionContext().appendScope( QgsExpressionContextUtils::globalScope() );
   mRenderContext.expressionContext().appendScope( QgsExpressionContextUtils::mapSettingsScope( mMapSettings ) );
 
-  mLabelingEngine = std::make_unique<QgsDefaultLabelingEngine>();
-  mLabelingEngine->setMapSettings( mMapSettings );
+  mLabelingEngine = std::make_unique<QgsDefaultLabelingEngine>( mMapSettings );
   mRenderContext.setLabelingEngine( mLabelingEngine.get() );
 
   const QList< QgsMapLayer * > layers = mMapSettings.layers();

--- a/src/core/labeling/qgslabelingengine.cpp
+++ b/src/core/labeling/qgslabelingengine.cpp
@@ -89,8 +89,12 @@ class QgsLabelSorter
 //
 
 QgsLabelingEngine::QgsLabelingEngine( const QgsMapSettings &mapSettings )
-  : mResults( new QgsLabelingResults )
 {
+  if ( !mapSettings.labelingEngineSettings().flags().testFlag( Qgis::LabelingFlag::DisableSearchTree ) )
+  {
+    mResults = std::make_unique< QgsLabelingResults >();
+  }
+
   setMapSettings( mapSettings );
 }
 

--- a/src/core/labeling/qgslabelingengine.cpp
+++ b/src/core/labeling/qgslabelingengine.cpp
@@ -88,9 +88,11 @@ class QgsLabelSorter
 // QgsLabelingEngine
 //
 
-QgsLabelingEngine::QgsLabelingEngine()
+QgsLabelingEngine::QgsLabelingEngine( const QgsMapSettings &mapSettings )
   : mResults( new QgsLabelingResults )
-{}
+{
+  setMapSettings( mapSettings );
+}
 
 QgsLabelingEngine::~QgsLabelingEngine()
 {
@@ -801,8 +803,8 @@ void QgsLabelingEngine::drawLabelMetrics( pal::LabelPosition *label, const QgsMa
 //  QgsDefaultLabelingEngine
 //
 
-QgsDefaultLabelingEngine::QgsDefaultLabelingEngine()
-  : QgsLabelingEngine()
+QgsDefaultLabelingEngine::QgsDefaultLabelingEngine( const QgsMapSettings &mapSettings )
+  : QgsLabelingEngine( mapSettings )
 {}
 
 void QgsDefaultLabelingEngine::run( QgsRenderContext &context )
@@ -830,8 +832,8 @@ void QgsDefaultLabelingEngine::run( QgsRenderContext &context )
 //  QgsStagedRenderLabelingEngine
 //
 
-QgsStagedRenderLabelingEngine::QgsStagedRenderLabelingEngine()
-  : QgsLabelingEngine()
+QgsStagedRenderLabelingEngine::QgsStagedRenderLabelingEngine( const QgsMapSettings &mapSettings )
+  : QgsLabelingEngine( mapSettings )
 {}
 
 void QgsStagedRenderLabelingEngine::run( QgsRenderContext &context )

--- a/src/core/labeling/qgslabelingengine.cpp
+++ b/src/core/labeling/qgslabelingengine.cpp
@@ -289,7 +289,7 @@ void QgsLabelingEngine::registerLabels( QgsRenderContext &context )
 
   const QgsLabelingEngineSettings &settings = mMapSettings.labelingEngineSettings();
 
-  mPal = std::make_unique< pal::Pal >();
+  mPal = std::make_unique< pal::Pal >( settings.flags() );
 
   mPal->setMaximumLineCandidatesPerMapUnit( settings.maximumLineCandidatesPerCm() / context.convertToMapUnits( 10, Qgis::RenderUnit::Millimeters ) );
   mPal->setMaximumPolygonCandidatesPerMapUnitSquared( settings.maximumPolygonCandidatesPerCmSquared() / std::pow( context.convertToMapUnits( 10, Qgis::RenderUnit::Millimeters ), 2 ) );

--- a/src/core/labeling/qgslabelingengine.h
+++ b/src/core/labeling/qgslabelingengine.h
@@ -362,7 +362,7 @@ class CORE_EXPORT QgsLabelingEngine
 {
   public:
     //! Construct the labeling engine with default settings
-    QgsLabelingEngine();
+    QgsLabelingEngine( const QgsMapSettings &mapSettings );
     //! Clean up everything (especially the registered providers)
     virtual ~QgsLabelingEngine();
 
@@ -522,7 +522,7 @@ class CORE_EXPORT QgsDefaultLabelingEngine : public QgsLabelingEngine
 {
   public:
     //! Construct the labeling engine with default settings
-    QgsDefaultLabelingEngine();
+    QgsDefaultLabelingEngine( const QgsMapSettings &mapSettings );
 
     QgsDefaultLabelingEngine( const QgsDefaultLabelingEngine &rh ) = delete;
     QgsDefaultLabelingEngine &operator=( const QgsDefaultLabelingEngine &rh ) = delete;
@@ -545,7 +545,7 @@ class CORE_EXPORT QgsStagedRenderLabelingEngine : public QgsLabelingEngine
 {
   public:
     //! Construct the labeling engine with default settings
-    QgsStagedRenderLabelingEngine();
+    QgsStagedRenderLabelingEngine( const QgsMapSettings &mapSettings );
 
     QgsStagedRenderLabelingEngine( const QgsStagedRenderLabelingEngine &rh ) = delete;
     QgsStagedRenderLabelingEngine &operator=( const QgsStagedRenderLabelingEngine &rh ) = delete;

--- a/src/core/labeling/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/labeling/qgsvectorlayerlabelprovider.cpp
@@ -346,12 +346,15 @@ void QgsVectorLayerLabelProvider::drawCallout( QgsRenderContext &context, pal::L
 
     const QList< QgsCalloutPosition > renderedPositions = calloutContext.positions();
 
-    for ( QgsCalloutPosition position : renderedPositions )
+    if ( !mEngine->engineSettings().flags().testFlag( Qgis::LabelingFlag::DisableSearchTree ) )
     {
-      position.layerID = mLayerId;
-      position.featureId = label->getFeaturePart()->featureId();
-      position.providerID = mProviderId;
-      mEngine->results()->mLabelSearchTree->insertCallout( position );
+      for ( QgsCalloutPosition position : renderedPositions )
+      {
+        position.layerID = mLayerId;
+        position.featureId = label->getFeaturePart()->featureId();
+        position.providerID = mProviderId;
+        mEngine->results()->mLabelSearchTree->insertCallout( position );
+      }
     }
   }
 }
@@ -470,8 +473,11 @@ void QgsVectorLayerLabelProvider::drawLabel( QgsRenderContext &context, pal::Lab
   drawLabelPrivate( label, context, tmpLyr, Qgis::TextComponent::Text );
 
   // add to the results
-  QString labeltext = label->getFeaturePart()->feature()->labelText();
-  mEngine->results()->mLabelSearchTree->insertLabel( label, label->getFeaturePart()->featureId(), mLayerId, labeltext, dFont, false, lf->hasFixedPosition(), mProviderId );
+  if ( !mEngine->engineSettings().flags().testFlag( Qgis::LabelingFlag::DisableSearchTree ) )
+  {
+    const QString labeltext = label->getFeaturePart()->feature()->labelText();
+    mEngine->results()->mLabelSearchTree->insertLabel( label, label->getFeaturePart()->featureId(), mLayerId, labeltext, dFont, false, lf->hasFixedPosition(), mProviderId );
+  }
 }
 
 void QgsVectorLayerLabelProvider::drawUnplacedLabel( QgsRenderContext &context, LabelPosition *label ) const
@@ -490,9 +496,12 @@ void QgsVectorLayerLabelProvider::drawUnplacedLabel( QgsRenderContext &context, 
     drawLabelPrivate( label, context, tmpLyr, Qgis::TextComponent::Text );
   }
 
-  // add to the results
-  QString labeltext = label->getFeaturePart()->feature()->labelText();
-  mEngine->results()->mLabelSearchTree->insertLabel( label, label->getFeaturePart()->featureId(), mLayerId, labeltext, format.font(), false, lf->hasFixedPosition(), mProviderId, true );
+  if ( !mEngine->engineSettings().flags().testFlag( Qgis::LabelingFlag::DisableSearchTree ) )
+  {
+    // add to the results
+    const QString labeltext = label->getFeaturePart()->feature()->labelText();
+    mEngine->results()->mLabelSearchTree->insertLabel( label, label->getFeaturePart()->featureId(), mLayerId, labeltext, format.font(), false, lf->hasFixedPosition(), mProviderId, true );
+  }
 }
 
 void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, QgsRenderContext &context, QgsPalLayerSettings &tmpLyr, Qgis::TextComponent drawType, double dpiRatio ) const

--- a/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/maprenderer/qgsmaprenderercustompainterjob.cpp
@@ -99,8 +99,7 @@ void QgsMapRendererCustomPainterJob::startPrivate()
 
   if ( mSettings.testFlag( Qgis::MapSettingsFlag::DrawLabeling ) )
   {
-    mLabelingEngineV2 = std::make_unique<QgsDefaultLabelingEngine>();
-    mLabelingEngineV2->setMapSettings( mSettings );
+    mLabelingEngineV2 = std::make_unique<QgsDefaultLabelingEngine>( mSettings );
   }
 
   const bool canUseLabelCache = prepareLabelCache();

--- a/src/core/maprenderer/qgsmaprendererparalleljob.cpp
+++ b/src/core/maprenderer/qgsmaprendererparalleljob.cpp
@@ -65,8 +65,7 @@ void QgsMapRendererParallelJob::startPrivate()
 
   if ( mSettings.testFlag( Qgis::MapSettingsFlag::DrawLabeling ) )
   {
-    mLabelingEngineV2 = std::make_unique<QgsDefaultLabelingEngine>();
-    mLabelingEngineV2->setMapSettings( mSettings );
+    mLabelingEngineV2 = std::make_unique<QgsDefaultLabelingEngine>( mSettings );
   }
 
   const bool canUseLabelCache = prepareLabelCache();

--- a/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererstagedrenderjob.cpp
@@ -58,10 +58,9 @@ void QgsMapRendererStagedRenderJob::startPrivate()
   if ( mSettings.testFlag( Qgis::MapSettingsFlag::DrawLabeling ) )
   {
     if ( mFlags & RenderLabelsByMapLayer )
-      mLabelingEngineV2 = std::make_unique<QgsStagedRenderLabelingEngine>();
+      mLabelingEngineV2 = std::make_unique<QgsStagedRenderLabelingEngine>( mSettings );
     else
-      mLabelingEngineV2 = std::make_unique<QgsDefaultLabelingEngine>();
-    mLabelingEngineV2->setMapSettings( mSettings );
+      mLabelingEngineV2 = std::make_unique<QgsDefaultLabelingEngine>( mSettings );
   }
 
   mLayerJobs = prepareJobs( nullptr, mLabelingEngineV2.get(), true );

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -2674,6 +2674,22 @@ std::vector< std::unique_ptr< LabelPosition > > FeaturePart::createCandidates( P
     }
   }
 
+  if ( !lPos.empty() && pal->flags().testFlag( Qgis::LabelingFlag::SingleCandidateOnly ) )
+  {
+    // retain only the single least-cost candidate
+    // Note that we didn't handle this flag earlier, as we wanted to generate the full number
+    // of candidates considering the geometry of the feature, and then only NOW cull to the best
+    // one.
+    auto minIt = std::min_element( lPos.begin(), lPos.end(), []( const std::unique_ptr< LabelPosition > &a, const std::unique_ptr< LabelPosition > &b ) { return a->cost() < b->cost(); } );
+
+    if ( minIt != lPos.end() )
+    {
+      std::unique_ptr< LabelPosition > bestCandidate = std::move( *minIt );
+      lPos.clear();
+      lPos.emplace_back( std::move( bestCandidate ) );
+    }
+  }
+
   return lPos;
 }
 

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -64,7 +64,8 @@ const QgsSettingsEntryInteger *Pal::settingsRenderingLabelCandidatesLimitLines =
 const QgsSettingsEntryInteger *Pal::settingsRenderingLabelCandidatesLimitPolygons = new QgsSettingsEntryInteger( u"label-candidates-limit-polygons"_s, sTreePal, 0 );
 
 
-Pal::Pal()
+Pal::Pal( Qgis::LabelingFlags flags )
+  : mFlags( flags )
 {
   mGlobalCandidatesLimitPoint = Pal::settingsRenderingLabelCandidatesLimitPoints->value();
   mGlobalCandidatesLimitLine = Pal::settingsRenderingLabelCandidatesLimitLines->value();

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -539,7 +539,10 @@ std::unique_ptr<Problem> Pal::extractProblem( const QgsRectangle &extent, const 
       switch ( feat->feature->feature()->overlapHandling() )
       {
         case Qgis::LabelOverlapHandling::PreventOverlap:
-          pruneHardConflicts();
+          if ( !mFlags.testFlag( Qgis::LabelingFlag::IgnoreOverlaps ) )
+          {
+            pruneHardConflicts();
+          }
           break;
 
         case Qgis::LabelOverlapHandling::AllowOverlapIfRequired:
@@ -566,7 +569,10 @@ std::unique_ptr<Problem> Pal::extractProblem( const QgsRectangle &extent, const 
           break;
         case Qgis::LabelOverlapHandling::AllowOverlapIfRequired:
         case Qgis::LabelOverlapHandling::AllowOverlapAtNoCost:
-          pruneHardConflicts();
+          if ( !mFlags.testFlag( Qgis::LabelingFlag::IgnoreOverlaps ) )
+          {
+            pruneHardConflicts();
+          }
           break;
       }
 
@@ -634,17 +640,20 @@ std::unique_ptr<Problem> Pal::extractProblem( const QgsRectangle &extent, const 
         //prob->feat[idlp] = j;
 
         // lookup for overlapping candidate
-        const QgsRectangle searchBounds = lp->boundingBoxForCandidateConflicts( this );
-        prob->allCandidatesIndex().intersects( searchBounds, [&lp, this]( const LabelPosition *lp2 ) -> bool {
-          if ( candidatesAreConflicting( lp.get(), lp2 ) )
-          {
-            lp->incrementNumOverlaps();
-          }
+        if ( !mFlags.testFlag( Qgis::LabelingFlag::IgnoreOverlaps ) )
+        {
+          const QgsRectangle searchBounds = lp->boundingBoxForCandidateConflicts( this );
+          prob->allCandidatesIndex().intersects( searchBounds, [&lp, this]( const LabelPosition *lp2 ) -> bool {
+            if ( candidatesAreConflicting( lp.get(), lp2 ) )
+            {
+              lp->incrementNumOverlaps();
+            }
 
-          return true;
-        } );
+            return true;
+          } );
 
-        nbOverlaps += lp->getNumOverlaps();
+          nbOverlaps += lp->getNumOverlaps();
+        }
 
         prob->addCandidatePosition( std::move( lp ) );
 

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -327,16 +327,19 @@ std::unique_ptr<Problem> Pal::extractProblem( const QgsRectangle &extent, const 
     if ( isCanceled() )
       return nullptr;
 
-    // collate all layer obstacles
-    for ( FeaturePart *obstaclePart : std::as_const( layer->mObstacleParts ) )
+    if ( !mFlags.testFlag( Qgis::LabelingFlag::IgnoreObstacles ) )
     {
-      if ( isCanceled() )
-        break; // do not continue searching
+      // collate all layer obstacles
+      for ( FeaturePart *obstaclePart : std::as_const( layer->mObstacleParts ) )
+      {
+        if ( isCanceled() )
+          break; // do not continue searching
 
-      // insert into obstacles
-      obstacles.insert( obstaclePart, obstaclePart->boundingBox() );
-      allObstacleParts.emplace_back( obstaclePart );
-      obstacleCount++;
+        // insert into obstacles
+        obstacles.insert( obstaclePart, obstaclePart->boundingBox() );
+        allObstacleParts.emplace_back( obstaclePart );
+        obstacleCount++;
+      }
     }
 
     if ( isCanceled() )
@@ -373,62 +376,64 @@ std::unique_ptr<Problem> Pal::extractProblem( const QgsRectangle &extent, const 
 
   if ( !features.empty() )
   {
-    if ( feedback )
-      feedback->emit obstacleCostingAboutToBegin();
-
-    std::unique_ptr< QgsScopedRuntimeProfile > costingProfile;
-    if ( context.flags() & Qgis::RenderContextFlag::RecordProfile )
+    if ( !mFlags.testFlag( Qgis::LabelingFlag::IgnoreObstacles ) )
     {
-      costingProfile = std::make_unique< QgsScopedRuntimeProfile >( QObject::tr( "Assigning label costs" ), u"rendering"_s );
-    }
+      if ( feedback )
+        feedback->emit obstacleCostingAboutToBegin();
 
-    // allow rules to alter candidate costs
-    for ( const auto &feature : features )
-    {
-      for ( auto &candidate : feature->candidates )
+      std::unique_ptr< QgsScopedRuntimeProfile > costingProfile;
+      if ( context.flags() & Qgis::RenderContextFlag::RecordProfile )
       {
-        for ( QgsAbstractLabelingEngineRule *rule : std::as_const( mRules ) )
+        costingProfile = std::make_unique< QgsScopedRuntimeProfile >( QObject::tr( "Assigning label costs" ), u"rendering"_s );
+      }
+
+      // allow rules to alter candidate costs
+      for ( const auto &feature : features )
+      {
+        for ( auto &candidate : feature->candidates )
         {
-          rule->alterCandidateCost( candidate.get(), labelContext );
+          for ( QgsAbstractLabelingEngineRule *rule : std::as_const( mRules ) )
+          {
+            rule->alterCandidateCost( candidate.get(), labelContext );
+          }
         }
       }
-    }
 
-    // Filtering label positions against obstacles
-    index = -1;
-    step = !allObstacleParts.empty() ? 100.0 / allObstacleParts.size() : 1;
+      // Filtering label positions against obstacles
+      index = -1;
+      step = !allObstacleParts.empty() ? 100.0 / allObstacleParts.size() : 1;
 
-    for ( FeaturePart *obstaclePart : allObstacleParts )
-    {
-      index++;
-      if ( feedback )
-        feedback->setProgress( step * index );
+      for ( FeaturePart *obstaclePart : allObstacleParts )
+      {
+        index++;
+        if ( feedback )
+          feedback->setProgress( step * index );
 
-      if ( isCanceled() )
-        break; // do not continue searching
+        if ( isCanceled() )
+          break; // do not continue searching
 
-      allCandidatesFirstRound.intersects( obstaclePart->boundingBox(), [obstaclePart, this]( const LabelPosition *candidatePosition ) -> bool {
-        // test whether we should ignore this obstacle for the candidate. We do this if:
-        // 1. it's not a hole, and the obstacle belongs to the same label feature as the candidate (e.g.,
-        // features aren't obstacles for their own labels)
-        // 2. it IS a hole, and the hole belongs to a different label feature to the candidate (e.g., holes
-        // are ONLY obstacles for the labels of the feature they belong to)
-        // 3. The label is set to "Always Allow" overlap mode
-        if ( candidatePosition->getFeaturePart()->feature()->overlapHandling() == Qgis::LabelOverlapHandling::AllowOverlapAtNoCost
-             || ( !obstaclePart->getHoleOf() && candidatePosition->getFeaturePart()->hasSameLabelFeatureAs( obstaclePart ) )
-             || ( obstaclePart->getHoleOf() && !candidatePosition->getFeaturePart()->hasSameLabelFeatureAs( dynamic_cast< FeaturePart * >( obstaclePart->getHoleOf() ) ) ) )
-        {
+        allCandidatesFirstRound.intersects( obstaclePart->boundingBox(), [obstaclePart, this]( const LabelPosition *candidatePosition ) -> bool {
+          // test whether we should ignore this obstacle for the candidate. We do this if:
+          // 1. it's not a hole, and the obstacle belongs to the same label feature as the candidate (e.g.,
+          // features aren't obstacles for their own labels)
+          // 2. it IS a hole, and the hole belongs to a different label feature to the candidate (e.g., holes
+          // are ONLY obstacles for the labels of the feature they belong to)
+          // 3. The label is set to "Always Allow" overlap mode
+          if ( candidatePosition->getFeaturePart()->feature()->overlapHandling() == Qgis::LabelOverlapHandling::AllowOverlapAtNoCost
+               || ( !obstaclePart->getHoleOf() && candidatePosition->getFeaturePart()->hasSameLabelFeatureAs( obstaclePart ) )
+               || ( obstaclePart->getHoleOf() && !candidatePosition->getFeaturePart()->hasSameLabelFeatureAs( dynamic_cast< FeaturePart * >( obstaclePart->getHoleOf() ) ) ) )
+          {
+            return true;
+          }
+
+          CostCalculator::addObstacleCostPenalty( const_cast< LabelPosition * >( candidatePosition ), obstaclePart, this );
           return true;
-        }
+        } );
+      }
 
-        CostCalculator::addObstacleCostPenalty( const_cast< LabelPosition * >( candidatePosition ), obstaclePart, this );
-        return true;
-      } );
+      if ( feedback )
+        feedback->emit obstacleCostingFinished();
     }
-
-    if ( feedback )
-      feedback->emit obstacleCostingFinished();
-    costingProfile.reset();
 
     if ( isCanceled() )
     {

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -173,6 +173,8 @@ namespace pal
        */
       void setShowPartialLabels( bool show );
 
+      static constexpr bool DEFAULT_SHOW_PARTIAL_LABELS = true;
+
       /**
        * Returns whether partial labels should be allowed.
        *
@@ -307,7 +309,7 @@ namespace pal
       /**
        * \brief show partial labels (cut-off by the map canvas) or not
        */
-      bool mShowPartialLabels = true;
+      bool mShowPartialLabels = DEFAULT_SHOW_PARTIAL_LABELS;
 
       double mMaxLineCandidatesPerMapUnit = 0;
       double mMaxPolygonCandidatesPerMapUnitSquared = 0;

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -96,11 +96,16 @@ namespace pal
       static const QgsSettingsEntryInteger *settingsRenderingLabelCandidatesLimitLines;
       static const QgsSettingsEntryInteger *settingsRenderingLabelCandidatesLimitPolygons;
 
-      Pal();
+      Pal( Qgis::LabelingFlags flags );
       ~Pal();
 
       Pal( const Pal &other ) = delete;
       Pal &operator=( const Pal &other ) = delete;
+
+      /**
+       * Returns labeling flags.
+       */
+      Qgis::LabelingFlags flags() const { return mFlags; }
 
       /**
        * \brief add a new layer
@@ -285,6 +290,8 @@ namespace pal
       QList< QgsAbstractLabelingEngineRule * > rules() const { return mRules; }
 
     private:
+      Qgis::LabelingFlags mFlags;
+
       std::vector< std::pair< QgsAbstractLabelProvider *, std::unique_ptr< Layer > > > mLayers;
 
       QList< QgsAbstractLabelingEngineRule * > mRules;

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -96,6 +96,9 @@ namespace pal
       static const QgsSettingsEntryInteger *settingsRenderingLabelCandidatesLimitLines;
       static const QgsSettingsEntryInteger *settingsRenderingLabelCandidatesLimitPolygons;
 
+      /**
+       * Constructor for pal labeling engine.
+       */
       Pal( Qgis::LabelingFlags flags );
       ~Pal();
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3047,6 +3047,7 @@ int QgisEvent = QEvent::User + 1;
       CollectUnplacedLabels = 1 << 7, //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered) \since QGIS 3.20
       DrawLabelMetrics = 1 << 8,      //!< Whether to render label metric guides (for debugging) \since QGIS 3.30
       SingleCandidateOnly = 1 << 10,  //!< Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews. \since QGIS 4.4
+      DisableSearchTree = 1 << 12,    //!< Disable the creation of the label search tree \since QGIS 4.4
     };
     Q_ENUM( LabelingFlag )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3046,6 +3046,7 @@ int QgisEvent = QEvent::User + 1;
       DrawUnplacedLabels = 1 << 6,    //!< Whether to render unplaced labels as an indicator/warning for users
       CollectUnplacedLabels = 1 << 7, //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered) \since QGIS 3.20
       DrawLabelMetrics = 1 << 8,      //!< Whether to render label metric guides (for debugging) \since QGIS 3.30
+      SingleCandidateOnly = 1 << 10,  //!< Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews. \since QGIS 4.4
     };
     Q_ENUM( LabelingFlag )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3046,6 +3046,7 @@ int QgisEvent = QEvent::User + 1;
       DrawUnplacedLabels = 1 << 6,    //!< Whether to render unplaced labels as an indicator/warning for users
       CollectUnplacedLabels = 1 << 7, //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered) \since QGIS 3.20
       DrawLabelMetrics = 1 << 8,      //!< Whether to render label metric guides (for debugging) \since QGIS 3.30
+      IgnoreObstacles = 1 << 9,       //!< Disable obstacle handling \since QGIS 4.4
       SingleCandidateOnly = 1 << 10,  //!< Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews. \since QGIS 4.4
       DisableSearchTree = 1 << 12,    //!< Disable the creation of the label search tree \since QGIS 4.4
     };

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3048,6 +3048,7 @@ int QgisEvent = QEvent::User + 1;
       DrawLabelMetrics = 1 << 8,      //!< Whether to render label metric guides (for debugging) \since QGIS 3.30
       IgnoreObstacles = 1 << 9,       //!< Disable obstacle handling \since QGIS 4.4
       SingleCandidateOnly = 1 << 10,  //!< Generate only the single least-cost candidate for each feature. Useful for fast labeling, such as interactive labeling previews. \since QGIS 4.4
+      IgnoreOverlaps = 1 << 11,       //!< Disable overlap detection and search solver, immediately returning lowest cost candidate per feature \since QGIS 4.4
       DisableSearchTree = 1 << 12,    //!< Disable the creation of the label search tree \since QGIS 4.4
     };
     Q_ENUM( LabelingFlag )

--- a/src/core/vector/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/vector/qgsvectorlayerdiagramprovider.cpp
@@ -154,8 +154,11 @@ void QgsVectorLayerDiagramProvider::drawLabel( QgsRenderContext &context, pal::L
 
   mSettings.renderer()->renderDiagram( feature, context, centerPt.toQPointF(), mSettings.dataDefinedProperties() );
 
-  //insert into label search tree to manipulate position interactively
-  mEngine->results()->mLabelSearchTree->insertLabel( label, label->getFeaturePart()->featureId(), mLayerId, QString(), QFont(), true, false );
+  if ( !mEngine->engineSettings().flags().testFlag( Qgis::LabelingFlag::DisableSearchTree ) )
+  {
+    //insert into label search tree to manipulate position interactively
+    mEngine->results()->mLabelSearchTree->insertLabel( label, label->getFeaturePart()->featureId(), mLayerId, QString(), QFont(), true, false );
+  }
 }
 
 bool QgsVectorLayerDiagramProvider::prepare( const QgsRenderContext &context, QSet<QString> &attributeNames )

--- a/src/gui/labeling/qgslabelengineconfigdialog.cpp
+++ b/src/gui/labeling/qgslabelengineconfigdialog.cpp
@@ -141,13 +141,12 @@ void QgsLabelEngineConfigWidget::apply()
 
 void QgsLabelEngineConfigWidget::setDefaults()
 {
-  const pal::Pal p;
   spinCandLine->setValue( 5 );
   spinCandPolygon->setValue( 10 );
   chkShowCandidates->setChecked( false );
   chkShowMetrics->setChecked( false );
   chkShowAllLabels->setChecked( false );
-  chkShowPartialsLabels->setChecked( p.showPartialLabels() );
+  chkShowPartialsLabels->setChecked( pal::Pal::DEFAULT_SHOW_PARTIAL_LABELS );
   mTextRenderFormatComboBox->setCurrentIndex( mTextRenderFormatComboBox->findData( QVariant::fromValue( Qgis::TextRenderFormat::AlwaysOutlines ) ) );
   mPlacementVersionComboBox->setCurrentIndex( mPlacementVersionComboBox->findData( static_cast<int>( Qgis::LabelPlacementEngineVersion::Version2 ) ) );
 }

--- a/tests/src/core/testqgscallout.cpp
+++ b/tests/src/core/testqgscallout.cpp
@@ -306,8 +306,8 @@ void TestQgsCallout::calloutsInLabeling()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -371,8 +371,8 @@ void TestQgsCallout::calloutsBlend()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -422,8 +422,8 @@ void TestQgsCallout::calloutsWithRotation()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -520,8 +520,8 @@ void TestQgsCallout::calloutsDisabled()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -572,8 +572,8 @@ void TestQgsCallout::calloutsDataDefinedDisabled()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -624,8 +624,8 @@ void TestQgsCallout::calloutDataDefinedSymbol()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -676,8 +676,8 @@ void TestQgsCallout::calloutDataDefinedSymbolColor()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -728,8 +728,8 @@ void TestQgsCallout::calloutMinimumDistance()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -781,8 +781,8 @@ void TestQgsCallout::calloutDataDefinedMinimumDistance()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -833,8 +833,8 @@ void TestQgsCallout::calloutOffsetFromAnchor()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -885,8 +885,8 @@ void TestQgsCallout::calloutDataDefinedOffsetFromAnchor()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -938,8 +938,8 @@ void TestQgsCallout::calloutOffsetFromLabel()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -991,8 +991,8 @@ void TestQgsCallout::calloutDataDefinedOffsetFromLabel()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1043,8 +1043,8 @@ void TestQgsCallout::calloutLabelAnchorTopRight()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1061,8 +1061,7 @@ void TestQgsCallout::calloutLabelAnchorTopRight()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1111,8 +1110,8 @@ void TestQgsCallout::calloutLabelAnchorTopLeft()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1129,8 +1128,7 @@ void TestQgsCallout::calloutLabelAnchorTopLeft()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1179,8 +1177,8 @@ void TestQgsCallout::calloutLabelAnchorTop()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1197,8 +1195,7 @@ void TestQgsCallout::calloutLabelAnchorTop()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1247,8 +1244,8 @@ void TestQgsCallout::calloutLabelAnchorBottomLeft()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1265,8 +1262,7 @@ void TestQgsCallout::calloutLabelAnchorBottomLeft()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1315,8 +1311,8 @@ void TestQgsCallout::calloutLabelAnchorBottom()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1333,8 +1329,7 @@ void TestQgsCallout::calloutLabelAnchorBottom()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1383,8 +1378,8 @@ void TestQgsCallout::calloutLabelAnchorBottomRight()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1401,8 +1396,7 @@ void TestQgsCallout::calloutLabelAnchorBottomRight()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1451,8 +1445,8 @@ void TestQgsCallout::calloutLabelAnchorLeft()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1469,8 +1463,7 @@ void TestQgsCallout::calloutLabelAnchorLeft()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1519,8 +1512,8 @@ void TestQgsCallout::calloutLabelAnchorRight()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1537,8 +1530,7 @@ void TestQgsCallout::calloutLabelAnchorRight()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1587,8 +1579,8 @@ void TestQgsCallout::calloutLabelAnchorCentroid()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1605,8 +1597,7 @@ void TestQgsCallout::calloutLabelAnchorCentroid()
   settings.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::LabelRotation, QgsProperty::fromValue( 15 ) );
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
 
-  QgsDefaultLabelingEngine engine2;
-  engine2.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine2( mapSettings );
   engine2.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine2.run( context );
@@ -1656,8 +1647,8 @@ void TestQgsCallout::calloutLabelDataDefinedAnchor()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1712,8 +1703,8 @@ void TestQgsCallout::calloutBehindLabel()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1768,8 +1759,8 @@ void TestQgsCallout::calloutBehindIndividualLabels()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1836,8 +1827,8 @@ void TestQgsCallout::calloutNoDrawToAllParts()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1905,8 +1896,8 @@ void TestQgsCallout::calloutDrawToAllParts()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -1974,8 +1965,8 @@ void TestQgsCallout::calloutDataDefinedDrawToAllParts()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2037,8 +2028,8 @@ void TestQgsCallout::calloutPointOnExterior()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2100,8 +2091,8 @@ void TestQgsCallout::calloutDataDefinedAnchorPoint()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2165,8 +2156,8 @@ void TestQgsCallout::calloutDataDefinedDestination()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2230,8 +2221,8 @@ void TestQgsCallout::calloutDataDefinedOrigin()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2282,8 +2273,8 @@ void TestQgsCallout::manhattan()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2335,8 +2326,8 @@ void TestQgsCallout::manhattanRotated()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2403,8 +2394,8 @@ void TestQgsCallout::manhattanNoDrawToAllParts()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2472,8 +2463,8 @@ void TestQgsCallout::manhattanDrawToAllParts()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2541,8 +2532,8 @@ void TestQgsCallout::manhattanDataDefinedDrawToAllParts()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2606,8 +2597,8 @@ void TestQgsCallout::manhattanDataDefinedDestination()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2671,8 +2662,8 @@ void TestQgsCallout::manhattanDataDefinedOrigin()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2771,8 +2762,8 @@ void TestQgsCallout::curvedAutoLeavingLabelsAtBottomLeft()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2871,8 +2862,8 @@ void TestQgsCallout::curvedAutoLeavingLabelsAtBottomRight()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -2971,8 +2962,8 @@ void TestQgsCallout::curvedAutoLeavingLabelsAtTopLeft()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3071,8 +3062,8 @@ void TestQgsCallout::curvedAutoLeavingLabelsAtTopRight()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3171,8 +3162,8 @@ void TestQgsCallout::curvedAutoLeavingLabelsAtTop()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3271,8 +3262,8 @@ void TestQgsCallout::curvedAutoLeavingLabelsAtBottom()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3371,8 +3362,8 @@ void TestQgsCallout::curvedAutoLeavingLabelsAtLeft()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3471,8 +3462,8 @@ void TestQgsCallout::curvedAutoLeavingLabelsAtRight()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3540,8 +3531,8 @@ void TestQgsCallout::curvedAutoHorizontalLines()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3609,8 +3600,8 @@ void TestQgsCallout::curvedAutoVerticalLines()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3709,8 +3700,8 @@ void TestQgsCallout::curvedClockwise()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3809,8 +3800,8 @@ void TestQgsCallout::curvedCounterClockwise()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3910,8 +3901,8 @@ void TestQgsCallout::curvedCurvature()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2.get(), QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -3962,8 +3953,8 @@ void TestQgsCallout::balloonCallout()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -4015,8 +4006,8 @@ void TestQgsCallout::balloonCalloutMargin()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -4068,8 +4059,8 @@ void TestQgsCallout::balloonCalloutWedgeWidth()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -4121,8 +4112,8 @@ void TestQgsCallout::balloonCalloutCornerRadius()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -4181,8 +4172,8 @@ void TestQgsCallout::balloonCalloutMarkerSymbol()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -354,8 +354,8 @@ void TestQgsLabelingEngine::testBasic()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -403,8 +403,8 @@ void TestQgsLabelingEngine::testDiagrams()
   vl->loadNamedStyle( QStringLiteral( TEST_DATA_DIR ) + "/points_diagrams.qml", res );
   QVERIFY( res );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerDiagramProvider( vl ) );
   engine.run( context );
 
@@ -507,7 +507,7 @@ void TestQgsLabelingEngine::testRuleBased()
   context.setPainter( &p );
 
   QgsLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+
   engine.addProvider( new QgsRuleBasedLabelProvider(, vl ) );
   engine.run( context );
 #endif
@@ -551,8 +551,8 @@ void TestQgsLabelingEngine::zOrder()
   pls1.dataDefinedProperties().setProperty( QgsPalLayerSettings::Property::Size, QgsProperty::fromExpression( u"case when \"Class\"='Jet' then 100 when \"Class\"='B52' then 30 else 50 end"_s ) );
 
   QgsVectorLayerLabelProvider *provider1 = new QgsVectorLayerLabelProvider( vl, QString(), true, &pls1 );
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( provider1 );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -599,7 +599,7 @@ void TestQgsLabelingEngine::zOrder()
   engine.addProvider( provider2 );
 
   mapSettings.setLayers( QList<QgsMapLayer *>() << vl << vl2 );
-  engine.setMapSettings( mapSettings );
+
 
   p.begin( &img );
   engine.run( context );
@@ -611,7 +611,7 @@ void TestQgsLabelingEngine::zOrder()
 
   //flip layer order and re-test
   mapSettings.setLayers( QList<QgsMapLayer *>() << vl2 << vl );
-  engine.setMapSettings( mapSettings );
+
   p.begin( &img );
   engine.run( context );
   p.end();
@@ -709,8 +709,8 @@ void TestQgsLabelingEngine::testSubstitutions()
   mapSettings.setOutputDpi( 96 );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   QSet<QString> attributes;
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( provider );
   provider->prepare( context, attributes );
 
@@ -742,8 +742,8 @@ void TestQgsLabelingEngine::testCapitalization()
   mapSettings.setOutputDpi( 96 );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   QSet<QString> attributes;
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
 
   // no change
   QgsPalLayerSettings settings;
@@ -849,8 +849,8 @@ void TestQgsLabelingEngine::testNumberFormat()
   mapSettings.setOutputDpi( 96 );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   QSet<QString> attributes;
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
 
   // no change
   QgsPalLayerSettings settings;
@@ -913,7 +913,8 @@ void TestQgsLabelingEngine::testNumberFormat()
 
 void TestQgsLabelingEngine::testParticipatingLayers()
 {
-  QgsDefaultLabelingEngine engine;
+  QgsMapSettings mapSettings;
+  QgsDefaultLabelingEngine engine( mapSettings );
   QVERIFY( engine.participatingLayers().isEmpty() );
 
   const QgsPalLayerSettings settings1;
@@ -968,8 +969,8 @@ void TestQgsLabelingEngine::testRegisterFeatureUnprojectible()
   mapSettings.setOutputDpi( 96 );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   QSet<QString> attributes;
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( provider );
   provider->prepare( context, attributes );
 
@@ -1036,8 +1037,8 @@ void TestQgsLabelingEngine::testRotateHidePartial()
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   context.setPainter( &p );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( provider );
 
   engine.run( context );
@@ -1111,8 +1112,8 @@ void TestQgsLabelingEngine::testParallelLabelSmallFeature()
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   context.setPainter( &p );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( provider );
 
   engine.run( context );
@@ -1180,8 +1181,8 @@ void TestQgsLabelingEngine::testAllowDegradedPlacements()
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   context.setPainter( &p );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( provider );
 
   engine.run( context );
@@ -1275,8 +1276,8 @@ void TestQgsLabelingEngine::testOverlapHandling()
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   context.setPainter( &p );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( provider );
   engine.addProvider( provider2 );
 
@@ -1438,8 +1439,8 @@ void TestQgsLabelingEngine::testAllowOverlapsIgnoresObstacles()
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
   context.setPainter( &p );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( provider );
   engine.addProvider( provider2 );
 
@@ -4117,8 +4118,8 @@ void TestQgsLabelingEngine::testLabelRotationUnit()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   engine.run( context );
 
@@ -5338,8 +5339,8 @@ void TestQgsLabelingEngine::testDataDefinedPlacementPositionPoint()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   engine.run( context );
 
@@ -5440,8 +5441,8 @@ void TestQgsLabelingEngine::testVerticalOrientation()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -5490,8 +5491,8 @@ void TestQgsLabelingEngine::testVerticalOrientationLetterLineSpacing()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -5536,8 +5537,8 @@ void TestQgsLabelingEngine::testRotationBasedOrientationPoint()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );
@@ -5585,8 +5586,8 @@ void TestQgsLabelingEngine::testRotationBasedOrientationPointHtmlLabel()
   vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl, QString(), true, &settings ) );
   engine.run( context );
 
@@ -5637,8 +5638,8 @@ void TestQgsLabelingEngine::testRotationBasedOrientationLine()
   vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) ); // TODO: this should not be necessary!
   vl2->setLabelsEnabled( true );
 
-  QgsDefaultLabelingEngine engine;
-  engine.setMapSettings( mapSettings );
+  QgsDefaultLabelingEngine engine( mapSettings );
+
   engine.addProvider( new QgsVectorLayerLabelProvider( vl2, QString(), true, &settings ) );
   //engine.setFlags( QgsLabelingEngine::RenderOutlineLabels | QgsLabelingEngine::DrawLabelRectOnly );
   engine.run( context );

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -599,7 +599,7 @@ void TestQgsLabelingEngine::zOrder()
   engine.addProvider( provider2 );
 
   mapSettings.setLayers( QList<QgsMapLayer *>() << vl << vl2 );
-
+  engine.setMapSettings( mapSettings );
 
   p.begin( &img );
   engine.run( context );
@@ -611,6 +611,7 @@ void TestQgsLabelingEngine::zOrder()
 
   //flip layer order and re-test
   mapSettings.setLayers( QList<QgsMapLayer *>() << vl2 << vl );
+  engine.setMapSettings( mapSettings );
 
   p.begin( &img );
   engine.run( context );


### PR DESCRIPTION
## Description

This is API only, added to permit the labeling engine to be executed in a "as fast as possible" mode for situations when the engine will be used for live label previews, where the cost of executing all the collision avoidance/obstacle handling/etc is too restrictive.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
