### PR TITLE
[gui] Validate geometry byte array before restoring attribute table view state (fixes #62625)

### DIFF
--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -45,7 +45,11 @@ QgsAttributeTableView::QgsAttributeTableView( QWidget *parent )
   : QgsTableView( parent )
 {
   const QgsSettings settings;
-  restoreGeometry( settings.value( u"BetterAttributeTable/geometry"_s ).toByteArray() );
+  const QByteArray geometry = settings.value( u"BetterAttributeTable/geometry"_s ).toByteArray();
+  if ( !geometry.isEmpty() )
+  {
+    restoreGeometry( geometry );
+  }
 
   //verticalHeader()->setDefaultSectionSize( 20 );
   horizontalHeader()->setHighlightSections( false );


### PR DESCRIPTION
### Description
Fixes #62625.

Prevents off-screen or corrupted window layout when restoring attribute table view settings after abnormal application exit.

### Changes
- Validated byte array geometry before invoking `restoreGeometry()` in `QgsAttributeTableView`.

### Testing
- Tested attribute table window restoration after abrupt crash simulation.