### PR TITLE
[python] Include field name in ValueError when resolveFieldIndex fails (fixes #55259)

### DIFF
--- a/python/plugins/processing/tools/vector.py
+++ b/python/plugins/processing/tools/vector.py
@@ -38,7 +38,7 @@ def resolveFieldIndex(source, attr):
     else:
         index = source.fields().lookupField(attr)
         if index == -1:
-            raise ValueError("Wrong field name")
+            raise ValueError(f"Field '{attr}' not found in layer fields")
         return index
 
 


### PR DESCRIPTION
### Description
Fixes #55259.

Improves error reporting context in PyQGIS processing tools when a specified field name is missing from layer fields.

### Changes
- Formatted missing field name into `ValueError` in `resolveFieldIndex()`.

### Testing
- Tested `resolveFieldIndex` error handling in PyQGIS suite.