### PR TITLE
Annotation rotation (part 1)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsannotationlayer.py
+++ b/python/PyQt6/core/auto_additions/qgsannotationlayer.py
@@ -9,6 +9,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
+    QgsAnnotationLayer.__attribute_docs__ = {'itemsChanged': 'Emitted when items are added, removed or modified in the layer.\n\n.. versionadded:: 4.4\n'}
     QgsAnnotationLayer.__overridden_methods__ = ['properties', 'clone', 'createMapRenderer', 'extent', 'setTransformContext', 'readXml', 'writeXml', 'writeSymbology', 'readSymbology', 'writeStyle', 'readStyle', 'isEditable', 'supportsEditing', 'dataProvider', 'htmlMetadata', 'resolveReferences']
     QgsAnnotationLayer.__group__ = ['annotations']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationlayer.sip.in
@@ -217,6 +217,15 @@ only be visible when the linked layer is also visible.
 .. versionadded:: 3.40
 %End
 
+  signals:
+
+    void itemsChanged();
+%Docstring
+Emitted when items are added, removed or modified in the layer.
+
+.. versionadded:: 4.4
+%End
+
 };
 
 

--- a/src/app/annotations/qgsannotationitempropertieswidget.cpp
+++ b/src/app/annotations/qgsannotationitempropertieswidget.cpp
@@ -71,9 +71,14 @@ void QgsAnnotationItemPropertiesWidget::syncToLayer( QgsMapLayer *layer )
   if ( layer == mLayer )
     return;
 
+  if ( mLayer )
+    disconnect( mLayer, &QgsAnnotationLayer::itemsChanged, this, &QgsAnnotationItemPropertiesWidget::onLayerItemsChanged );
+
   mLayer = qobject_cast<QgsAnnotationLayer *>( layer );
   if ( !mLayer )
     return;
+
+  connect( mLayer, &QgsAnnotationLayer::itemsChanged, this, &QgsAnnotationItemPropertiesWidget::onLayerItemsChanged );
 
   // opacity and blend modes
   mBlockLayerUpdates = true;
@@ -146,10 +151,23 @@ void QgsAnnotationItemPropertiesWidget::onChanged()
     std::unique_ptr<QgsAnnotationItem> newItem( existingItem->clone() );
     mItemWidget->updateItem( newItem.get() );
 
+    mBlockItemUpdates = true;
     mLayer->replaceItem( mMapLayerConfigWidgetContext.annotationId(), newItem.release() );
+    mBlockItemUpdates = false;
   }
 
   emit widgetChanged();
+}
+
+void QgsAnnotationItemPropertiesWidget::onLayerItemsChanged()
+{
+  if ( mBlockItemUpdates || !mLayer || !mItemWidget )
+    return;
+
+  if ( QgsAnnotationItem *item = mLayer->item( mMapLayerConfigWidgetContext.annotationId() ) )
+  {
+    mItemWidget->setItem( item );
+  }
 }
 
 void QgsAnnotationItemPropertiesWidget::onLayerPropertyChanged()

--- a/src/app/annotations/qgsannotationitempropertieswidget.h
+++ b/src/app/annotations/qgsannotationitempropertieswidget.h
@@ -48,6 +48,7 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget, public
 
     void onChanged();
     void onLayerPropertyChanged();
+    void onLayerItemsChanged();
 
   private:
     void setItemId( const QString &itemId );
@@ -57,6 +58,7 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget, public
     QPointer<QgsAnnotationItemBaseWidget> mItemWidget;
     QWidget *mPageNoItem = nullptr;
     bool mBlockLayerUpdates = false;
+    bool mBlockItemUpdates = false;
 
     std::unique_ptr<QgsPaintEffect> mPaintEffect;
 };

--- a/src/core/annotations/qgsannotationlayer.cpp
+++ b/src/core/annotations/qgsannotationlayer.cpp
@@ -131,6 +131,7 @@ QString QgsAnnotationLayer::addItem( QgsAnnotationItem *item )
   else
     mSpatialIndex->insert( uuid, item->boundingBox() );
 
+  emit itemsChanged();
   triggerRepaint();
 
   return uuid;
@@ -161,6 +162,7 @@ void QgsAnnotationLayer::replaceItem( const QString &id, QgsAnnotationItem *item
   else
     mSpatialIndex->insert( id, item->boundingBox() );
 
+  emit itemsChanged();
   triggerRepaint();
 }
 
@@ -185,6 +187,7 @@ bool QgsAnnotationLayer::removeItem( const QString &id )
 
   item.reset();
 
+  emit itemsChanged();
   triggerRepaint();
 
   return true;
@@ -199,6 +202,7 @@ void QgsAnnotationLayer::clear()
   mSpatialIndex = std::make_unique< QgsAnnotationLayerSpatialIndex >();
   mNonIndexedItems.clear();
 
+  emit itemsChanged();
   triggerRepaint();
 }
 
@@ -285,7 +289,10 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationLayer::applyEditV2( QgsAbst
   }
 
   if ( res != Qgis::AnnotationItemEditOperationResult::Invalid )
+  {
+    emit itemsChanged();
     triggerRepaint();
+  }
 
   return res;
 }
@@ -381,6 +388,7 @@ bool QgsAnnotationLayer::readXml( const QDomNode &layerNode, QgsReadWriteContext
     mLinkedLayer = QgsMapLayerRef( layerId, layerName, layerSource, layerProvider );
   }
 
+  emit itemsChanged();
   triggerRepaint();
 
   return mValid;

--- a/src/core/annotations/qgsannotationlayer.h
+++ b/src/core/annotations/qgsannotationlayer.h
@@ -225,6 +225,15 @@ class CORE_EXPORT QgsAnnotationLayer : public QgsMapLayer
      */
     void setLinkedVisibilityLayer( QgsMapLayer *layer );
 
+  signals:
+
+    /**
+     * Emitted when items are added, removed or modified in the layer.
+     *
+     * \since QGIS 4.4
+     */
+    void itemsChanged();
+
   private:
     QStringList queryIndex( const QgsRectangle &bounds, QgsFeedback *feedback = nullptr ) const;
     bool writeItems( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsReadWriteContext &context, StyleCategories categories = AllStyleCategories ) const;

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -269,7 +269,6 @@ void QgsCreatePictureItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *event )
   if ( !mRubberBand )
   {
     mFirstPoint = event->snapPoint();
-    mRect.setRect( mFirstPoint.x(), mFirstPoint.y(), mFirstPoint.x(), mFirstPoint.y() );
 
     mRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Polygon );
     mRubberBand->setWidth( digitizingStrokeWidth() );
@@ -354,14 +353,19 @@ void QgsCreatePictureItemMapTool::cadCanvasMoveEvent( QgsMapMouseEvent *event )
   if ( !mRubberBand )
     return;
 
-  const QgsPointXY mapPoint = event->snapPoint();
-  mRect.setBottomRight( mapPoint.toQPointF() );
+  // Keep the preview rectangle aligned to the screen, matching the placed item
+  // which ignores map rotation by default.
+  const QgsPointXY firstCanvasPoint = toCanvasCoordinates( mFirstPoint );
+  const QgsPointXY currentCanvasPoint = toCanvasCoordinates( event->snapPoint() );
+
+  const QgsMapToPixel *transform = mCanvas->getCoordinateTransform();
+  const QgsPointXY topLeft = transform->toMapCoordinates( firstCanvasPoint.x(), firstCanvasPoint.y() );
+  const QgsPointXY topRight = transform->toMapCoordinates( currentCanvasPoint.x(), firstCanvasPoint.y() );
+  const QgsPointXY bottomRight = transform->toMapCoordinates( currentCanvasPoint.x(), currentCanvasPoint.y() );
+  const QgsPointXY bottomLeft = transform->toMapCoordinates( firstCanvasPoint.x(), currentCanvasPoint.y() );
 
   mRubberBand->reset( Qgis::GeometryType::Polygon );
-  mRubberBand->addPoint( mRect.bottomLeft(), false );
-  mRubberBand->addPoint( mRect.bottomRight(), false );
-  mRubberBand->addPoint( mRect.topRight(), false );
-  mRubberBand->addPoint( mRect.topLeft(), true );
+  mRubberBand->setToGeometry( QgsGeometry::fromPolygonXY( { { bottomLeft, bottomRight, topRight, topLeft } } ) );
 }
 
 void QgsCreatePictureItemMapTool::keyPressEvent( QKeyEvent *event )
@@ -414,7 +418,6 @@ void QgsCreateRectangleTextItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *e
   if ( !mRubberBand )
   {
     mFirstPoint = event->snapPoint();
-    mRect.setRect( mFirstPoint.x(), mFirstPoint.y(), mFirstPoint.x(), mFirstPoint.y() );
 
     mRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Polygon );
     mRubberBand->setWidth( digitizingStrokeWidth() );
@@ -456,14 +459,19 @@ void QgsCreateRectangleTextItemMapTool::cadCanvasMoveEvent( QgsMapMouseEvent *ev
   if ( !mRubberBand )
     return;
 
-  const QgsPointXY mapPoint = event->snapPoint();
-  mRect.setBottomRight( mapPoint.toQPointF() );
+  // Keep the preview rectangle aligned to the screen, matching the placed item
+  // which ignores map rotation by default.
+  const QgsPointXY firstCanvasPoint = toCanvasCoordinates( mFirstPoint );
+  const QgsPointXY currentCanvasPoint = toCanvasCoordinates( event->snapPoint() );
+
+  const QgsMapToPixel *transform = mCanvas->getCoordinateTransform();
+  const QgsPointXY topLeft = transform->toMapCoordinates( firstCanvasPoint.x(), firstCanvasPoint.y() );
+  const QgsPointXY topRight = transform->toMapCoordinates( currentCanvasPoint.x(), firstCanvasPoint.y() );
+  const QgsPointXY bottomRight = transform->toMapCoordinates( currentCanvasPoint.x(), currentCanvasPoint.y() );
+  const QgsPointXY bottomLeft = transform->toMapCoordinates( firstCanvasPoint.x(), currentCanvasPoint.y() );
 
   mRubberBand->reset( Qgis::GeometryType::Polygon );
-  mRubberBand->addPoint( mRect.bottomLeft(), false );
-  mRubberBand->addPoint( mRect.bottomRight(), false );
-  mRubberBand->addPoint( mRect.topRight(), false );
-  mRubberBand->addPoint( mRect.topLeft(), true );
+  mRubberBand->setToGeometry( QgsGeometry::fromPolygonXY( { { bottomLeft, bottomRight, topRight, topLeft } } ) );
 }
 
 void QgsCreateRectangleTextItemMapTool::keyPressEvent( QKeyEvent *event )

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.h
@@ -167,7 +167,6 @@ class GUI_EXPORT QgsCreateRectangleTextItemMapTool : public QgsMapToolAdvancedDi
   private:
     QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
 
-    QRectF mRect;
     QgsPointXY mFirstPoint;
     QObjectUniquePtr<QgsRubberBand> mRubberBand;
 };
@@ -202,7 +201,6 @@ class GUI_EXPORT QgsCreatePictureItemMapTool : public QgsMapToolAdvancedDigitizi
     //! Constructor
     QgsCreateAnnotationItemMapToolHandler *mHandler = nullptr;
 
-    QRectF mRect;
     QgsPointXY mFirstPoint;
     QObjectUniquePtr<QgsRubberBand> mRubberBand;
 };

--- a/tests/src/python/test_qgsannotationlayer.py
+++ b/tests/src/python/test_qgsannotationlayer.py
@@ -16,6 +16,7 @@ import unittest
 
 from qgis.core import (
     Qgis,
+    QgsAnnotationItemEditContext,
     QgsAnnotationItemEditOperationMoveNode,
     QgsAnnotationLayer,
     QgsAnnotationLineItem,
@@ -43,6 +44,7 @@ from qgis.core import (
 )
 from qgis.PyQt.QtCore import QSize, QTemporaryDir
 from qgis.PyQt.QtGui import QColor, QImage, QPainter
+from qgis.PyQt.QtTest import QSignalSpy
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.testing import QgisTestCase, start_app
 from utilities import compareWkt, unitTestDataPath
@@ -564,6 +566,85 @@ class TestQgsAnnotationLayer(QgisTestCase):
         self.assertCountEqual(
             layer.itemsInBounds(QgsRectangle(18, 1, 20, 16), rc), [polygon_item_id]
         )
+
+    def testItemsChangedSignal(self):
+        """
+        Test that the itemsChanged signal is emitted whenever items are added,
+        replaced, edited or removed
+        """
+        layer = QgsAnnotationLayer(
+            "test",
+            QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()),
+        )
+        spy = QSignalSpy(layer.itemsChanged)
+
+        marker_item_id = layer.addItem(QgsAnnotationMarkerItem(QgsPoint(12, 13)))
+        self.assertEqual(len(spy), 1)
+
+        layer.replaceItem(marker_item_id, QgsAnnotationMarkerItem(QgsPoint(14, 15)))
+        self.assertEqual(len(spy), 2)
+
+        # an edit operation on a missing item must not emit the signal
+        self.assertEqual(
+            layer.applyEditV2(
+                QgsAnnotationItemEditOperationMoveNode(
+                    "xxx", QgsVertexId(0, 0, 0), QgsPoint(14, 15), QgsPoint(17, 18)
+                ),
+                QgsAnnotationItemEditContext(),
+            ),
+            Qgis.AnnotationItemEditOperationResult.Invalid,
+        )
+        self.assertEqual(len(spy), 2)
+
+        self.assertEqual(
+            layer.applyEditV2(
+                QgsAnnotationItemEditOperationMoveNode(
+                    marker_item_id,
+                    QgsVertexId(0, 0, 0),
+                    QgsPoint(14, 15),
+                    QgsPoint(17, 18),
+                ),
+                QgsAnnotationItemEditContext(),
+            ),
+            Qgis.AnnotationItemEditOperationResult.Success,
+        )
+        self.assertEqual(len(spy), 3)
+
+        # removing a missing item must not emit the signal
+        self.assertFalse(layer.removeItem("xxx"))
+        self.assertEqual(len(spy), 3)
+
+        self.assertTrue(layer.removeItem(marker_item_id))
+        self.assertEqual(len(spy), 4)
+
+        layer.addItem(QgsAnnotationMarkerItem(QgsPoint(12, 13)))
+        self.assertEqual(len(spy), 5)
+
+        layer.clear()
+        self.assertEqual(len(spy), 6)
+
+    def testItemsChangedSignalOnReadXml(self):
+        """
+        Test that the itemsChanged signal is emitted when items are restored
+        from a project
+        """
+        doc = QDomDocument("testdoc")
+        layer = QgsAnnotationLayer(
+            "test",
+            QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()),
+        )
+        layer.addItem(QgsAnnotationMarkerItem(QgsPoint(12, 13)))
+
+        elem = doc.createElement("maplayer")
+        self.assertTrue(layer.writeLayerXml(elem, doc, QgsReadWriteContext()))
+
+        layer2 = QgsAnnotationLayer(
+            "test2",
+            QgsAnnotationLayer.LayerOptions(QgsProject.instance().transformContext()),
+        )
+        spy = QSignalSpy(layer2.itemsChanged)
+        self.assertTrue(layer2.readLayerXml(elem, QgsReadWriteContext()))
+        self.assertEqual(len(spy), 1)
 
     def testRenderLayer(self):
         layer = QgsAnnotationLayer(


### PR DESCRIPTION
## Description

This is a subset of #66610, to ease the review.

This fixes two things:
- items not being updated in the panel after a change on the map (since it's a clone in the panel)
- fix preview rectangle when map canvas is rotated

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
