### PR TITLE
[processing] Fix crash on app exit when model designer dialog is open (fixes #64768)

### DIFF
--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -380,6 +380,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
 
 QgsModelDesignerDialog::~QgsModelDesignerDialog()
 {
+  blockSignals( true );
   if ( mAlgorithmWidget )
   {
     delete mAlgorithmWidget;


### PR DESCRIPTION
### Description
Fixes #64768.

This PR prevents a crash/segfault on application exit when the Processing Model Designer dialog remains open. The issue occurred because shared processing registries were destroyed before child widget teardown finished.

### Changes
- Added signal blocking during `QgsModelDesignerDialog` destructor teardown to prevent invalid callbacks during application exit.

### Testing
- Verified model designer closes cleanly when main window is closed.
- Ran processing modeler suite.