### PR TITLE
Fix error being raised about not being able to convert crs to WGS84 for non Earth crs on project change

### DIFF
--- a/src/app/gps/qgsgpscanvasbridge.cpp
+++ b/src/app/gps/qgsgpscanvasbridge.cpp
@@ -87,7 +87,17 @@ QgsGpsCanvasBridge::QgsGpsCanvasBridge( QgsAppGpsConnection *connection, QgsMapC
   } );
 
   connect( QgsProject::instance(), &QgsProject::transformContextChanged, this, [this] {
-    mCanvasToWgs84Transform = QgsCoordinateTransform( mCanvas->mapSettings().destinationCrs(), mWgs84CRS, QgsProject::instance() );
+    if ( mCanvas->mapSettings().destinationCrs().isEarthCrs() )
+    {
+      mCanvasToWgs84Transform = QgsCoordinateTransform( mCanvas->mapSettings().destinationCrs(), mWgs84CRS, QgsProject::instance() );
+    }
+    else
+    {
+      if ( mConnection->isConnected() )
+      {
+        mConnection->disconnectGps();
+      }
+    }
   } );
 
   mDistanceCalculator.setEllipsoid( QgsProject::instance()->ellipsoid() );


### PR DESCRIPTION
## Description

Addition to #65000 and #65026. This fixes situation when project with non Earth CRS is reloaded with another project with non Earth CRS . That goes trough signal `transformContextChanged` in `QgsGpsCanvasBridge`. It should be handled the same way as signal `QgsMapCanvas::destinationCrsChanged` just few lines above. But it was not, causing error message to appear. The proper handling is to disconnect the GPS (as we do in above case).
 
## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 
