### PR TITLE
Add missing `CREATION_OPTIONS` handling to `native:modelerrastercalc`

### DIFF
--- a/src/analysis/processing/qgsalgorithmrastercalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmrastercalculator.cpp
@@ -323,6 +323,7 @@ QVariantMap QgsRasterCalculatorModelerAlgorithm::processAlgorithm( const QVarian
     cellSize = minCellSize;
   }
 
+  const QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
   const QString expression = parameterAsExpression( parameters, u"EXPRESSION"_s, context );
   const QString outputFile = parameterAsOutputLayer( parameters, u"OUTPUT"_s, context );
   const QString outputFormat = parameterAsOutputRasterFormat( parameters, u"OUTPUT"_s, context );
@@ -331,6 +332,7 @@ QVariantMap QgsRasterCalculatorModelerAlgorithm::processAlgorithm( const QVarian
   double height = std::round( ( bbox.yMaximum() - bbox.yMinimum() ) / cellSize );
 
   QgsRasterCalculator calc( expression, outputFile, outputFormat, bbox, crs, width, height, entries, context.transformContext() );
+  calc.setCreationOptions( creationOptions.split( '|', Qt::SplitBehaviorFlags::SkipEmptyParts ) );
   QgsRasterCalculator::Result result = calc.processCalculation( feedback );
   qDeleteAll( mLayers );
   mLayers.clear();

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -89,6 +89,7 @@ class TestQgsProcessingAlgsPt1 : public QgsTest
     void saveFeaturesAlg();
     void packageAlg();
     void rasterLayerProperties();
+    void modelerRasterCalculatorCreationOptions();
     void exportToSpreadsheetXlsx();
     void exportToSpreadsheetOds();
     void exportToSpreadsheetOptions();
@@ -524,6 +525,37 @@ void TestQgsProcessingAlgsPt1::rasterLayerProperties()
   QCOMPARE( results.value( u"BAND_COUNT"_s ).toInt(), 1 );
   QCOMPARE( results.value( u"HAS_NODATA_VALUE"_s ).toInt(), 1 );
   QCOMPARE( results.value( u"NODATA_VALUE"_s ).toInt(), -9999 );
+}
+
+void TestQgsProcessingAlgsPt1::modelerRasterCalculatorCreationOptions()
+{
+  std::unique_ptr<QgsProcessingAlgorithm> alg( QgsApplication::processingRegistry()->createAlgorithmById( u"native:modelerrastercalc"_s ) );
+  QVERIFY( alg );
+
+  const QString inputFilename = QStringLiteral( TEST_DATA_DIR ) + u"/raster/band1_int16_noct_epsg4326.tif"_s;
+  const QTemporaryDir tempDir;
+  const QString outputFilename = tempDir.filePath( u"modeler_raster_calculator.tif"_s );
+
+  QVariantMap parameters;
+  parameters.insert( u"LAYERS"_s, QStringList( { inputFilename } ) );
+  parameters.insert( u"EXPRESSION"_s, u"\"A@1\""_s );
+  parameters.insert( u"CREATION_OPTIONS"_s, u"TILED=YES|BLOCKXSIZE=16|BLOCKYSIZE=16"_s );
+  parameters.insert( u"OUTPUT"_s, outputFilename );
+
+  QgsProcessingContext context;
+  QgsProcessingFeedback feedback;
+  bool ok = false;
+  alg->run( parameters, context, &feedback, &ok );
+  QVERIFY( ok );
+
+  gdal::dataset_unique_ptr dataset( GDALOpen( outputFilename.toUtf8().constData(), GA_ReadOnly ) );
+  QVERIFY( dataset );
+
+  int blockWidth = 0;
+  int blockHeight = 0;
+  GDALGetBlockSize( GDALGetRasterBand( dataset.get(), 1 ), &blockWidth, &blockHeight );
+  QCOMPARE( blockWidth, 16 );
+  QCOMPARE( blockHeight, 16 );
 }
 
 void TestQgsProcessingAlgsPt1::exportToSpreadsheetXlsx()


### PR DESCRIPTION
## Description

`CREATION_OPTIONS` is listed as a parameter for `native:modelerrastercalc`, but not actually passed on to GDAL.

Fixes #67034

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

AI assisted in originally finding the issue and creating this PR, especially the regression test.
