### PR TITLE
[processing] Emit styleChanged when post-processing layer renderer in categorizeusingstyle (fixes #66550)

### DIFF
--- a/src/analysis/processing/qgsalgorithmcategorizeusingstyle.cpp
+++ b/src/analysis/processing/qgsalgorithmcategorizeusingstyle.cpp
@@ -126,6 +126,7 @@ class SetCategorizedRendererPostProcessor : public QgsProcessingLayerPostProcess
       {
         vl->setRenderer( mRenderer.release() );
         vl->triggerRepaint();
+        vl->emitStyleChanged();
       }
     }
 


### PR DESCRIPTION
### Description
Fixes #66550.

Ensures styling dock and layer legend update automatically when a processing post-processor modifies layer renderer.

### Changes
- Emitted `styleChanged()` signal in `postProcessLayer()` of categorizeusingstyle algorithm.

### Testing
- Verified styling dock updates when algorithm execution completes.