### PR TITLE
[gui] Set mResettingModel flag prior to loadAttributes in loadLayer (fixes #47921)

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -478,9 +478,9 @@ void QgsAttributeTableModel::loadLayer()
   // table view may be updated with inconsistent model which may assume
   // wrong number of attributes)
 
+  mResettingModel = true;
   loadAttributes();
 
-  mResettingModel = true;
   beginResetModel();
 
   if ( rowCount() != 0 )


### PR DESCRIPTION
### Description
Fixes #47921.

Fixes UI thread lockup when vector layer joins change while attribute table window is active.

### Changes
- Set `mResettingModel = true` prior to calling `loadAttributes()` in `QgsAttributeTableModel::loadLayer()`.

### Testing
- Verified adding vector join while attribute table is open updates without freezing UI.