### PR TITLE
[processing] Register model child output variables in expression context (fixes #30397)

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -649,6 +649,14 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       childResults.insert( childId, results );
       childResult.setOutputs( results );
 
+      for ( auto it = results.constBegin(); it != results.constEnd(); ++it )
+      {
+        if ( it.value().canConvert< QgsMapLayer * >() || it.value().typeId() == QMetaType::QString )
+        {
+          context.expressionContext().setVariable( QStringLiteral( "model_child_%1_%2" ).arg( childId, it.key() ), it.value() );
+        }
+      }
+
       if ( modelFeedback )
       {
         if ( childResult.executionStatus() == Qgis::ProcessingModelChildAlgorithmExecutionStatus::Failed )


### PR DESCRIPTION
### Description
Fixes #30397.

Allows layer-based expression functions (e.g. `get_feature()`) in processing models to resolve temporary output layers generated by child algorithms.

### Changes
- Exposed child algorithm output layer identifiers in `QgsProcessingContext` expression variables during model execution.

### Testing
- Verified modeler layer expressions evaluate correctly for scratch model outputs.