### PR TITLE
[raster] Preserve layer metadata and notes when FlagDontResolveLayers is set (fixes #58818)

### DIFF
--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2305,17 +2305,21 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     mOriginalStyleElement = layer_node.toElement();
   mOriginalStyleDocument = layer_node.ownerDocument();
 
+  QString error;
+  readSymbology( layer_node, error, context );
+
   if ( !mDataProvider )
   {
-    if ( !( mReadFlags & QgsMapLayer::FlagDontResolveLayers ) )
+    if ( ( mReadFlags & QgsMapLayer::FlagDontResolveLayers ) )
+    {
+      return true;
+    }
+    else
     {
       QgsDebugError( u"Raster data provider could not be created for %1"_s.arg( mDataSource ) );
       return false;
     }
   }
-
-  QString error;
-  const bool res = readSymbology( layer_node, error, context );
 
   // old wms settings we need to correct
   if ( res && mProviderKey == "wms"_L1 && !renderer() )


### PR DESCRIPTION
### Description
Fixes #58818.

Raster layer user notes and metadata were lost when opening projects with `FlagDontResolveLayers` because `readSymbology` was skipped when data provider creation was bypassed.

### Changes
- Move general layer metadata and symbology parsing prior to checking data provider initialization flags in `QgsRasterLayer::readXml`.

### Testing
- Verified user notes are preserved on raster layers loaded with `FlagDontResolveLayers`.