### PR TITLE
[core] Prevent re-entrant startEditing calls during beforeEditingStarted emission (fixes #63904)

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1844,7 +1844,13 @@ bool QgsVectorLayer::startEditing()
 
   mDataProvider->enterUpdateMode();
 
+  static bool sIsStartingEditing = false;
+  if ( sIsStartingEditing )
+    return false;
+
+  sIsStartingEditing = true;
   emit beforeEditingStarted();
+  sIsStartingEditing = false;
 
   createEditBuffer();
 


### PR DESCRIPTION
### Description
Fixes #63904.

Prevents a crash/recursion when slots connected to `beforeEditingStarted` or layer modification signals query or toggle layer edit state.

### Changes
- Added a recursion guard flag around signal emission in `QgsVectorLayer::startEditing()`.

### Testing
- Tested signal connections to `beforeEditingStarted` in unit test suite.