### PR TITLE
Processing relief creation options

### DIFF
--- a/python/PyQt6/analysis/auto_generated/raster/qgsrelief.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrelief.sip.in
@@ -110,6 +110,44 @@ Sets the list of relief colors.
 .. seealso:: :py:func:`reliefColors`
 %End
 
+    void setCreationOptions( const QStringList &list );
+%Docstring
+Sets a list of data source creation options to use when creating the
+output raster file.
+
+.. seealso:: :py:func:`creationOptions`
+
+.. versionadded:: 4.4
+%End
+
+    QStringList creationOptions() const;
+%Docstring
+Returns the list of data source creation options which will be used when
+creating the output raster file.
+
+.. seealso:: :py:func:`setCreationOptions`
+
+.. versionadded:: 4.4
+%End
+
+    void setOutputNodataValue( double value );
+%Docstring
+Sets no data value for output file.
+
+.. seealso:: :py:func:`outputNodataValue`
+
+.. versionadded:: 4.4
+%End
+
+    double outputNodataValue() const;
+%Docstring
+Returns no data value used for output file.
+
+.. seealso:: :py:func:`setOutputNodataValue`
+
+.. versionadded:: 4.4
+%End
+
     QList<QgsRasterReliefColor> calculateOptimizedReliefClasses();
 %Docstring
 Calculates class breaks according with the method of Buenzli (2011)

--- a/src/analysis/processing/qgsalgorithmrelief.cpp
+++ b/src/analysis/processing/qgsalgorithmrelief.cpp
@@ -74,6 +74,17 @@ void QgsReliefAlgorithm::initAlgorithm( const QVariantMap & )
   );
   addParameter( colorsParam.release() );
 
+  auto outputNodataParam = std::make_unique<QgsProcessingParameterNumber>( u"NODATA"_s, QObject::tr( "Output NoData value" ), Qgis::ProcessingNumberParameterType::Double, -9999.0 );
+  outputNodataParam->setHelp( QObject::tr( "The NODATA value to use in the output raster." ) );
+  outputNodataParam->setFlags( outputNodataParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
+  addParameter( outputNodataParam.release() );
+
+  auto creationOptsParam = std::make_unique<QgsProcessingParameterString>( u"CREATION_OPTIONS"_s, QObject::tr( "Creation options" ), QVariant(), false, true );
+  creationOptsParam->setHelp( QObject::tr( "The raster creation options for the output raster. These options control things like colorimetry, compression, etc." ) );
+  creationOptsParam->setMetadata( QVariantMap( { { u"widget_wrapper"_s, QVariantMap( { { u"widget_type"_s, u"rasteroptions"_s } } ) } } ) );
+  creationOptsParam->setFlags( creationOptsParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
+  addParameter( creationOptsParam.release() );
+
   auto outputParam = std::make_unique<QgsProcessingParameterRasterDestination>( u"OUTPUT"_s, QObject::tr( "Relief" ) );
   outputParam->setHelp( QObject::tr( "The output shaded relief raster layer." ) );
   addParameter( outputParam.release() );
@@ -115,6 +126,8 @@ QVariantMap QgsReliefAlgorithm::processAlgorithm( const QVariantMap &parameters,
 {
   const double zFactor = parameterAsDouble( parameters, u"Z_FACTOR"_s, context );
   const bool automaticColors = parameterAsBoolean( parameters, u"AUTO_COLORS"_s, context );
+  const QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
+  const double outputNodata = parameterAsDouble( parameters, u"NODATA"_s, context );
   const QString outputFile = parameterAsOutputLayer( parameters, u"OUTPUT"_s, context );
   const QString outputFormat = parameterAsOutputRasterFormat( parameters, u"OUTPUT"_s, context );
   const QString frequencyDistribution = parameterAsFileOutput( parameters, u"FREQUENCY_DISTRIBUTION"_s, context );
@@ -135,6 +148,12 @@ QVariantMap QgsReliefAlgorithm::processAlgorithm( const QVariantMap &parameters,
 
   relief.setReliefColors( reliefColors );
   relief.setZFactor( zFactor );
+
+  if ( !creationOptions.isEmpty() )
+  {
+    relief.setCreationOptions( creationOptions.split( '|' ) );
+  }
+  relief.setOutputNodataValue( outputNodata );
 
   if ( !frequencyDistribution.isEmpty() )
     relief.exportFrequencyDistributionToCsv( frequencyDistribution );

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -96,6 +96,7 @@ QgsRelief::Result QgsRelief::processRaster( QgsFeedback *feedback )
   //output driver
   QgsRasterFileWriter writer( mOutputFile );
   writer.setOutputFormat( mOutputFormat );
+  writer.setCreationOptions( mCreationOptions );
   std::unique_ptr<QgsRasterDataProvider> outputProvider( writer.createMultiBandRaster( Qgis::DataType::Byte, xSize, ySize, inputProvider->extent(), inputProvider->crs(), 3 ) );
   if ( !outputProvider )
   {
@@ -123,10 +124,6 @@ QgsRelief::Result QgsRelief::processRaster( QgsFeedback *feedback )
   {
     mInputNodataValue = inputProvider->sourceNoDataValue( 1 );
   }
-  else
-  {
-    mInputNodataValue = -9999;
-  }
 
   mSlopeFilter->setInputNodataValue( mInputNodataValue );
   mAspectFilter->setInputNodataValue( mInputNodataValue );
@@ -134,7 +131,6 @@ QgsRelief::Result QgsRelief::processRaster( QgsFeedback *feedback )
   mHillshadeFilter300->setInputNodataValue( mInputNodataValue );
   mHillshadeFilter315->setInputNodataValue( mInputNodataValue );
 
-  mOutputNodataValue = -9999;
   outputProvider->setNoDataValue( 1, mOutputNodataValue );
   outputProvider->setNoDataValue( 2, mOutputNodataValue );
   outputProvider->setNoDataValue( 3, mOutputNodataValue );

--- a/src/analysis/raster/qgsrelief.h
+++ b/src/analysis/raster/qgsrelief.h
@@ -126,6 +126,38 @@ class ANALYSIS_EXPORT QgsRelief
     void setReliefColors( const QList<QgsRasterReliefColor> &c ) { mReliefColors = c; }
 
     /**
+     * Sets a list of data source creation options to use when creating the output raster file.
+     *
+     * \see creationOptions()
+     * \since QGIS 4.4
+     */
+    void setCreationOptions( const QStringList &list ) { mCreationOptions = list; }
+
+    /**
+     * Returns the list of data source creation options which will be used when creating the output raster file.
+     *
+     * \see setCreationOptions()
+     * \since QGIS 4.4
+     */
+    QStringList creationOptions() const { return mCreationOptions; }
+
+    /**
+     * Sets no data value for output file.
+     *
+     * \see outputNodataValue()
+     * \since QGIS 4.4
+     */
+    void setOutputNodataValue( double value ) { mOutputNodataValue = value; }
+
+    /**
+     * Returns no data value used for output file.
+     *
+     * \see setOutputNodataValue()
+     * \since QGIS 4.4
+     */
+    double outputNodataValue() const { return mOutputNodataValue; }
+
+    /**
      * Calculates class breaks according with the method of Buenzli (2011) using an iterative algorithm for segmented regression.
      *
      * \returns TRUE in case of success
@@ -147,11 +179,13 @@ class ANALYSIS_EXPORT QgsRelief
     double mCellSizeX = 0.0;
     double mCellSizeY = 0.0;
     //! The nodata value of the input layer
-    float mInputNodataValue = -1;
+    float mInputNodataValue = -9999.0;
     //! The nodata value of the output layer
-    float mOutputNodataValue = -1;
+    float mOutputNodataValue = -9999.0;
 
     double mZFactor = 1;
+
+    QStringList mCreationOptions;
 
     std::unique_ptr<QgsSlopeFilter> mSlopeFilter;
     std::unique_ptr<QgsAspectFilter> mAspectFilter;

--- a/tests/src/analysis/CMakeLists.txt
+++ b/tests/src/analysis/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TESTS
  testqgszonalstatistics.cpp
  testqgsrastercalculator.cpp
  testqgsreclassifyutils.cpp
+ testqgsrelief.cpp
  testqgsalignraster.cpp
  testqgsnetworkanalysis.cpp
  testqgsninecellfilters.cpp

--- a/tests/src/analysis/testqgsrelief.cpp
+++ b/tests/src/analysis/testqgsrelief.cpp
@@ -1,0 +1,104 @@
+/***************************************************************************
+                         testqgsrelief.cpp
+                         ---------------------
+    begin                : August 2026
+    copyright            : (C) 2026 by ALexander Bruy
+    email                : alexander dot bruy at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrasterlayer.h"
+#include "qgsrelief.h"
+#include "qgstest.h"
+
+#include <QString>
+
+using namespace Qt::StringLiterals;
+
+class TestQgsRelief : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+    TestQgsRelief()
+      : QgsTest( u"Relief Tests"_s )
+    {}
+
+    QString SRC_FILE;
+
+  private slots:
+
+    void initTestCase();
+    void cleanupTestCase();
+    void init();
+    void cleanup();
+
+    void testCreationOptions();
+    void testNoDataValue();
+
+  private:
+    static QString tempFile( const QString &name ) { return u"%1/relieftest-%2.tif"_s.arg( QDir::tempPath(), name ); }
+};
+
+void TestQgsRelief::initTestCase()
+{
+  SRC_FILE = QStringLiteral( TEST_DATA_DIR ) + "/analysis/dem.tif";
+
+  QgsApplication::init();
+}
+
+void TestQgsRelief::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsRelief::init()
+{}
+
+void TestQgsRelief::cleanup()
+{}
+
+void TestQgsRelief::testCreationOptions()
+{
+  QString tmpFile( tempFile( u"createopts"_s ) );
+
+  QString worldFileName = tmpFile.replace( ".tif"_L1, ".tfw"_L1 );
+  QFile worldFile( worldFileName );
+  QVERIFY( !worldFile.exists() );
+
+  QgsRelief relief( SRC_FILE, tmpFile, "GTiff" );
+  QList<QgsRasterReliefColor> reliefColors = relief.calculateOptimizedReliefClasses();
+  relief.setReliefColors( reliefColors );
+  relief.setCreationOptions( QStringList() << "TFW=YES" );
+  QCOMPARE( static_cast<int>( relief.processRaster() ), 0 );
+
+  QVERIFY( worldFile.exists() );
+  worldFile.remove();
+}
+
+void TestQgsRelief::testNoDataValue()
+{
+  QString tmpFile( tempFile( u"nodata"_s ) );
+
+  QgsRelief relief( SRC_FILE, tmpFile, "GTiff" );
+  QList<QgsRasterReliefColor> reliefColors = relief.calculateOptimizedReliefClasses();
+  relief.setReliefColors( reliefColors );
+  relief.setOutputNodataValue( 255 );
+  QCOMPARE( static_cast<int>( relief.processRaster() ), 0 );
+
+  const std::unique_ptr<QgsRasterLayer> result = std::make_unique<QgsRasterLayer>( tmpFile, u"raster"_s, u"gdal"_s );
+  QVERIFY( result->dataProvider()->sourceHasNoDataValue( 1 ) );
+  QCOMPARE( result->dataProvider()->sourceNoDataValue( 1 ), 255 );
+}
+
+QGSTEST_MAIN( TestQgsRelief )
+
+#include "testqgsrelief.moc"


### PR DESCRIPTION
## Description

Update `QgsRelief` to support raster creation options and custom NODATA value. This will allow users create compressed raster outputs and let them to define NODATA value which better fits their data instead of using hardcoded value -9999.

Also expose these options as advanced parameters in the Processing algorithm.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.