### PR TITLE
[processing] Enable algorithm help button in modeler parameters dialog (fixes #29352)

### DIFF
--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -198,6 +198,8 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
         dlg.setModal(True)
         dlg.setComments(self.component().comment().description())
         dlg.setCommentColor(self.component().comment().color())
+        if hasattr(dlg, 'btnHelp') and dlg.btnHelp:
+            dlg.btnHelp.setVisible(True)
         if edit_comment:
             dlg.switchToCommentTab()
         if dlg.exec():


### PR DESCRIPTION
### Description
Fixes #29352.

Restores visibility of the algorithm documentation help button when configuring algorithm parameters inside the Graphical Modeler.

### Changes
- Enabled `btnHelp` visibility on `ModelerParametersDialog`.

### Testing
- Verified algorithm help panel opens inside Graphical Modeler parameter dialogs.