### PR TITLE
Duplicate layer: fix cloning layers's server properties (Fixes #67023)

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -157,7 +157,7 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
   layer->setCustomProperties( mCustomProperties );
   layer->setOpacity( mLayerOpacity );
   layer->setMetadata( mMetadata );
-  layer->serverProperties()->copyTo( mServerProperties.get() );
+  mServerProperties->copyTo( layer->serverProperties() );
 }
 
 Qgis::LayerType QgsMapLayer::type() const

--- a/src/core/qgsmaplayerserverproperties.cpp
+++ b/src/core/qgsmaplayerserverproperties.cpp
@@ -259,6 +259,7 @@ void QgsMapLayerServerProperties::copyTo( QgsMapLayerServerProperties *propertie
 
   properties->setShortName( mShortName );
   properties->setTitle( mTitle );
+  properties->setWfsTitle( mWfsTitle );
   properties->setAbstract( mAbstract );
   properties->setKeywordList( mKeywordList );
   properties->setDataUrl( mDataUrl );
@@ -275,6 +276,7 @@ bool QgsMapLayerServerProperties::operator==( const QgsMapLayerServerProperties 
          && QgsServerWmsDimensionProperties::operator==( other )
          && mShortName == other.mShortName
          && mTitle == other.mTitle
+         && mWfsTitle == other.mWfsTitle
          && mAbstract == other.mAbstract
          && mKeywordList == other.mKeywordList
          && mDataUrl == other.mDataUrl

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -82,6 +82,8 @@ class TestQgsMapLayer : public QObject
 
     void publicSourceOnGdalWithCredentials();
 
+    void cloneServerProperties();
+
   private:
     QgsVectorLayer *mpLayer = nullptr;
 };
@@ -552,6 +554,64 @@ void TestQgsMapLayer::publicSourceOnGdalWithCredentials()
   QCOMPARE( rl.publicSource( true ), u"test.tif|option:AN=OPTION|credential:ANOTHER=XXXXXXXX|credential:SOMEKEY=XXXXXXXX"_s );
   QCOMPARE( rl.publicSource( false ), u"test.tif|option:AN=OPTION"_s );
   QCOMPARE( rl.publicSource(), u"test.tif|option:AN=OPTION"_s );
+}
+
+void TestQgsMapLayer::cloneServerProperties()
+{
+  auto source = std::make_unique<QgsVectorLayer>( u"Point"_s, u"source"_s, u"memory"_s );
+  source->serverProperties()->setShortName( u"MyShortName"_s );
+  source->serverProperties()->setTitle( u"MyTitle"_s );
+  source->serverProperties()->setWfsTitle( u"MyWfsTitle"_s );
+  source->serverProperties()->setAbstract( u"MyAbstract"_s );
+  source->serverProperties()->setKeywordList( u"keyword1,keyword2,keyword3"_s );
+  source->serverProperties()->setDataUrl( u"MyDataUrl"_s );
+  source->serverProperties()->setDataUrlFormat( u"text/html"_s );
+  source->serverProperties()->setAttribution( u"MyAttribution"_s );
+  source->serverProperties()->setAttributionUrl( u"MyAttributionUrl"_s );
+  source->serverProperties()->setLegendUrl( u"MyLegendUrl"_s );
+  source->serverProperties()->setLegendUrlFormat( u"image/png"_s );
+
+  const QgsServerMetadataUrlProperties::MetadataUrl metadataUrl( u"https://www.test.url"_s, u"FGDC"_s, u"text/xml"_s );
+  source->serverProperties()->addMetadataUrl( metadataUrl );
+
+  const QgsServerWmsDimensionProperties::WmsDimensionInfo
+    wmsDimension( u"elevation"_s, u"field_name"_s, u"end_field_name"_s, u"foot"_s, u"ft"_s, QgsServerWmsDimensionProperties::WmsDimensionInfo::ReferenceValue, QVariant( u"0"_s ) );
+  QVERIFY( source->serverProperties()->addWmsDimension( wmsDimension ) );
+
+  std::unique_ptr<QgsVectorLayer> clone( source->clone() );
+  QVERIFY( clone );
+
+  QCOMPARE( source->serverProperties()->shortName(), u"MyShortName"_s );
+  QCOMPARE( source->serverProperties()->title(), u"MyTitle"_s );
+  QCOMPARE( source->serverProperties()->wfsTitle(), u"MyWfsTitle"_s );
+  QCOMPARE( source->serverProperties()->abstract(), u"MyAbstract"_s );
+  QCOMPARE( source->serverProperties()->keywordList(), u"keyword1,keyword2,keyword3"_s );
+  QCOMPARE( source->serverProperties()->dataUrl(), u"MyDataUrl"_s );
+  QCOMPARE( source->serverProperties()->dataUrlFormat(), u"text/html"_s );
+  QCOMPARE( source->serverProperties()->attribution(), u"MyAttribution"_s );
+  QCOMPARE( source->serverProperties()->attributionUrl(), u"MyAttributionUrl"_s );
+  QCOMPARE( source->serverProperties()->legendUrl(), u"MyLegendUrl"_s );
+  QCOMPARE( source->serverProperties()->legendUrlFormat(), u"image/png"_s );
+  QCOMPARE( source->serverProperties()->metadataUrls().size(), 1 );
+  QCOMPARE( source->serverProperties()->metadataUrls().at( 0 ), metadataUrl );
+  QCOMPARE( source->serverProperties()->wmsDimensions().size(), 1 );
+  QCOMPARE( source->serverProperties()->wmsDimensions().at( 0 ), wmsDimension );
+
+  QCOMPARE( clone->serverProperties()->shortName(), u"MyShortName"_s );
+  QCOMPARE( clone->serverProperties()->title(), u"MyTitle"_s );
+  QCOMPARE( clone->serverProperties()->wfsTitle(), u"MyWfsTitle"_s );
+  QCOMPARE( clone->serverProperties()->abstract(), u"MyAbstract"_s );
+  QCOMPARE( clone->serverProperties()->keywordList(), u"keyword1,keyword2,keyword3"_s );
+  QCOMPARE( clone->serverProperties()->dataUrl(), u"MyDataUrl"_s );
+  QCOMPARE( clone->serverProperties()->dataUrlFormat(), u"text/html"_s );
+  QCOMPARE( clone->serverProperties()->attribution(), u"MyAttribution"_s );
+  QCOMPARE( clone->serverProperties()->attributionUrl(), u"MyAttributionUrl"_s );
+  QCOMPARE( clone->serverProperties()->legendUrl(), u"MyLegendUrl"_s );
+  QCOMPARE( clone->serverProperties()->legendUrlFormat(), u"image/png"_s );
+  QCOMPARE( clone->serverProperties()->metadataUrls().size(), 1 );
+  QCOMPARE( clone->serverProperties()->metadataUrls().at( 0 ), metadataUrl );
+  QCOMPARE( clone->serverProperties()->wmsDimensions().size(), 1 );
+  QCOMPARE( clone->serverProperties()->wmsDimensions().at( 0 ), wmsDimension );
 }
 
 QGSTEST_MAIN( TestQgsMapLayer )

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -599,13 +599,13 @@ class TestQgsRasterLayer(QgisTestCase):
         renderer.setOpacity(33.3)
         layer.setRenderer(renderer)
 
-        # clone layer
-        clone = layer.clone()
-
         # generate xml from layer
         layer_doc = QDomDocument("doc")
         layer_elem = layer_doc.createElement("maplayer")
         layer.writeLayerXml(layer_elem, layer_doc, QgsReadWriteContext())
+
+        # clone layer
+        clone = layer.clone()
 
         # generate xml from clone
         clone_doc = QDomDocument("doc")

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -3976,15 +3976,15 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
         metadata.setFees("a handful of roos")
         layer.setMetadata(metadata)
 
-        # clone layer
-        clone = layer.clone()
-
-        self.assertEqual(layer.metadata().fees(), "a handful of roos")
-
         # generate xml from layer
         layer_doc = QDomDocument("doc")
         layer_elem = layer_doc.createElement("maplayer")
         layer.writeLayerXml(layer_elem, layer_doc, QgsReadWriteContext())
+
+        # clone layer
+        clone = layer.clone()
+
+        self.assertEqual(clone.metadata().fees(), "a handful of roos")
 
         # generate xml from clone
         clone_doc = QDomDocument("doc")


### PR DESCRIPTION
## Description

Fixes #67023.

This PR fixes (https://github.com/qgis/QGIS/pull/67062/changes/adb4d09db3e2830eea452fbb034f80b20b0f78e9) a regression occurring in `QgsMapLayer::clone` since QGIS 3.22.0 due to an oversight in PR https://github.com/qgis/QGIS/pull/44862 where the server properties of the duplicated layer were copied over the server properties of the source layer, instead of the other way round, actually clearing the server properties of the source layer instead of copying them to the duplicated layer.

The issue occurred (QGIS 3.22 <-> QGIS 3.36) only for the `QgsServerMetadataUrlProperties` and `QgsServerWmsDimensionProperties` server properties since its effects were mitigated by some other implementation details of https://github.com/qgis/QGIS/pull/44862, thus it remained unreported.

Afterwards, the changes introduce by PR https://github.com/qgis/QGIS/pull/57103 inadvertently worsened the issue: since QGIS 3.38.0, all (not only `QgsServerMetadataUrlProperties` and `QgsServerWmsDimensionProperties`) the server properties (short tile, title, abstract, ...) of the source layer are cleared instead of copied to the duplicated layer.

Both the regressions were possible due to the fact that the tests introduced by https://github.com/qgis/QGIS/pull/4567 for `QgsMapLayer::clone()` were not able to prevent such kind of issue.
I've fixed (1413fa3599371f403e554ee83b22a24a1631b2ae) the existing tests, ensuring they actually tests the functionality, and added (69270563718457368f3a0fdcedda1693d35df0c9) a new one specifically for the server properties.

During the debug of the issue, I've also noticed and fixed (0715e0e1313164529a3188bbf0bb1145ef7a4cb3) an oversight in https://github.com/qgis/QGIS/pull/57822, where the newly (since QGIS 3.40.0) introduced WFS Title server property was not added to `QgsMapLayerServerProperties::copyTo()` and `QgsMapLayerServerProperties::operator==`.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
