### PR TITLE
Remove QgsProject::instance() references from QgsMapLayerModel and QgsMapLayerProxyModel (QEP 423)

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
@@ -34,7 +34,7 @@ A model for display of map layers in widgets.
     };
 
 
- explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
+    explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
 %Docstring
 QgsMapLayerModel creates a model to display layers in widgets.
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
@@ -34,7 +34,7 @@ A model for display of map layers in widgets.
     };
 
 
- explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
+    explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
 %Docstring
 QgsMapLayerModel creates a model to display layers in widgets.
 
@@ -61,8 +61,22 @@ model.
    Will be removed in QGIS 5.0. Use the constructor with the explicit :py:class:`QgsProject` argument instead.
 %End
 
+    explicit QgsMapLayerModel( QgsProject *project, QObject *parent /TransferThis/ = 0 );
+%Docstring
+QgsMapLayerModel creates a model to display layers in widgets.
 
+Layers are taken from ``project``.
 
+.. versionadded:: 4.4
+%End
+
+    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent /TransferThis/ = 0 );
+%Docstring
+QgsMapLayerModel creates a model to display a specific list of layers in
+a widget.
+
+.. versionadded:: 4.4
+%End
 
     void setItemsCheckable( bool checkable );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
@@ -34,7 +34,7 @@ A model for display of map layers in widgets.
     };
 
 
- explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
+    explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated/;
 %Docstring
 QgsMapLayerModel creates a model to display layers in widgets.
 
@@ -42,7 +42,7 @@ If ``project`` is not specified then the
 :py:func:`QgsProject.instance()` project will be used to populate the
 model.
 
-.. deprecated:: 4.4
+.. note::
 
    Will be removed in QGIS 5.0. Use the constructor with the explicit :py:class:`QgsProject` argument instead.
 %End
@@ -61,22 +61,8 @@ model.
    Will be removed in QGIS 5.0. Use the constructor with the explicit :py:class:`QgsProject` argument instead.
 %End
 
-    explicit QgsMapLayerModel( QgsProject *project, QObject *parent /TransferThis/ = 0 );
-%Docstring
-QgsMapLayerModel creates a model to display layers in widgets.
 
-Layers are taken from ``project``.
 
-.. versionadded:: 4.4
-%End
-
-    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent /TransferThis/ = 0 );
-%Docstring
-QgsMapLayerModel creates a model to display a specific list of layers in
-a widget.
-
-.. versionadded:: 4.4
-%End
 
     void setItemsCheckable( bool checkable );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
@@ -34,7 +34,7 @@ A model for display of map layers in widgets.
     };
 
 
-    explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
+ explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
 %Docstring
 QgsMapLayerModel creates a model to display layers in widgets.
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
@@ -33,16 +33,21 @@ A model for display of map layers in widgets.
       Additional,
     };
 
-    explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 );
+
+ explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
 %Docstring
 QgsMapLayerModel creates a model to display layers in widgets.
 
 If ``project`` is not specified then the
 :py:func:`QgsProject.instance()` project will be used to populate the
 model.
+
+.. deprecated:: 4.4
+
+   Will be removed in QGIS 5.0. Use the constructor with the explicit :py:class:`QgsProject` argument instead.
 %End
 
-    explicit QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent = 0, QgsProject *project = 0 );
+ explicit QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
 %Docstring
 QgsMapLayerModel creates a model to display a specific list of layers in
 a widget.
@@ -50,6 +55,27 @@ a widget.
 If ``project`` is not specified then the
 :py:func:`QgsProject.instance()` project will be used to populate the
 model.
+
+.. deprecated:: 4.4
+
+   Will be removed in QGIS 5.0. Use the constructor with the explicit :py:class:`QgsProject` argument instead.
+%End
+
+    explicit QgsMapLayerModel( QgsProject *project, QObject *parent /TransferThis/ = 0 );
+%Docstring
+QgsMapLayerModel creates a model to display layers in widgets.
+
+Layers are taken from ``project``.
+
+.. versionadded:: 4.4
+%End
+
+    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent /TransferThis/ = 0 );
+%Docstring
+QgsMapLayerModel creates a model to display a specific list of layers in
+a widget.
+
+.. versionadded:: 4.4
 %End
 
     void setItemsCheckable( bool checkable );

--- a/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayermodel.sip.in
@@ -34,7 +34,7 @@ A model for display of map layers in widgets.
     };
 
 
-    explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
+ explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0, QgsProject *project = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead."/;
 %Docstring
 QgsMapLayerModel creates a model to display layers in widgets.
 
@@ -61,22 +61,8 @@ model.
    Will be removed in QGIS 5.0. Use the constructor with the explicit :py:class:`QgsProject` argument instead.
 %End
 
-    explicit QgsMapLayerModel( QgsProject *project, QObject *parent /TransferThis/ = 0 );
-%Docstring
-QgsMapLayerModel creates a model to display layers in widgets.
 
-Layers are taken from ``project``.
 
-.. versionadded:: 4.4
-%End
-
-    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent /TransferThis/ = 0 );
-%Docstring
-QgsMapLayerModel creates a model to display a specific list of layers in
-a widget.
-
-.. versionadded:: 4.4
-%End
 
     void setItemsCheckable( bool checkable );
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmaplayerproxymodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerproxymodel.sip.in
@@ -32,7 +32,7 @@ the layers list in a widget.
    Will be removed in QGIS 5.0. Use the constructor with the :py:class:`QgsProject` argument instead.
 %End
 
-    explicit QgsMapLayerProxyModel( QObject *parent /TransferThis/, QgsProject *project );
+    explicit QgsMapLayerProxyModel( QgsProject *project, QObject *parent /TransferThis/ = 0 );
 %Docstring
 QgsMapLayerProxyModel creates a proxy model with a QgsMapLayerModel as
 source model. It can be used to filter the layers list in a widget.

--- a/python/PyQt6/core/auto_generated/qgsmaplayerproxymodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerproxymodel.sip.in
@@ -21,26 +21,17 @@ layers in widgets.
 #include "qgsmaplayerproxymodel.h"
 %End
   public:
- explicit QgsMapLayerProxyModel( QObject *parent /TransferThis/ = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the QgsProject argument instead."/;
+    explicit QgsMapLayerProxyModel( QObject *parent /TransferThis/ = 0 ) /Deprecated/;
 %Docstring
 :py:class:`QgsMapLayerProxModel` creates a proxy model with a
 :py:class:`QgsMapLayerModel` as source model. It can be used to filter
 the layers list in a widget.
 
-.. deprecated:: 4.4
+.. note::
 
    Will be removed in QGIS 5.0. Use the constructor with the :py:class:`QgsProject` argument instead.
 %End
 
-    explicit QgsMapLayerProxyModel( QgsProject *project, QObject *parent /TransferThis/ = 0 );
-%Docstring
-QgsMapLayerProxyModel creates a proxy model with a QgsMapLayerModel as
-source model. It can be used to filter the layers list in a widget.
-
-Layers are taken from ``project``.
-
-.. versionadded:: 4.4
-%End
 
     QgsMapLayerModel *sourceLayerModel() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgsmaplayerproxymodel.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerproxymodel.sip.in
@@ -21,11 +21,25 @@ layers in widgets.
 #include "qgsmaplayerproxymodel.h"
 %End
   public:
-    explicit QgsMapLayerProxyModel( QObject *parent /TransferThis/ = 0 );
+ explicit QgsMapLayerProxyModel( QObject *parent /TransferThis/ = 0 ) /Deprecated="Since 4.4. Will be removed in QGIS 5.0. Use the constructor with the QgsProject argument instead."/;
 %Docstring
 :py:class:`QgsMapLayerProxModel` creates a proxy model with a
 :py:class:`QgsMapLayerModel` as source model. It can be used to filter
 the layers list in a widget.
+
+.. deprecated:: 4.4
+
+   Will be removed in QGIS 5.0. Use the constructor with the :py:class:`QgsProject` argument instead.
+%End
+
+    explicit QgsMapLayerProxyModel( QObject *parent /TransferThis/, QgsProject *project );
+%Docstring
+QgsMapLayerProxyModel creates a proxy model with a QgsMapLayerModel as
+source model. It can be used to filter the layers list in a widget.
+
+Layers are taken from ``project``.
+
+.. versionadded:: 4.4
 %End
 
     QgsMapLayerModel *sourceLayerModel() const;

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -110,7 +110,7 @@ QgsElevationProfileLayersDialog::QgsElevationProfileLayersDialog( QWidget *paren
   mFilterLineEdit->setShowClearButton( true );
   mFilterLineEdit->setShowSearchIcon( true );
 
-  mModel = new QgsMapLayerProxyModel( listMapLayers );
+  mModel = new QgsMapLayerProxyModel( QgsProject::instance(), listMapLayers );
   listMapLayers->setModel( mModel );
   const QModelIndex firstLayer = mModel->index( 0, 0 );
   listMapLayers->selectionModel()->select( firstLayer, QItemSelectionModel::Select );

--- a/src/app/gps/qgsgpstoolbar.cpp
+++ b/src/app/gps/qgsgpstoolbar.cpp
@@ -95,7 +95,7 @@ QgsGpsToolBar::QgsGpsToolBar( QgsAppGpsConnection *connection, QgsMapCanvas *can
 
   addSeparator();
 
-  mDestinationLayerModel = new QgsMapLayerProxyModel( this );
+  mDestinationLayerModel = new QgsMapLayerProxyModel( QgsProject::instance(), this );
   mDestinationLayerModel->setProject( QgsProject::instance() );
   mDestinationLayerModel->setFilters( Qgis::LayerFilter::HasGeometry | Qgis::LayerFilter::WritableLayer );
 

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -31,19 +31,25 @@ using namespace Qt::StringLiterals;
 
 QgsMapLayerModel::QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent, QgsProject *project )
   : QAbstractItemModel( parent )
-  , mProject( project ? project : QgsProject::instance() ) // skip-keyword-check
+  , mProject( project )
 {
-  connect( mProject, static_cast< void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+  if ( mProject )
+  {
+    connect( mProject, static_cast< void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+  }
   addLayers( layers );
 }
 
 QgsMapLayerModel::QgsMapLayerModel( QObject *parent, QgsProject *project )
   : QAbstractItemModel( parent )
-  , mProject( project ? project : QgsProject::instance() ) // skip-keyword-check
+  , mProject( project )
 {
-  connect( mProject, &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
-  connect( mProject, static_cast< void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
-  addLayers( mProject->mapLayers().values() );
+  if ( mProject )
+  {
+    connect( mProject, &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
+    connect( mProject, static_cast< void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+    addLayers( mProject->mapLayers().values() );
+  }
 }
 
 void QgsMapLayerModel::setProject( QgsProject *project )

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -64,7 +64,10 @@ QgsMapLayerModel::QgsMapLayerModel( QgsProject *project, QObject *parent )
 
 void QgsMapLayerModel::setProject( QgsProject *project )
 {
-  if ( mProject == ( project ? project : QgsProject::instance() ) ) // skip-keyword-check
+  if ( !project )
+    return;
+
+  if ( mProject == project )
     return;
 
   // remove layers from previous project
@@ -75,7 +78,7 @@ void QgsMapLayerModel::setProject( QgsProject *project )
     disconnect( mProject, static_cast< void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
   }
 
-  mProject = project ? project : QgsProject::instance(); // skip-keyword-check
+  mProject = project;
 
   connect( mProject, &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
   connect( mProject, static_cast< void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -31,17 +31,17 @@ using namespace Qt::StringLiterals;
 
 // TODO QGIS 5.0 Remove deprecated constructor
 QgsMapLayerModel::QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent, QgsProject *project )
-  : QgsMapLayerModel( project ? project : QgsProject::instance(), layers, parent ) // skip-keyword-check
+  : QgsMapLayerModel( project ? *project : *QgsProject::instance(), layers, parent ) // skip-keyword-check
 {}
 
 // TODO QGIS 5.0 Remove deprecated constructor
 QgsMapLayerModel::QgsMapLayerModel( QObject *parent, QgsProject *project )
-  : QgsMapLayerModel( project ? project : QgsProject::instance(), parent ) // skip-keyword-check
+  : QgsMapLayerModel( project ? *project : *QgsProject::instance(), parent ) // skip-keyword-check
 {}
 
-QgsMapLayerModel::QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent )
+QgsMapLayerModel::QgsMapLayerModel( QgsProject &project, const QList<QgsMapLayer *> &layers, QObject *parent )
   : QAbstractItemModel( parent )
-  , mProject( project )
+  , mProject( &project )
 {
   if ( mProject )
   {
@@ -50,9 +50,9 @@ QgsMapLayerModel::QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer
   addLayers( layers );
 }
 
-QgsMapLayerModel::QgsMapLayerModel( QgsProject *project, QObject *parent )
+QgsMapLayerModel::QgsMapLayerModel( QgsProject &project, QObject *parent )
   : QAbstractItemModel( parent )
-  , mProject( project )
+  , mProject( &project )
 {
   if ( mProject )
   {

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -29,7 +29,17 @@
 
 using namespace Qt::StringLiterals;
 
+// TODO QGIS 5.0 Remove deprecated constructor
 QgsMapLayerModel::QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent, QgsProject *project )
+  : QgsMapLayerModel( project ? project : QgsProject::instance(), layers, parent ) // skip-keyword-check
+{}
+
+// TODO QGIS 5.0 Remove deprecated constructor
+QgsMapLayerModel::QgsMapLayerModel( QObject *parent, QgsProject *project )
+  : QgsMapLayerModel( project ? project : QgsProject::instance(), parent ) // skip-keyword-check
+{}
+
+QgsMapLayerModel::QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent )
   : QAbstractItemModel( parent )
   , mProject( project )
 {
@@ -40,7 +50,7 @@ QgsMapLayerModel::QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject 
   addLayers( layers );
 }
 
-QgsMapLayerModel::QgsMapLayerModel( QObject *parent, QgsProject *project )
+QgsMapLayerModel::QgsMapLayerModel( QgsProject *project, QObject *parent )
   : QAbstractItemModel( parent )
   , mProject( project )
 {

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -31,17 +31,17 @@ using namespace Qt::StringLiterals;
 
 // TODO QGIS 5.0 Remove deprecated constructor
 QgsMapLayerModel::QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent, QgsProject *project )
-  : QgsMapLayerModel( project ? *project : *QgsProject::instance(), layers, parent ) // skip-keyword-check
+  : QgsMapLayerModel( project ? project : QgsProject::instance(), layers, parent ) // skip-keyword-check
 {}
 
 // TODO QGIS 5.0 Remove deprecated constructor
 QgsMapLayerModel::QgsMapLayerModel( QObject *parent, QgsProject *project )
-  : QgsMapLayerModel( project ? *project : *QgsProject::instance(), parent ) // skip-keyword-check
+  : QgsMapLayerModel( project ? project : QgsProject::instance(), parent ) // skip-keyword-check
 {}
 
-QgsMapLayerModel::QgsMapLayerModel( QgsProject &project, const QList<QgsMapLayer *> &layers, QObject *parent )
+QgsMapLayerModel::QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent )
   : QAbstractItemModel( parent )
-  , mProject( &project )
+  , mProject( project )
 {
   if ( mProject )
   {
@@ -50,9 +50,9 @@ QgsMapLayerModel::QgsMapLayerModel( QgsProject &project, const QList<QgsMapLayer
   addLayers( layers );
 }
 
-QgsMapLayerModel::QgsMapLayerModel( QgsProject &project, QObject *parent )
+QgsMapLayerModel::QgsMapLayerModel( QgsProject *project, QObject *parent )
   : QAbstractItemModel( parent )
-  , mProject( &project )
+  , mProject( project )
 {
   if ( mProject )
   {

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      *
      * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead.
      */
-    Q_DECL_DEPRECATED explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
+    explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      *
      * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead.
      */
-    explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
+    Q_DECL_DEPRECATED explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of
@@ -91,14 +91,15 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      *
      * \since QGIS 4.4
      */
-    explicit QgsMapLayerModel( QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsMapLayerModel( QgsProject &project, QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_SKIP;
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of layers in a widget.
      *
      * \since QGIS 4.4
      */
-    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsMapLayerModel( QgsProject &project, const QList<QgsMapLayer *> &layers, QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_SKIP;
+
 
     /**
      * \brief Defines if layers should be selectable in the widget

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -69,9 +69,9 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      * If \a project is not specified then the QgsProject.instance() project will be used to
      * populate the model.
      *
-     * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead.
+     * \note Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead.
      */
-    Q_DECL_DEPRECATED explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
+    explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of
@@ -84,6 +84,8 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      */
     Q_DECL_DEPRECATED explicit QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
 
+    // TODO QGIS 5.0 -- drop SIP_SKIP from the following constructors, so that they are available in Python
+
     /**
      * \brief QgsMapLayerModel creates a model to display layers in widgets.
      *
@@ -91,14 +93,14 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      *
      * \since QGIS 4.4
      */
-    explicit QgsMapLayerModel( QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsMapLayerModel( QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_SKIP;
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of layers in a widget.
      *
      * \since QGIS 4.4
      */
-    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_SKIP;
 
     /**
      * \brief Defines if layers should be selectable in the widget

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -61,21 +61,44 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
     Q_ENUM( CustomRole )
     // *INDENT-ON*
 
+    // TODO QGIS 5.0 -- remove deprecated constructors
+
     /**
      * \brief QgsMapLayerModel creates a model to display layers in widgets.
      *
      * If \a project is not specified then the QgsProject.instance() project will be used to
      * populate the model.
+     *
+     * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead.
      */
-    explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr );
+    Q_DECL_DEPRECATED explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
+
+    /**
+     * \brief QgsMapLayerModel creates a model to display a specific list of
+     * layers in a widget.
+     *
+     * If \a project is not specified then the QgsProject.instance() project
+     * will be used to populate the model.
+     *
+     * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead.
+     */
+    Q_DECL_DEPRECATED explicit QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
+
+    /**
+     * \brief QgsMapLayerModel creates a model to display layers in widgets.
+     *
+     * Layers are taken from \a project.
+     *
+     * \since QGIS 4.4
+     */
+    explicit QgsMapLayerModel( QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of layers in a widget.
      *
-     * If \a project is not specified then the QgsProject.instance() project will be used to
-     * populate the model.
+     * \since QGIS 4.4
      */
-    explicit QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent = nullptr, QgsProject *project = nullptr );
+    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * \brief Defines if layers should be selectable in the widget

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      *
      * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead.
      */
-    Q_DECL_DEPRECATED explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
+    explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of
@@ -91,15 +91,14 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      *
      * \since QGIS 4.4
      */
-    explicit QgsMapLayerModel( QgsProject &project, QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_SKIP;
+    explicit QgsMapLayerModel( QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of layers in a widget.
      *
      * \since QGIS 4.4
      */
-    explicit QgsMapLayerModel( QgsProject &project, const QList<QgsMapLayer *> &layers, QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_SKIP;
-
+    explicit QgsMapLayerModel( QgsProject *project, const QList<QgsMapLayer *> &layers, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * \brief Defines if layers should be selectable in the widget

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsMapLayerModel : public QAbstractItemModel
      *
      * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the explicit QgsProject argument instead.
      */
-    explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
+    Q_DECL_DEPRECATED explicit QgsMapLayerModel( QObject *parent SIP_TRANSFERTHIS = nullptr, QgsProject *project = nullptr ) SIP_DEPRECATED;
 
     /**
      * \brief QgsMapLayerModel creates a model to display a specific list of

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -23,9 +23,13 @@
 #include "moc_qgsmaplayerproxymodel.cpp"
 
 QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent )
+  : QgsMapLayerProxyModel( parent, QgsProject::instance() ) // skip-keyword-check
+{}
+
+QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent, QgsProject *project )
   : QSortFilterProxyModel( parent )
   , mFilters( Qgis::LayerFilter::All )
-  , mModel( new QgsMapLayerModel( parent ) )
+  , mModel( new QgsMapLayerModel( parent, project ) )
 {
   setSourceModel( mModel );
   setDynamicSortFilter( true );

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -29,7 +29,7 @@ QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent )
 QgsMapLayerProxyModel::QgsMapLayerProxyModel( QgsProject *project, QObject *parent )
   : QSortFilterProxyModel( parent )
   , mFilters( Qgis::LayerFilter::All )
-  , mModel( new QgsMapLayerModel( project, parent ) )
+  , mModel( new QgsMapLayerModel( *project, parent ) )
 {
   setSourceModel( mModel );
   setDynamicSortFilter( true );

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -23,10 +23,10 @@
 #include "moc_qgsmaplayerproxymodel.cpp"
 
 QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent )
-  : QgsMapLayerProxyModel( parent, QgsProject::instance() ) // skip-keyword-check
+  : QgsMapLayerProxyModel( QgsProject::instance(), parent ) // skip-keyword-check
 {}
 
-QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent, QgsProject *project )
+QgsMapLayerProxyModel::QgsMapLayerProxyModel( QgsProject *project, QObject *parent )
   : QSortFilterProxyModel( parent )
   , mFilters( Qgis::LayerFilter::All )
   , mModel( new QgsMapLayerModel( project, parent ) )

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -29,7 +29,7 @@ QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent )
 QgsMapLayerProxyModel::QgsMapLayerProxyModel( QgsProject *project, QObject *parent )
   : QSortFilterProxyModel( parent )
   , mFilters( Qgis::LayerFilter::All )
-  , mModel( new QgsMapLayerModel( *project, parent ) )
+  , mModel( new QgsMapLayerModel( project, parent ) )
 {
   setSourceModel( mModel );
   setDynamicSortFilter( true );

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -29,7 +29,7 @@ QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent )
 QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent, QgsProject *project )
   : QSortFilterProxyModel( parent )
   , mFilters( Qgis::LayerFilter::All )
-  , mModel( new QgsMapLayerModel( parent, project ) )
+  , mModel( new QgsMapLayerModel( project, parent ) )
 {
   setSourceModel( mModel );
   setDynamicSortFilter( true );

--- a/src/core/qgsmaplayerproxymodel.h
+++ b/src/core/qgsmaplayerproxymodel.h
@@ -40,11 +40,24 @@ class CORE_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
     Q_PROPERTY( QStringList exceptedLayerIds READ exceptedLayerIds WRITE setExceptedLayerIds )
 
   public:
+    // TODO QGIS 5.0 -- remove deprecated constructor
     /**
-     * \brief QgsMapLayerProxModel creates a proxy model with a QgsMapLayerModel as source model.
-     * It can be used to filter the layers list in a widget.
+     * \brief QgsMapLayerProxModel creates a proxy model with a QgsMapLayerModel
+     * as source model. It can be used to filter the layers list in a widget.
+     *
+     * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the QgsProject argument instead.
      */
-    explicit QgsMapLayerProxyModel( QObject *parent SIP_TRANSFERTHIS = nullptr );
+    Q_DECL_DEPRECATED explicit QgsMapLayerProxyModel( QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_DEPRECATED;
+
+    /**
+     * \brief QgsMapLayerProxyModel creates a proxy model with a QgsMapLayerModel as source model.
+     * It can be used to filter the layers list in a widget.
+     *
+     * Layers are taken from \a project.
+     *
+     * \since QGIS 4.4
+     */
+    explicit QgsMapLayerProxyModel( QObject *parent SIP_TRANSFERTHIS, QgsProject *project );
 
     /**
      * \brief layerModel returns the QgsMapLayerModel used in this QSortFilterProxyModel

--- a/src/core/qgsmaplayerproxymodel.h
+++ b/src/core/qgsmaplayerproxymodel.h
@@ -45,19 +45,21 @@ class CORE_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
      * \brief QgsMapLayerProxModel creates a proxy model with a QgsMapLayerModel
      * as source model. It can be used to filter the layers list in a widget.
      *
-     * \deprecated QGIS 4.4. Will be removed in QGIS 5.0. Use the constructor with the QgsProject argument instead.
+     * \note Will be removed in QGIS 5.0. Use the constructor with the QgsProject argument instead.
      */
-    Q_DECL_DEPRECATED explicit QgsMapLayerProxyModel( QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_DEPRECATED;
+    explicit QgsMapLayerProxyModel( QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_DEPRECATED;
 
+    // TODO QGIS 5.0 -- drop SIP_SKIP from the following constructor, so that it is available in Python
     /**
-     * \brief QgsMapLayerProxyModel creates a proxy model with a QgsMapLayerModel as source model.
-     * It can be used to filter the layers list in a widget.
+     * \brief QgsMapLayerProxyModel creates a proxy model with a
+     * QgsMapLayerModel as source model. It can be used to filter the layers
+     * list in a widget.
      *
      * Layers are taken from \a project.
      *
      * \since QGIS 4.4
      */
-    explicit QgsMapLayerProxyModel( QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsMapLayerProxyModel( QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr ) SIP_SKIP;
 
     /**
      * \brief layerModel returns the QgsMapLayerModel used in this QSortFilterProxyModel

--- a/src/core/qgsmaplayerproxymodel.h
+++ b/src/core/qgsmaplayerproxymodel.h
@@ -57,7 +57,7 @@ class CORE_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
      *
      * \since QGIS 4.4
      */
-    explicit QgsMapLayerProxyModel( QObject *parent SIP_TRANSFERTHIS, QgsProject *project );
+    explicit QgsMapLayerProxyModel( QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * \brief layerModel returns the QgsMapLayerModel used in this QSortFilterProxyModel

--- a/src/gui/layout/qgsgeopdflayertreemodel.cpp
+++ b/src/gui/layout/qgsgeopdflayertreemodel.cpp
@@ -29,7 +29,7 @@
 using namespace Qt::StringLiterals;
 
 QgsGeospatialPdfLayerTreeModel::QgsGeospatialPdfLayerTreeModel( const QList<QgsMapLayer *> &layers, QObject *parent )
-  : QgsMapLayerModel( layers, parent )
+  : QgsMapLayerModel( QgsProject::instance(), layers, parent )
 {
   setItemsCanBeReordered( true );
 }

--- a/src/gui/layout/qgsgeopdflayertreemodel.cpp
+++ b/src/gui/layout/qgsgeopdflayertreemodel.cpp
@@ -29,7 +29,7 @@
 using namespace Qt::StringLiterals;
 
 QgsGeospatialPdfLayerTreeModel::QgsGeospatialPdfLayerTreeModel( const QList<QgsMapLayer *> &layers, QObject *parent )
-  : QgsMapLayerModel( *QgsProject::instance(), layers, parent )
+  : QgsMapLayerModel( QgsProject::instance(), layers, parent )
 {
   setItemsCanBeReordered( true );
 }

--- a/src/gui/layout/qgsgeopdflayertreemodel.cpp
+++ b/src/gui/layout/qgsgeopdflayertreemodel.cpp
@@ -29,7 +29,7 @@
 using namespace Qt::StringLiterals;
 
 QgsGeospatialPdfLayerTreeModel::QgsGeospatialPdfLayerTreeModel( const QList<QgsMapLayer *> &layers, QObject *parent )
-  : QgsMapLayerModel( QgsProject::instance(), layers, parent )
+  : QgsMapLayerModel( *QgsProject::instance(), layers, parent )
 {
   setItemsCanBeReordered( true );
 }

--- a/src/gui/layout/qgslayoutlegendlayersdialog.cpp
+++ b/src/gui/layout/qgslayoutlegendlayersdialog.cpp
@@ -19,6 +19,7 @@
 #include "qgsmaplayer.h"
 #include "qgsmaplayermodel.h"
 #include "qgsmaplayerproxymodel.h"
+#include "qgsproject.h"
 #include "qgssettings.h"
 
 #include <QStandardItem>
@@ -29,6 +30,10 @@
 using namespace Qt::StringLiterals;
 
 QgsLayoutLegendLayersDialog::QgsLayoutLegendLayersDialog( QWidget *parent )
+  : QgsLayoutLegendLayersDialog( parent, QgsProject::instance() )
+{}
+
+QgsLayoutLegendLayersDialog::QgsLayoutLegendLayersDialog( QWidget *parent, QgsProject *project )
   : QDialog( parent )
 {
   setupUi( this );
@@ -37,7 +42,7 @@ QgsLayoutLegendLayersDialog::QgsLayoutLegendLayersDialog( QWidget *parent )
   mFilterLineEdit->setShowClearButton( true );
   mFilterLineEdit->setShowSearchIcon( true );
 
-  mModel = new QgsMapLayerProxyModel( listMapLayers );
+  mModel = new QgsMapLayerProxyModel( listMapLayers, project );
   listMapLayers->setModel( mModel );
   const QModelIndex firstLayer = mModel->index( 0, 0 );
   listMapLayers->selectionModel()->select( firstLayer, QItemSelectionModel::Select );

--- a/src/gui/layout/qgslayoutlegendlayersdialog.cpp
+++ b/src/gui/layout/qgslayoutlegendlayersdialog.cpp
@@ -38,7 +38,7 @@ QgsLayoutLegendLayersDialog::QgsLayoutLegendLayersDialog( QWidget *parent, QgsPr
   mFilterLineEdit->setShowClearButton( true );
   mFilterLineEdit->setShowSearchIcon( true );
 
-  mModel = new QgsMapLayerProxyModel( listMapLayers, project );
+  mModel = new QgsMapLayerProxyModel( project, listMapLayers );
   listMapLayers->setModel( mModel );
   const QModelIndex firstLayer = mModel->index( 0, 0 );
   listMapLayers->selectionModel()->select( firstLayer, QItemSelectionModel::Select );

--- a/src/gui/layout/qgslayoutlegendlayersdialog.cpp
+++ b/src/gui/layout/qgslayoutlegendlayersdialog.cpp
@@ -29,10 +29,6 @@
 
 using namespace Qt::StringLiterals;
 
-QgsLayoutLegendLayersDialog::QgsLayoutLegendLayersDialog( QWidget *parent )
-  : QgsLayoutLegendLayersDialog( parent, QgsProject::instance() )
-{}
-
 QgsLayoutLegendLayersDialog::QgsLayoutLegendLayersDialog( QWidget *parent, QgsProject *project )
   : QDialog( parent )
 {

--- a/src/gui/layout/qgslayoutlegendlayersdialog.h
+++ b/src/gui/layout/qgslayoutlegendlayersdialog.h
@@ -25,6 +25,7 @@
 
 class QgsMapLayer;
 class QgsMapLayerProxyModel;
+class QgsProject;
 
 /**
  * \ingroup gui
@@ -38,8 +39,16 @@ class GUI_EXPORT QgsLayoutLegendLayersDialog : public QDialog, private Ui::QgsLa
     Q_OBJECT
 
   public:
+    // TODO QGIS 5.0 -- remove deprecated constructor
+
     //! constructor
-    QgsLayoutLegendLayersDialog( QWidget *parent = nullptr );
+    Q_DECL_DEPRECATED QgsLayoutLegendLayersDialog( QWidget *parent = nullptr );
+
+    /**
+     * Constructor, taking layers from \a project.
+     * \since QGIS 4.4
+     */
+    QgsLayoutLegendLayersDialog( QWidget *parent, QgsProject *project );
 
     /**
      * Sets a list of visible \a layers, to use for filtering within the dialog.

--- a/src/gui/layout/qgslayoutlegendlayersdialog.h
+++ b/src/gui/layout/qgslayoutlegendlayersdialog.h
@@ -39,11 +39,6 @@ class GUI_EXPORT QgsLayoutLegendLayersDialog : public QDialog, private Ui::QgsLa
     Q_OBJECT
 
   public:
-    // TODO QGIS 5.0 -- remove deprecated constructor
-
-    //! constructor
-    Q_DECL_DEPRECATED QgsLayoutLegendLayersDialog( QWidget *parent = nullptr );
-
     /**
      * Constructor, taking layers from \a project.
      * \since QGIS 4.4

--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -1038,7 +1038,7 @@ void QgsLayoutLegendWidget::mAddToolButton_clicked()
     visibleLayers = mMapCanvas->layers( true );
   }
 
-  QgsLayoutLegendLayersDialog addDialog( this );
+  QgsLayoutLegendLayersDialog addDialog( this, mLegend->layout()->project() );
   addDialog.setVisibleLayers( visibleLayers );
   if ( addDialog.exec() == QDialog::Accepted )
   {

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -480,7 +480,7 @@ void QgsLayoutMapWidget::aboutToShowLayersMenu()
 
   if ( !mMapLayerModel )
   {
-    mMapLayerModel = new QgsMapLayerProxyModel( this, mMapItem->layout()->project() );
+    mMapLayerModel = new QgsMapLayerProxyModel( mMapItem->layout()->project(), this );
     mMapLayerModel->setFilters( Qgis::LayerFilter::SpatialLayer );
   }
 

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -480,7 +480,7 @@ void QgsLayoutMapWidget::aboutToShowLayersMenu()
 
   if ( !mMapLayerModel )
   {
-    mMapLayerModel = new QgsMapLayerProxyModel( this, QgsProject::instance() );
+    mMapLayerModel = new QgsMapLayerProxyModel( this, mMapItem->layout()->project() );
     mMapLayerModel->setFilters( Qgis::LayerFilter::SpatialLayer );
   }
 

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -2125,11 +2125,11 @@ QgsLayoutMapClippingWidget::QgsLayoutMapClippingWidget( QgsLayoutItemMap *map )
 
   if ( map->layout() && map->layout()->project() )
   {
-    mLayerModel = new QgsMapLayerModel( *map->layout()->project(), this );
+    mLayerModel = new QgsMapLayerModel( map->layout()->project(), this );
   }
   else
   {
-    mLayerModel = new QgsMapLayerModel( *QgsProject::instance(), this );
+    mLayerModel = new QgsMapLayerModel( QgsProject::instance(), this );
   }
   mLayerModel->setItemsCheckable( true );
   mLayersTreeView->setModel( mLayerModel );

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -480,7 +480,7 @@ void QgsLayoutMapWidget::aboutToShowLayersMenu()
 
   if ( !mMapLayerModel )
   {
-    mMapLayerModel = new QgsMapLayerProxyModel( this );
+    mMapLayerModel = new QgsMapLayerProxyModel( this, QgsProject::instance() );
     mMapLayerModel->setFilters( Qgis::LayerFilter::SpatialLayer );
   }
 
@@ -2123,7 +2123,14 @@ QgsLayoutMapClippingWidget::QgsLayoutMapClippingWidget( QgsLayoutItemMap *map )
   setupUi( this );
   setPanelTitle( tr( "Clipping Settings" ) );
 
-  mLayerModel = new QgsMapLayerModel( this );
+  if ( map->layout() && map->layout()->project() )
+  {
+    mLayerModel = new QgsMapLayerModel( this, map->layout()->project() );
+  }
+  else
+  {
+    mLayerModel = new QgsMapLayerModel( this, QgsProject::instance() );
+  }
   mLayerModel->setItemsCheckable( true );
   mLayersTreeView->setModel( mLayerModel );
 

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -2125,11 +2125,11 @@ QgsLayoutMapClippingWidget::QgsLayoutMapClippingWidget( QgsLayoutItemMap *map )
 
   if ( map->layout() && map->layout()->project() )
   {
-    mLayerModel = new QgsMapLayerModel( map->layout()->project(), this );
+    mLayerModel = new QgsMapLayerModel( *map->layout()->project(), this );
   }
   else
   {
-    mLayerModel = new QgsMapLayerModel( QgsProject::instance(), this );
+    mLayerModel = new QgsMapLayerModel( *QgsProject::instance(), this );
   }
   mLayerModel->setItemsCheckable( true );
   mLayersTreeView->setModel( mLayerModel );

--- a/src/gui/layout/qgslayoutmapwidget.cpp
+++ b/src/gui/layout/qgslayoutmapwidget.cpp
@@ -2125,11 +2125,11 @@ QgsLayoutMapClippingWidget::QgsLayoutMapClippingWidget( QgsLayoutItemMap *map )
 
   if ( map->layout() && map->layout()->project() )
   {
-    mLayerModel = new QgsMapLayerModel( this, map->layout()->project() );
+    mLayerModel = new QgsMapLayerModel( map->layout()->project(), this );
   }
   else
   {
-    mLayerModel = new QgsMapLayerModel( this, QgsProject::instance() );
+    mLayerModel = new QgsMapLayerModel( QgsProject::instance(), this );
   }
   mLayerModel->setItemsCheckable( true );
   mLayersTreeView->setModel( mLayerModel );

--- a/src/gui/qgsextentwidget.cpp
+++ b/src/gui/qgsextentwidget.cpp
@@ -58,7 +58,7 @@ QgsExtentWidget::QgsExtentWidget( QWidget *parent, WidgetStyle style )
   mLayerMenu = new QMenu( tr( "Calculate from Layer" ), this );
   mButtonCalcFromLayer->setMenu( mLayerMenu );
   connect( mLayerMenu, &QMenu::aboutToShow, this, &QgsExtentWidget::layerMenuAboutToShow );
-  mMapLayerModel = new QgsMapLayerProxyModel( this, QgsProject::instance() ); // skip-keyword-check
+  mMapLayerModel = new QgsMapLayerProxyModel( QgsProject::instance(), this ); // skip-keyword-check
   mMapLayerModel->setFilters( Qgis::LayerFilter::SpatialLayer );
 
   mLayoutMenu = new QMenu( tr( "Calculate from Layout Map" ), this );

--- a/src/gui/qgsextentwidget.cpp
+++ b/src/gui/qgsextentwidget.cpp
@@ -58,7 +58,7 @@ QgsExtentWidget::QgsExtentWidget( QWidget *parent, WidgetStyle style )
   mLayerMenu = new QMenu( tr( "Calculate from Layer" ), this );
   mButtonCalcFromLayer->setMenu( mLayerMenu );
   connect( mLayerMenu, &QMenu::aboutToShow, this, &QgsExtentWidget::layerMenuAboutToShow );
-  mMapLayerModel = new QgsMapLayerProxyModel( this );
+  mMapLayerModel = new QgsMapLayerProxyModel( this, QgsProject::instance() ); // skip-keyword-check
   mMapLayerModel->setFilters( Qgis::LayerFilter::SpatialLayer );
 
   mLayoutMenu = new QMenu( tr( "Calculate from Layout Map" ), this );

--- a/src/gui/qgsmaplayercombobox.cpp
+++ b/src/gui/qgsmaplayercombobox.cpp
@@ -27,7 +27,7 @@
 QgsMapLayerComboBox::QgsMapLayerComboBox( QWidget *parent )
   : QComboBox( parent )
 {
-  mProxyModel = new QgsMapLayerProxyModel( this, QgsProject::instance() ); // skip-keyword-check
+  mProxyModel = new QgsMapLayerProxyModel( QgsProject::instance(), this ); // skip-keyword-check
   setModel( mProxyModel );
 
   connect( this, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ), this, &QgsMapLayerComboBox::indexChanged );

--- a/src/gui/qgsmaplayercombobox.cpp
+++ b/src/gui/qgsmaplayercombobox.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsmaplayermodel.h"
 #include "qgsmimedatautils.h"
+#include "qgsproject.h"
 
 #include <QDragEnterEvent>
 #include <QPainter>
@@ -26,7 +27,7 @@
 QgsMapLayerComboBox::QgsMapLayerComboBox( QWidget *parent )
   : QComboBox( parent )
 {
-  mProxyModel = new QgsMapLayerProxyModel( this );
+  mProxyModel = new QgsMapLayerProxyModel( this, QgsProject::instance() ); // skip-keyword-check
   setModel( mProxyModel );
 
   connect( this, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ), this, &QgsMapLayerComboBox::indexChanged );

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -134,7 +134,7 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
 
   connect( mSettings, &QPushButton::clicked, this, &QgsTemporalControllerWidget::settings_clicked );
 
-  mMapLayerModel = new QgsMapLayerModel( *QgsProject::instance(), this );
+  mMapLayerModel = new QgsMapLayerModel( QgsProject::instance(), this );
 
   mRangeMenu = std::make_unique<QMenu>( this );
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -134,7 +134,7 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
 
   connect( mSettings, &QPushButton::clicked, this, &QgsTemporalControllerWidget::settings_clicked );
 
-  mMapLayerModel = new QgsMapLayerModel( this );
+  mMapLayerModel = new QgsMapLayerModel( this, QgsProject::instance() );
 
   mRangeMenu = std::make_unique<QMenu>( this );
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -134,7 +134,7 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
 
   connect( mSettings, &QPushButton::clicked, this, &QgsTemporalControllerWidget::settings_clicked );
 
-  mMapLayerModel = new QgsMapLayerModel( this, QgsProject::instance() );
+  mMapLayerModel = new QgsMapLayerModel( QgsProject::instance(), this );
 
   mRangeMenu = std::make_unique<QMenu>( this );
 

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -134,7 +134,7 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
 
   connect( mSettings, &QPushButton::clicked, this, &QgsTemporalControllerWidget::settings_clicked );
 
-  mMapLayerModel = new QgsMapLayerModel( QgsProject::instance(), this );
+  mMapLayerModel = new QgsMapLayerModel( *QgsProject::instance(), this );
 
   mRangeMenu = std::make_unique<QMenu>( this );
 

--- a/src/providers/virtual/qgsembeddedlayerselectdialog.cpp
+++ b/src/providers/virtual/qgsembeddedlayerselectdialog.cpp
@@ -20,12 +20,13 @@ email                : hugo dot mercier at oslandia dot com
 #include "qgsgui.h"
 #include "qgsmaplayermodel.h"
 #include "qgsmaplayerproxymodel.h"
+#include "qgsproject.h"
 
 #include "moc_qgsembeddedlayerselectdialog.cpp"
 
 QgsEmbeddedLayerSelectDialog::QgsEmbeddedLayerSelectDialog( QWidget *parent )
   : QDialog( parent )
-  , mLayerProxyModel( new QgsMapLayerProxyModel( this ) )
+  , mLayerProxyModel( new QgsMapLayerProxyModel( QgsProject::instance(), this ) ) // skip-keyword-check
 {
   setupUi( this );
 


### PR DESCRIPTION
## Description

Remove `QgsMapLayerModel` and `QgsMapLayerProxyModel` by deprecating constructors and creating new ones with explicit project. 

Some `QgsProject::instance()` were moved from `core` to `gui`, which is not ideal but still better then having them in `core`. It is mostly to allow easy construction of objects like `QgsMapLayerComboBox` from **ui** files. 

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 
