### PR TITLE
Fix difference methods in QgsGeometry

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1414,7 +1414,7 @@ Replaces a part of this geometry with another line
 %End
 
 
-    QgsGeometry makeDifference( const QgsGeometry &other, QgsFeedback* feedback = 0 ) const;
+ QgsGeometry makeDifference( const QgsGeometry &other, QgsFeedback* feedback = 0 ) const /Deprecated="Since 4.4. Use QgsGeometry.difference()."/;
 %Docstring
 Returns the geometry formed by modifying this geometry such that it does
 not intersect the other geometry.
@@ -1425,6 +1425,10 @@ not intersect the other geometry.
 
 :return: difference geometry, or empty geometry if difference could not
          be calculated
+
+.. deprecated:: 4.4
+
+   Use :py:func:`QgsGeometry.difference()`.
 %End
 
     QgsRectangle boundingBox() const;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1428,7 +1428,7 @@ int QgsGeometry::makeDifferenceInPlace( const QgsGeometry &other, QgsFeedback *f
   QgsGeos geos( d->geometry.get() );
 
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > diffGeom( geos.intersection( other.constGet(), &mLastError, QgsGeometryParameters(), feedback ) );
+  std::unique_ptr< QgsAbstractGeometry > diffGeom( geos.difference( other.constGet(), &mLastError, QgsGeometryParameters(), feedback ) );
   if ( !diffGeom )
   {
     return 1;
@@ -1440,23 +1440,7 @@ int QgsGeometry::makeDifferenceInPlace( const QgsGeometry &other, QgsFeedback *f
 
 QgsGeometry QgsGeometry::makeDifference( const QgsGeometry &other, QgsFeedback *feedback ) const
 {
-  if ( !d->geometry || other.isNull() )
-  {
-    return QgsGeometry();
-  }
-
-  QgsGeos geos( d->geometry.get() );
-
-  mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > diffGeom( geos.intersection( other.constGet(), &mLastError, QgsGeometryParameters(), feedback ) );
-  if ( !diffGeom )
-  {
-    QgsGeometry result;
-    result.mLastError = mLastError;
-    return result;
-  }
-
-  return QgsGeometry( diffGeom.release() );
+  return difference( other, QgsGeometryParameters(), feedback );
 }
 
 QgsRectangle QgsGeometry::boundingBox() const

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1393,8 +1393,9 @@ class CORE_EXPORT QgsGeometry
      * \param other geometry that should not be intersect
      * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      * \note Not available in Python
+     * \deprecated QGIS 4.4
      */
-    int makeDifferenceInPlace( const QgsGeometry &other, QgsFeedback* feedback = nullptr ) SIP_SKIP;
+    Q_DECL_DEPRECATED int makeDifferenceInPlace( const QgsGeometry &other, QgsFeedback* feedback = nullptr ) SIP_SKIP;
 
     /**
      * Returns the geometry formed by modifying this geometry such that it does not
@@ -1402,8 +1403,9 @@ class CORE_EXPORT QgsGeometry
      * \param other geometry that should not be intersect
      * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      * \returns difference geometry, or empty geometry if difference could not be calculated
+     * \deprecated QGIS 4.4. Use QgsGeometry::difference().
      */
-    QgsGeometry makeDifference( const QgsGeometry &other, QgsFeedback* feedback = nullptr ) const;
+    Q_DECL_DEPRECATED QgsGeometry makeDifference( const QgsGeometry &other, QgsFeedback* feedback = nullptr ) const SIP_DEPRECATED;
 
     /**
      * Returns the bounding box of the geometry.

--- a/src/plugins/topology/topolError.cpp
+++ b/src/plugins/topology/topolError.cpp
@@ -42,7 +42,7 @@ bool TopolError::fixMove( const FeatureLayer &fl1, const FeatureLayer &fl2 )
 
   // 0 means success
   const QgsGeometry g = f1.geometry();
-  QgsGeometry difference = g.makeDifference( f2.geometry() );
+  QgsGeometry difference = g.difference( f2.geometry() );
   if ( !difference.isNull() )
   {
     return fl1.layer->changeGeometry( f1.id(), difference );


### PR DESCRIPTION
Was looking for something else and came across this.

4 difference methods? 2 of them being intersections in disguise!?

`makeDifferenceInPlace` was like this since the beginning and not used in the codebase. 
Do we need to go through deprecation cycle or can we just remove it?

If we'd want in-place operations, it would be simpler to have them as param `bool inPlace` in existing methods, rather than separate methods.

`makeDifference` set as deprecated and calls internally difference().

No AI used.