### PR TITLE
[server]: package landing page webapp in Debian builds

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -28,6 +28,7 @@ Build-Depends:
  libzip-dev,
 #!trixie !plucky# nlohmann-json3-dev (>= 3.12.0),
  ninja-build,
+ nodejs,
  ocl-icd-opencl-dev,
  opencl-headers,
  pkgconf,
@@ -66,7 +67,8 @@ Build-Depends:
  libcups2-dev,
 #oracle# oracle-instantclient-basiclite, oracle-instantclient-devel,
 #pdal# libpdal-dev, pdal,
- locales
+ locales,
+ yarnpkg
 #apidoc#Build-Depends-indep:
 #apidoc# doxygen
 Build-Conflicts:
@@ -476,6 +478,8 @@ Depends:
  qgis-server-common (= ${source:Version}),
  ${shlibs:Depends},
  ${misc:Depends}
+Recommends:
+ qgis-server-landingpage (= ${binary:Version})
 Replaces: qgis-server-qt6
 Description: QGIS server providing various OGC services
  QGIS is a Geographic Information System (GIS) which manages, analyzes and
@@ -561,6 +565,18 @@ Description: QGIS server providing various OGC services
  display databases of geographic information.
  .
  This package contains the WCS service.
+
+Package: qgis-server-landingpage
+Architecture: any
+Depends:
+ qgis-server-common (= ${source:Version}),
+ ${shlibs:Depends},
+ ${misc:Depends}
+Description: QGIS server providing various OGC services
+ QGIS is a Geographic Information System (GIS) which manages, analyzes and
+ display databases of geographic information.
+ .
+ This package contains the landing page/catalog webapp for QGIS server.
 
 #apidoc#Package: qgis-api-doc
 #apidoc#Architecture: all

--- a/debian/qgis-server-landingpage.install
+++ b/debian/qgis-server-landingpage.install
@@ -1,0 +1,1 @@
+usr/lib/qgis/server/liblandingpage.so

--- a/debian/rules
+++ b/debian/rules
@@ -149,7 +149,7 @@ CMAKE_OPTS := \
 	-DWITH_CUSTOM_WIDGETS=TRUE \
 	-DWITH_SERVER=TRUE \
 	-DWITH_SERVER_PLUGINS=TRUE \
-	-DWITH_SERVER_LANDINGPAGE_WEBAPP=FALSE \
+	-DWITH_SERVER_LANDINGPAGE_WEBAPP=TRUE \
 	-DWITH_INTERNAL_MESHOPTIMIZER=FALSE \
 	-DWITH_INTERNAL_QWT=TRUE \
 	-DWITH_QUICK=TRUE \
@@ -320,8 +320,7 @@ override_dh_auto_install:
 	$(RM) $(CURDIR)/debian/tmp/usr/bin/test_provider_wcs*
 	$(RM) $(CURDIR)/debian/tmp/usr/bin/qgis_quickapp*
 
-	# landing page not packaged
-	$(RM) $(CURDIR)/debian/tmp/usr/lib/qgis*/server/liblandingpage*.so
+	# landing page sources are not needed at runtime, only the built webapp is packaged
 	$(RM) -r $(CURDIR)/debian/tmp/usr/share/qgis*/resources/server/src/landingpage
 
 	# Man pages are installed by dh_installman

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -39,7 +39,8 @@ endif()
 
 # Server landingpage webapp
 if (WITH_SERVER_LANDINGPAGE_WEBAPP)
-  find_program(YARN yarn REQUIRED)
+  # Debian/Ubuntu's yarnpkg package installs the binary as "yarnpkg" (not "yarn")
+  find_program(YARN NAMES yarn yarnpkg REQUIRED)
 
   file(GLOB_RECURSE LANDINGPAGE_SOURCE_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} server/src/landingpage/*)
   set(LANDINGPAGE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/output/data/resources/server/src/landingpage)


### PR DESCRIPTION

## Description

Fixes #55462 and #65668.

Debian packaging forced WITH_SERVER_LANDINGPAGE_WEBAPP=FALSE and explicitly deleted the built liblandingpage*.so artifacts, so qgis-server installed via .deb packages never shipped the landing page/catalog webapp — even though it builds and works correctly from source or via the official Docker images.

Changes:

rules: enable WITH_SERVER_LANDINGPAGE_WEBAPP and stop deleting the built module.
control.in: add nodejs/yarnpkg build-deps, new qgis-server-landingpage binary package, recommended by qgis-server.
qgis-server-landingpage.install: installs liblandingpage.so.
CMakeLists.txt: Debian's yarnpkg apt package installs the binary as yarnpkg, not yarn — broadened find_program() to accept either name.

Validated with a full dpkg-buildpackage build on debian:trixie in Docker (not included in this PR) confirming the landing page installs and serves correctly (HTML/JS/CSS assets + JSON API) with the following variable envs : 
- QGIS_SERVER_LANDING_PAGE_PREFIX=/welcome
- QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES=/io/data/data||/io/data/test_project    

Using the URL http://localhost/welcome/index.html#/ I can see the following : 
<img width="1169" height="800" alt="image" src="https://github.com/user-attachments/assets/271433c2-20bc-471f-9d51-fcbcd3d9a905" />


## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


