### PR TITLE
Remove QgisProject::instance() from QgsOfflineEditing (QEP 423)

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsofflineediting.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsofflineediting.sip.in
@@ -39,7 +39,15 @@ layer data.
       GPKG
     };
 
-    QgsOfflineEditing();
+    QgsOfflineEditing() /Deprecated/;
+
+    QgsOfflineEditing( QgsProject *project );
+%Docstring
+QgsOfflineEditing object based on a QgsProject instance. This allows the
+offline editing plugin to be used with multiple projects.
+
+.. versionadded:: 4.4
+%End
 
     bool convertToOfflineProject(
       const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType containerType = SpatiaLite, const QString &layerNameSuffix = QStringLiteral( " (offline)" )

--- a/python/PyQt6/core/auto_generated/qgsofflineediting.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsofflineediting.sip.in
@@ -39,13 +39,14 @@ layer data.
       GPKG
     };
 
-    QgsOfflineEditing() /Deprecated="Since 4.4. Use the constructor which requires an explicit project instead."/;
+    QgsOfflineEditing() /Deprecated/;
 %Docstring
-Default constructor -- uses the :py:func:`QgsProject.instance()`.
+Default constructor -- uses the :py:class:`QgsProject`
+:py:func:`~QgsOfflineEditing.instance`.
 
-.. deprecated:: 4.4
+.. note::
 
-   Use the constructor which requires an explicit project instead.
+   Will be removed in QGIS 5.0. Use the constructor which requires an explicit project instead.
 %End
 
     QgsOfflineEditing( QgsProject *project );

--- a/python/PyQt6/core/auto_generated/qgsofflineediting.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsofflineediting.sip.in
@@ -39,7 +39,14 @@ layer data.
       GPKG
     };
 
-    QgsOfflineEditing() /Deprecated/;
+    QgsOfflineEditing() /Deprecated="Since 4.4. Use the constructor which requires an explicit project instead."/;
+%Docstring
+Default constructor -- uses the :py:func:`QgsProject.instance()`.
+
+.. deprecated:: 4.4
+
+   Use the constructor which requires an explicit project instead.
+%End
 
     QgsOfflineEditing( QgsProject *project );
 %Docstring

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -69,9 +69,15 @@ extern "C"
 #define PROJECT_ENTRY_SCOPE_OFFLINE "OfflineEditingPlugin"
 #define PROJECT_ENTRY_KEY_OFFLINE_DB_PATH "/OfflineDbPath"
 
+// TODO QGIS 5.0 - remove default constructor
 QgsOfflineEditing::QgsOfflineEditing()
+  : QgsOfflineEditing( QgsProject::instance() ) // skip-keyword-check
+{}
+
+QgsOfflineEditing::QgsOfflineEditing( QgsProject *project )
+  : mProject( project )
 {
-  connect( QgsProject::instance(), &QgsProject::layerWasAdded, this, &QgsOfflineEditing::setupLayer ); // skip-keyword-check
+  connect( project, &QgsProject::layerWasAdded, this, &QgsOfflineEditing::setupLayer );
 }
 
 /**
@@ -116,7 +122,7 @@ bool QgsOfflineEditing::convertToOfflineProject(
       {
         emit layerProgressUpdated( i + 1, layerIds.count() );
 
-        QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerIds.at( i ) ); // skip-keyword-check
+        QgsMapLayer *layer = mProject->mapLayer( layerIds.at( i ) );
         QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
         if ( vl && vl->isValid() )
         {
@@ -127,14 +133,14 @@ bool QgsOfflineEditing::convertToOfflineProject(
       emit progressStopped();
 
       // save offline project
-      QString projectTitle = QgsProject::instance()->title(); // skip-keyword-check
+      QString projectTitle = mProject->title();
       if ( projectTitle.isEmpty() )
       {
-        projectTitle = QFileInfo( QgsProject::instance()->fileName() ).fileName(); // skip-keyword-check
+        projectTitle = QFileInfo( mProject->fileName() ).fileName();
       }
-      projectTitle += " (offline)"_L1;                                                                                                                   // skip-keyword-check
-      QgsProject::instance()->setTitle( projectTitle );                                                                                                  // skip-keyword-check
-      QgsProject::instance()->writeEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH, QgsProject::instance()->writePath( dbPath ) ); // skip-keyword-check
+      projectTitle += " (offline)"_L1;
+      mProject->setTitle( projectTitle );
+      mProject->writeEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH, mProject->writePath( dbPath ) );
 
       return true;
     }
@@ -145,7 +151,7 @@ bool QgsOfflineEditing::convertToOfflineProject(
 
 bool QgsOfflineEditing::isOfflineProject() const
 {
-  return !QgsProject::instance()->readEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH ).isEmpty(); // skip-keyword-check
+  return !mProject->readEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH ).isEmpty();
 }
 
 void QgsOfflineEditing::synchronize( bool useTransaction )
@@ -159,10 +165,10 @@ void QgsOfflineEditing::synchronize( bool useTransaction )
 
   emit progressStarted();
 
-  const QgsSnappingConfig snappingConfig = QgsProject::instance()->snappingConfig(); // skip-keyword-check
+  const QgsSnappingConfig snappingConfig = mProject->snappingConfig();
 
   // restore and sync remote layers
-  QMap<QString, QgsMapLayer *> mapLayers = QgsProject::instance()->mapLayers(); // skip-keyword-check
+  QMap<QString, QgsMapLayer *> mapLayers = mProject->mapLayers();
   QMap<int, std::shared_ptr<QgsVectorLayer>> remoteLayersByOfflineId;
   QMap<int, QgsVectorLayer *> offlineLayersByOfflineId;
 
@@ -185,7 +191,7 @@ void QgsOfflineEditing::synchronize( bool useTransaction )
     const QString remoteNameSuffix = offlineLayer->customProperty( CUSTOM_PROPERTY_LAYERNAME_SUFFIX, " (offline)" ).toString();
     if ( remoteName.endsWith( remoteNameSuffix ) )
       remoteName.chop( remoteNameSuffix.size() );
-    const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() }; // skip-keyword-check
+    const QgsVectorLayer::LayerOptions options { mProject->transformContext() };
 
     auto remoteLayer = std::make_shared<QgsVectorLayer>( remoteSource, remoteName, remoteProvider, options );
 
@@ -345,9 +351,9 @@ void QgsOfflineEditing::synchronize( bool useTransaction )
   }
 
   // disable offline project
-  const QString projectTitle = QgsProject::instance()->title().remove( QRegularExpression( " \\(offline\\)$" ) ); // skip-keyword-check
-  QgsProject::instance()->setTitle( projectTitle );                                                               // skip-keyword-check
-  QgsProject::instance()->removeEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH );          // skip-keyword-check
+  const QString projectTitle = mProject->title().remove( QRegularExpression( " \\(offline\\)$" ) );
+  mProject->setTitle( projectTitle );
+  mProject->removeEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH );
   // reset commitNo
   const QString sql = u"UPDATE 'log_indices' SET 'last_index' = 0 WHERE \"name\" = 'commit_no'"_s;
   sqlExec( database.get(), sql );
@@ -655,7 +661,7 @@ void QgsOfflineEditing::convertToOfflineLayer( QgsVectorLayer *layer, sqlite3 *d
 
       // add new layer
       const QString connectionString = u"dbname='%1' table='%2'%3 sql="_s.arg( offlineDbPath, tableName, layer->isSpatial() ? "(Geometry)" : "" );
-      const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() }; // skip-keyword-check
+      const QgsVectorLayer::LayerOptions options { mProject->transformContext() };
       newLayer = std::make_unique<QgsVectorLayer>( connectionString, layer->name() + layerNameSuffix, u"spatialite"_s, options );
       break;
 
@@ -770,7 +776,7 @@ void QgsOfflineEditing::convertToOfflineLayer( QgsVectorLayer *layer, sqlite3 *d
       hDS.reset();
 
       const QString uri = u"%1|layername=%2|option:QGIS_FORCE_WAL=ON"_s.arg( offlineDbPath, tableName );
-      const QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() }; // skip-keyword-check
+      const QgsVectorLayer::LayerOptions layerOptions { mProject->transformContext() };
       newLayer = std::make_unique<QgsVectorLayer>( uri, layer->name() + layerNameSuffix, u"ogr"_s, layerOptions );
       break;
     }
@@ -1177,10 +1183,10 @@ void QgsOfflineEditing::showWarning( const QString &message )
 sqlite3_database_unique_ptr QgsOfflineEditing::openLoggingDb()
 {
   sqlite3_database_unique_ptr database;
-  const QString dbPath = QgsProject::instance()->readEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH ); // skip-keyword-check
+  const QString dbPath = mProject->readEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH );
   if ( !dbPath.isEmpty() )
   {
-    const QString absoluteDbPath = QgsProject::instance()->readPath( dbPath ); // skip-keyword-check
+    const QString absoluteDbPath = mProject->readPath( dbPath );
     const int rc = database.open( absoluteDbPath );
     if ( rc != SQLITE_OK )
     {
@@ -1494,11 +1500,11 @@ void QgsOfflineEditing::committedFeaturesAdded( const QString &qgisLayerId, cons
   const int layerId = getOrCreateLayerId( database.get(), qgisLayerId );
 
   // get new feature ids from db
-  QgsMapLayer *layer = QgsProject::instance()->mapLayer( qgisLayerId ); // skip-keyword-check
+  QgsMapLayer *layer = mProject->mapLayer( qgisLayerId );
   const QString dataSourceString = layer->source();
   const QgsDataSourceUri uri = QgsDataSourceUri( dataSourceString );
 
-  const QString offlinePath = QgsProject::instance()->readPath( QgsProject::instance()->readEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH ) ); // skip-keyword-check
+  const QString offlinePath = mProject->readPath( mProject->readEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH ) );
   QString tableName;
 
   if ( !offlinePath.contains( ".gpkg" ) )

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -60,6 +60,11 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     };
 
     // TODO QGIS 5.0 - remove default constructor
+    /**
+     * Default constructor -- uses the QgsProject::instance().
+     * 
+     * \deprecated QGIS 4.4 Use the constructor which requires an explicit project instead.
+     */
     QgsOfflineEditing() SIP_DEPRECATED;
 
     /**

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -21,6 +21,7 @@
 
 #include "qgis_core.h"
 #include "qgsfeature.h"
+#include "qgsproject.h"
 #include "qgssqliteutils.h"
 
 #include <QObject>
@@ -58,7 +59,15 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
       GPKG
     };
 
-    QgsOfflineEditing();
+    // TODO QGIS 5.0 - remove default constructor
+    QgsOfflineEditing() SIP_DEPRECATED;
+
+    /**
+     * QgsOfflineEditing object based on a QgsProject instance. This allows the offline editing plugin to be used with multiple projects.
+     *
+     * \since QGIS 4.4
+     */
+    QgsOfflineEditing( QgsProject *project );
 
     /**
      * Convert current project for offline editing
@@ -191,6 +200,9 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void committedGeometriesChanges( const QString &qgisLayerId, const QgsGeometryMap &changedGeometries );
     void startListenFeatureChanges();
     void stopListenFeatureChanges();
+
+  private:
+    QgsProject *mProject = nullptr;
 };
 
 #endif // QGS_OFFLINE_EDITING_H

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -61,9 +61,9 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
 
     // TODO QGIS 5.0 - remove default constructor
     /**
-     * Default constructor -- uses the QgsProject::instance().
-     * 
-     * \deprecated QGIS 4.4 Use the constructor which requires an explicit project instead.
+     * Default constructor -- uses the QgsProject instance().
+     *
+     * \note Will be removed in QGIS 5.0. Use the constructor which requires an explicit project instead.
      */
     QgsOfflineEditing() SIP_DEPRECATED;
 

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -45,10 +45,7 @@ QgsOfflineEditingPlugin::QgsOfflineEditingPlugin( QgisInterface *qgisInterface )
   , mQGisIface( qgisInterface )
 {}
 
-QgsOfflineEditingPlugin::~QgsOfflineEditingPlugin()
-{
-  delete mOfflineEditing;
-}
+QgsOfflineEditingPlugin::~QgsOfflineEditingPlugin() = default;
 
 void QgsOfflineEditingPlugin::initGui()
 {
@@ -74,22 +71,30 @@ void QgsOfflineEditingPlugin::initGui()
   mQGisIface->addPluginToDatabaseMenu( tr( "&Offline Editing" ), mActionSynchronize );
   mActionSynchronize->setEnabled( false );
 
-  mOfflineEditing = new QgsOfflineEditing();
   mProgressDialog = new QgsOfflineEditingProgressDialog( mQGisIface->mainWindow(), QgsGuiUtils::ModalDialogFlags );
 
-  connect( mOfflineEditing, &QgsOfflineEditing::progressStarted, this, &QgsOfflineEditingPlugin::showProgress );
-  connect( mOfflineEditing, &QgsOfflineEditing::layerProgressUpdated, this, &QgsOfflineEditingPlugin::setLayerProgress );
-  connect( mOfflineEditing, &QgsOfflineEditing::progressModeSet, this, &QgsOfflineEditingPlugin::setProgressMode );
-  connect( mOfflineEditing, &QgsOfflineEditing::progressUpdated, this, &QgsOfflineEditingPlugin::updateProgress );
-  connect( mOfflineEditing, &QgsOfflineEditing::progressStopped, this, &QgsOfflineEditingPlugin::hideProgress );
-  connect( mOfflineEditing, &QgsOfflineEditing::warning, mQGisIface->messageBar(), &QgsMessageBar::pushWarning );
+  setupOfflineEditing();
 
+  connect( mQGisIface, &QgisInterface::projectRead, this, &QgsOfflineEditingPlugin::setupOfflineEditing );
+  connect( mQGisIface, &QgisInterface::newProjectCreated, this, &QgsOfflineEditingPlugin::setupOfflineEditing );
   connect( mQGisIface, &QgisInterface::projectRead, this, &QgsOfflineEditingPlugin::updateActions );
   connect( mQGisIface, &QgisInterface::newProjectCreated, this, &QgsOfflineEditingPlugin::updateActions );
   connect( QgsProject::instance(), &QgsProject::writeProject, this, &QgsOfflineEditingPlugin::updateActions );
   connect( QgsProject::instance(), &QgsProject::layerWasAdded, this, &QgsOfflineEditingPlugin::updateActions );
   connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QString & )>( &QgsProject::layerWillBeRemoved ), this, &QgsOfflineEditingPlugin::updateActions );
   updateActions();
+}
+
+void QgsOfflineEditingPlugin::setupOfflineEditing()
+{
+  mOfflineEditing = std::make_unique<QgsOfflineEditing>( QgsProject::instance() );
+
+  connect( mOfflineEditing.get(), &QgsOfflineEditing::progressStarted, this, &QgsOfflineEditingPlugin::showProgress );
+  connect( mOfflineEditing.get(), &QgsOfflineEditing::layerProgressUpdated, this, &QgsOfflineEditingPlugin::setLayerProgress );
+  connect( mOfflineEditing.get(), &QgsOfflineEditing::progressModeSet, this, &QgsOfflineEditingPlugin::setProgressMode );
+  connect( mOfflineEditing.get(), &QgsOfflineEditing::progressUpdated, this, &QgsOfflineEditingPlugin::updateProgress );
+  connect( mOfflineEditing.get(), &QgsOfflineEditing::progressStopped, this, &QgsOfflineEditingPlugin::hideProgress );
+  connect( mOfflineEditing.get(), &QgsOfflineEditing::warning, mQGisIface->messageBar(), &QgsMessageBar::pushWarning );
 }
 
 void QgsOfflineEditingPlugin::convertProject()

--- a/src/plugins/offline_editing/offline_editing_plugin.h
+++ b/src/plugins/offline_editing/offline_editing_plugin.h
@@ -19,6 +19,8 @@
 #ifndef QGS_OFFLINE_EDITING_PLUGIN_H
 #define QGS_OFFLINE_EDITING_PLUGIN_H
 
+#include <memory>
+
 #include "../qgisplugin.h"
 #include "qgsofflineediting.h"
 
@@ -54,11 +56,14 @@ class QgsOfflineEditingPlugin : public QObject, public QgisPlugin
     QAction *mActionConvertProject = nullptr;
     QAction *mActionSynchronize = nullptr;
 
-    QgsOfflineEditing *mOfflineEditing = nullptr;
+    std::unique_ptr<QgsOfflineEditing> mOfflineEditing;
     QgsOfflineEditingProgressDialog *mProgressDialog = nullptr;
 
   private slots:
     void updateActions();
+
+    //! recreates mOfflineEditing bound to the current project
+    void setupOfflineEditing();
 
     //! update progress dialog
     void showProgress();

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -72,8 +72,6 @@ void TestQgsOfflineEditing::initTestCase()
   QgsApplication::initQgis();
   QgsApplication::showSettings();
 
-  //OfflineEditing
-  mOfflineEditing = new QgsOfflineEditing();
   offlineDataPath = ".";
 }
 
@@ -106,6 +104,9 @@ void TestQgsOfflineEditing::init()
 
   QgsProject::instance()->addMapLayer( gpkgLayer );
   layerIds.append( gpkgLayer->id() );
+
+  //OfflineEditing
+  mOfflineEditing = new QgsOfflineEditing( QgsProject::instance() );
 }
 
 void TestQgsOfflineEditing::cleanup()


### PR DESCRIPTION
## Description

Remove `QgisProject::instance()` calls from `QgsOfflineEditing` by introducing a new member member variable that holds current project. Update the  `QgsOfflineEditingPlugin` to use the new API.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 