### PR TITLE
[providers] Emit fullExtentChanged and dataChanged on memory provider geometry update (fixes #58113)

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -746,6 +746,8 @@ bool QgsMemoryProvider::changeGeometryValues( const QgsGeometryMap &geometry_map
   }
 
   updateExtents();
+  emit fullExtentChanged();
+  emit dataChanged();
 
   return true;
 }


### PR DESCRIPTION
### Description
Fixes #58113.

Ensures spatial index iterators and downstream consumers are notified when geometry values in `QgsMemoryProvider` are changed in place.

### Changes
- Emitted `fullExtentChanged()` and `dataChanged()` signals in `QgsMemoryProvider::changeGeometryValues()`.

### Testing
- Verified feature source spatial queries update immediately after editing memory layer geometries.