### PR TITLE
Defer next batch step to the event loop (fix #53806)

### DIFF
--- a/src/gui/processing/qgsprocessingbatchalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingbatchalgorithmdialogbase.cpp
@@ -158,7 +158,9 @@ void QgsProcessingBatchAlgorithmDialogBase::onTaskComplete( bool ok, const QVari
     mResults.append( QVariantMap( { { u"parameters"_s, mCurrentParameters }, { u"results"_s, results } } ) );
 
     handleAlgorithmResults( algorithm(), *mTaskContext, mBatchFeedback.get(), mCurrentParameters );
-    executeNext();
+
+    // must not start the next step from within QgsTaskManager::taskStatusChanged() (fix #53806)
+    QMetaObject::invokeMethod( this, &QgsProcessingBatchAlgorithmDialogBase::executeNext, Qt::QueuedConnection );
   }
   else if ( mBatchFeedback->isCanceled() )
   {
@@ -173,7 +175,9 @@ void QgsProcessingBatchAlgorithmDialogBase::onTaskComplete( bool ok, const QVari
     reportError( tr( "Execution failed after %1 seconds" ).arg( mCurrentStepTimer.elapsed() / 1000.0, 2 ), false );
 
     mErrors.append( QVariantMap( { { u"parameters"_s, mCurrentParameters }, { u"errors"_s, taskErrors } } ) );
-    executeNext();
+
+    // must not start the next step from within QgsTaskManager::taskStatusChanged() (fix #53806)
+    QMetaObject::invokeMethod( this, &QgsProcessingBatchAlgorithmDialogBase::executeNext, Qt::QueuedConnection );
   }
 }
 


### PR DESCRIPTION
## Description

`executeNext()` is deferred to the event loop with a queued invokeMethod, so nothing is allocated or enqueued while `QgsTaskManager::taskStatusChanged()` is still on the stack handling the previous task’s completion.
The stale pointer is `TaskInfo::runnable`: it is never cleared once the wrapper has run (the pool auto-deletes it), yet `cleanupAndDeleteTask()` later hands it to `QThreadPool::tryTake()`. Today task N+1’s wrapper is created inside task N’s completion handling (`finished()` → executed → `executeNext()` → `addTask()`), and the allocator can recycle the just-freed address of task N’s wrapper for it — likely with the Windows LFH (freed on the worker thread, reallocated on the main thread), unlikely with glibc’s per-thread tcache, matching the Windows-only reports. When that happens, the stale `tryTake()` pointer-matches the new runnable, removes it from the pool queue and deletes it: task N+1 stays Queued forever (`TaskInfo::added == 1`, so `processQueue()` never recreates it) and the batch freezes.  
With `executeNext()` deferred, `cleanupAndDeleteTask()` removes task N’s `TaskInfo` — the last holder of the stale pointer — before any new wrapper can be allocated at the recycled address, so the stale `tryTake()` can no longer match anything.

Fixes #53806

<details>
  <summary>Graphs</summary>
  
  Before the fix

```mermaid
sequenceDiagram
    autonumber
    participant W as Pool worker thread
    participant H as Heap
    participant Q as QThreadPool queue
    participant M as Main thread<br/>(QgsTaskManager)
    participant B as Batch dialog

    Note over Q: Wn was popped from the queue when task N started,<br/>but TaskInfo::runnable still holds its pointer
    W->>W: task N: QgsTask::run() returns
    W->>M: completed() queues processSubTasksForCompletion
    W->>H: pool auto-deletes wrapper Wn
    Note over H: address X freed

    activate M
    M->>M: processSubTasksForCompletion()<br/>emit statusChanged(Complete)
    M->>M: taskStatusChanged(N)
    M->>Q: tryTake(stale X)
    Q-->>M: false (Wn already consumed) — stale pointer kept
    M->>B: task->finished() → executed signal (direct)
    activate B
    B->>B: onTaskComplete() → executeNext()
    B->>M: addTask(task N+1)
    M->>H: new QgsTaskRunnableWrapper
    H-->>M: returns recycled address X
    M->>Q: threadPool->start(Wn+1)
    Note over Q: Wn+1 waiting in queue, at address X
    deactivate B
    rect rgb(255, 224, 224)
    M->>M: cleanupAndDeleteTask(N)<br/>re-reads stale TaskInfo::runnable == X
    M->>Q: tryTake(stale X)
    Q-->>M: true — pointer matches Wn+1
    M->>M: delete runnable → kills task N+1's wrapper
    end
    deactivate M
    Note over Q,B: task N+1: status Queued, TaskInfo::added == 1, runnable gone.<br/>processQueue() skips it forever → batch frozen (#53806)

```

After the fix 

```mermaid
sequenceDiagram
    autonumber
    participant Q as QThreadPool queue
    participant M as Main thread<br/>(QgsTaskManager)
    participant B as Batch dialog
    participant E as Event loop

    M->>M: taskStatusChanged(N)
    M->>B: task->finished() → executed signal (direct)
    B->>E: invokeMethod(executeNext, Qt::QueuedConnection)
    Note over B,E: nothing allocated, nothing enqueued
    M->>M: cleanupAndDeleteTask(N)
    M->>Q: tryTake(stale X)
    Q-->>M: false — queue empty, no harm
    M->>M: TaskInfo(N) removed → last stale pointer gone
    E->>B: executeNext() (next event loop iteration)
    B->>M: addTask(task N+1)
    M->>Q: start(Wn+1) — no stale pointer alive anymore
```
  
</details>

## AI tool usage

 - [X] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

Claude has been used to diagnose the issue and write the fix. To be truly honest, I would have not be able to write this but I spent times ton understand what was happening here and the explanation given by Claude makes sense.

This bug is very annoying when it happens after time was spent to setup tasks (sometimes tens of tasks), there is no way to recover the setup. 

I would understand if this is closed without further notice but please, consider my good intentions here.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->