### PR TITLE
Follow up of #66915: Fix warning and small behavior regression

### DIFF
--- a/src/gui/symbology/qgssymbollayermodel.cpp
+++ b/src/gui/symbology/qgssymbollayermodel.cpp
@@ -511,6 +511,9 @@ void QgsSymbolLayerModel::changeLayer( QgsSymbolLayerModelNode *node, QgsSymbolL
 void QgsSymbolLayerModel::updatePreview( QgsSymbolLayerModelNode *node )
 {
   const QModelIndex index = node2index( node );
+  if ( !index.isValid() )
+    return;
+
   emit dataChanged( index, index, QVector<int>() << Qt::DecorationRole );
 
   // Recursively update the parent's preview up to the root node.

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -321,6 +321,7 @@ void QgsSymbolSelectorWidget::loadSymbol( QgsSymbol *symbol )
 
   mSymbol = symbol;
   mSymbolLayersModel->setSymbol( symbol );
+  layersTree->expandAll();
 }
 
 void QgsSymbolSelectorWidget::reloadSymbol()

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -320,8 +320,7 @@ void QgsSymbolSelectorWidget::loadSymbol( QgsSymbol *symbol )
     return;
 
   mSymbol = symbol;
-  mSymbolLayersModel->setSymbol( symbol );
-  layersTree->expandAll();
+  reloadSymbol();
 }
 
 void QgsSymbolSelectorWidget::reloadSymbol()


### PR DESCRIPTION
Follow up of #66915 fixes the following:

* Fix the warning "dataChanged() called with an invalid index range"  On `updatePreview` the root node was also updated even if the root node doesn't have a valid index
* In annotations widget the symbol layer tree would not be expanded by default 

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
