### PR TITLE
[Wms] Compute WMS Time dimension even if group is Opaque

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -50,7 +50,7 @@ namespace QgsWms
   {
     QString dateToString( const QDateTime &dateTime, bool forceToDate );
 
-    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos, QList<QgsDateTimeRange> &dateRanges );
+    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos, const QStringList &restrictedLayers, QList<QgsDateTimeRange> &dateRanges );
 
     void appendLayerProjectSettings( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer );
 
@@ -1123,9 +1123,10 @@ namespace QgsWms
     }
 
     /**
-     * Update recursively \a dateRanges with all \a layerTreeGroup children date ranges
+     * Update recursively \a dateRanges with all \a layerTreeGroup children date ranges.
+     * Don't return date range for layer not published in \a wmsLayerInfos or group which name appears in \a restrictedLayers
      */
-    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos, QList<QgsDateTimeRange> &dateRanges )
+    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos, const QStringList &restrictedLayers, QList<QgsDateTimeRange> &dateRanges )
     {
       QList<QgsLayerTreeNode *> layerTreeGroupChildren = layerTreeGroup->children();
       for ( int i = 0; i < layerTreeGroupChildren.size(); ++i )
@@ -1135,11 +1136,11 @@ namespace QgsWms
         if ( treeNode->nodeType() == QgsLayerTreeNode::NodeGroup )
         {
           QgsLayerTreeGroup *treeGroupChild = static_cast<QgsLayerTreeGroup *>( treeNode );
-          QList<QgsDateTimeRange> childrenDateRanges;
-          getChildrenRanges( treeGroupChild, wmsLayerInfos, childrenDateRanges );
-
-          if ( treeGroupChild->hasWmsTimeDimension() )
+          if ( !restrictedLayers.contains( treeGroupChild->name() ) // skip restricted group
+               && treeGroupChild->hasWmsTimeDimension() )
           {
+            QList<QgsDateTimeRange> childrenDateRanges;
+            getChildrenRanges( treeGroupChild, wmsLayerInfos, restrictedLayers, childrenDateRanges );
             dateRanges.append( childrenDateRanges );
           }
         }
@@ -1276,7 +1277,7 @@ namespace QgsWms
           if ( treeGroupChild->hasWmsTimeDimension() )
           {
             QList<QgsDateTimeRange> childrenDateRanges;
-            getChildrenRanges( treeGroupChild, wmsLayerInfos, childrenDateRanges );
+            getChildrenRanges( treeGroupChild, wmsLayerInfos, restrictedLayers, childrenDateRanges );
             writeTimeDimensionNode( doc, layerElem, childrenDateRanges );
           }
 

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -50,7 +50,7 @@ namespace QgsWms
   {
     QString dateToString( const QDateTime &dateTime, bool forceToDate );
 
-    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, QList<QgsDateTimeRange> &parentDateRanges );
+    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos, QList<QgsDateTimeRange> &dateRanges );
 
     void appendLayerProjectSettings( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer );
 
@@ -1123,9 +1123,9 @@ namespace QgsWms
     }
 
     /**
-     * Update recursively \a parentDateRanges with all \a layerTreeGroup children date ranges
+     * Update recursively \a dateRanges with all \a layerTreeGroup children date ranges
      */
-    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, QList<QgsDateTimeRange> &parentDateRanges )
+    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos, QList<QgsDateTimeRange> &dateRanges )
     {
       QList<QgsLayerTreeNode *> layerTreeGroupChildren = layerTreeGroup->children();
       for ( int i = 0; i < layerTreeGroupChildren.size(); ++i )
@@ -1136,22 +1136,25 @@ namespace QgsWms
         {
           QgsLayerTreeGroup *treeGroupChild = static_cast<QgsLayerTreeGroup *>( treeNode );
           QList<QgsDateTimeRange> childrenDateRanges;
-          getChildrenRanges( treeGroupChild, childrenDateRanges );
+          getChildrenRanges( treeGroupChild, wmsLayerInfos, childrenDateRanges );
 
           if ( treeGroupChild->hasWmsTimeDimension() )
           {
-            parentDateRanges.append( childrenDateRanges );
+            dateRanges.append( childrenDateRanges );
           }
         }
         else
         {
           QgsLayerTreeLayer *treeLayer = static_cast<QgsLayerTreeLayer *>( treeNode );
           QgsMapLayer *l = treeLayer->layer();
-          if ( l->temporalProperties() && l->temporalProperties()->isActive() )
+
+          if ( wmsLayerInfos.contains( treeLayer->layerId() ) // layer need to be published
+               && l->temporalProperties()
+               && l->temporalProperties()->isActive() )
           {
             // Add all values
             const QList<QgsDateTimeRange> allRanges { l->temporalProperties()->allTemporalRanges( l ) };
-            parentDateRanges.append( allRanges );
+            dateRanges.append( allRanges );
           }
         }
       }
@@ -1273,7 +1276,7 @@ namespace QgsWms
           if ( treeGroupChild->hasWmsTimeDimension() )
           {
             QList<QgsDateTimeRange> childrenDateRanges;
-            getChildrenRanges( treeGroupChild, childrenDateRanges );
+            getChildrenRanges( treeGroupChild, wmsLayerInfos, childrenDateRanges );
             writeTimeDimensionNode( doc, layerElem, childrenDateRanges );
           }
 

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -50,6 +50,8 @@ namespace QgsWms
   {
     QString dateToString( const QDateTime &dateTime, bool forceToDate );
 
+    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, QList<QgsDateTimeRange> &parentDateRanges );
+
     void appendLayerProjectSettings( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer );
 
     void appendDrawingOrder( QDomDocument &doc, QDomElement &parentElem, QgsServerInterface *serverIface, const QgsProject *project );
@@ -72,8 +74,7 @@ namespace QgsWms
       const QgsWmsRequest &request,
       const QgsLayerTreeGroup *layerTreeGroup,
       const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos,
-      bool projectSettings,
-      QList<QgsDateTimeRange> &parentDateRanges
+      bool projectSettings
     );
 
     void addKeywordListElement( const QgsProject *project, QDomDocument &doc, QDomElement &parent );
@@ -777,8 +778,7 @@ namespace QgsWms
     const QgsWmsRequest &request,
     const QgsLayerTreeGroup *layerTreeGroup,
     const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos,
-    bool projectSettings,
-    QList<QgsDateTimeRange> &parentDateRanges
+    bool projectSettings
   )
   {
     const auto layerIds = layerTreeGroup->findLayerIds();
@@ -794,7 +794,7 @@ namespace QgsWms
 
     // when the group is opaque we should not append any child layers
     if ( layerTreeGroup->wmsGroupRequestMode() != Qgis::WmsGroupRequestMode::Opaque )
-      appendLayersFromTreeGroup( doc, parentLayer, serverIface, project, request, layerTreeGroup, wmsLayerInfos, projectSettings, parentDateRanges );
+      appendLayersFromTreeGroup( doc, parentLayer, serverIface, project, request, layerTreeGroup, wmsLayerInfos, projectSettings );
   }
 
   QDomElement getLayersAndStylesCapabilitiesElement( QDomDocument &doc, QgsServerInterface *serverIface, const QgsProject *project, const QgsWmsRequest &request, bool projectSettings )
@@ -903,13 +903,11 @@ namespace QgsWms
       appendLayerWgs84BoundingRect( doc, layerParentElem, wmsWgs84BoundingRect );
       appendLayerCrsExtents( doc, layerParentElem, wmsCrsExtents );
 
-      QList<QgsDateTimeRange> parentDateRanges;
-      appendLayersFromTreeGroup( doc, layerParentElem, serverIface, project, request, projectLayerTreeRoot, wmsLayerInfos, projectSettings, parentDateRanges );
+      appendLayersFromTreeGroup( doc, layerParentElem, serverIface, project, request, projectLayerTreeRoot, wmsLayerInfos, projectSettings );
     }
     else
     {
-      QList<QgsDateTimeRange> parentDateRanges;
-      handleLayersFromTreeGroup( doc, layerParentElem, serverIface, project, request, projectLayerTreeRoot, wmsLayerInfos, projectSettings, parentDateRanges );
+      handleLayersFromTreeGroup( doc, layerParentElem, serverIface, project, request, projectLayerTreeRoot, wmsLayerInfos, projectSettings );
     }
 
     return layerParentElem;
@@ -1124,6 +1122,41 @@ namespace QgsWms
       return dateOnly ? dateTime.date().toString( Qt::DateFormat::ISODate ) : dateTime.toString( Qt::DateFormat::ISODate );
     }
 
+    /**
+     * Update recursively \a parentDateRanges with all \a layerTreeGroup children date ranges
+     */
+    void getChildrenRanges( const QgsLayerTreeGroup *layerTreeGroup, QList<QgsDateTimeRange> &parentDateRanges )
+    {
+      QList<QgsLayerTreeNode *> layerTreeGroupChildren = layerTreeGroup->children();
+      for ( int i = 0; i < layerTreeGroupChildren.size(); ++i )
+      {
+        QgsLayerTreeNode *treeNode = layerTreeGroupChildren.at( i );
+
+        if ( treeNode->nodeType() == QgsLayerTreeNode::NodeGroup )
+        {
+          QgsLayerTreeGroup *treeGroupChild = static_cast<QgsLayerTreeGroup *>( treeNode );
+          QList<QgsDateTimeRange> childrenDateRanges;
+          getChildrenRanges( treeGroupChild, childrenDateRanges );
+
+          if ( treeGroupChild->hasWmsTimeDimension() )
+          {
+            parentDateRanges.append( childrenDateRanges );
+          }
+        }
+        else
+        {
+          QgsLayerTreeLayer *treeLayer = static_cast<QgsLayerTreeLayer *>( treeNode );
+          QgsMapLayer *l = treeLayer->layer();
+          if ( l->temporalProperties() && l->temporalProperties()->isActive() )
+          {
+            // Add all values
+            const QList<QgsDateTimeRange> allRanges { l->temporalProperties()->allTemporalRanges( l ) };
+            parentDateRanges.append( allRanges );
+          }
+        }
+      }
+    }
+
     //! Return TRUE if date only have been written, FALSE if there are date and time
     bool writeTimeDimensionNode( QDomDocument &doc, QDomElement &layerElem, const QList<QgsDateTimeRange> &dateRanges )
     {
@@ -1166,8 +1199,7 @@ namespace QgsWms
       const QgsWmsRequest &request,
       const QgsLayerTreeGroup *layerTreeGroup,
       const QMap<QString, QgsWmsLayerInfos> &wmsLayerInfos,
-      bool projectSettings,
-      QList<QgsDateTimeRange> &parentDateRanges
+      bool projectSettings
     )
     {
       const QString version = request.wmsParameters().version();
@@ -1236,14 +1268,13 @@ namespace QgsWms
             layerElem.appendChild( treeNameElem );
           }
 
-
-          QList<QgsDateTimeRange> childrenDateRanges;
-          handleLayersFromTreeGroup( doc, layerElem, serverIface, project, request, treeGroupChild, wmsLayerInfos, projectSettings, childrenDateRanges );
+          handleLayersFromTreeGroup( doc, layerElem, serverIface, project, request, treeGroupChild, wmsLayerInfos, projectSettings );
 
           if ( treeGroupChild->hasWmsTimeDimension() )
           {
+            QList<QgsDateTimeRange> childrenDateRanges;
+            getChildrenRanges( treeGroupChild, childrenDateRanges );
             writeTimeDimensionNode( doc, layerElem, childrenDateRanges );
-            parentDateRanges.append( childrenDateRanges );
           }
 
           // Check if child layer elements have been added - anyway opaque groups are added even without any children
@@ -1408,8 +1439,6 @@ namespace QgsWms
             // Add all values
             const QList<QgsDateTimeRange> allRanges { l->temporalProperties()->allTemporalRanges( l ) };
             const bool dateOnly = writeTimeDimensionNode( doc, layerElem, allRanges );
-
-            parentDateRanges.append( allRanges );
 
             QDomElement timeExtentElem = doc.createElement( u"Extent"_s );
             timeExtentElem.setAttribute( u"name"_s, u"TIME"_s );

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -3096,7 +3096,12 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
             self.get_test_data_path("raster/byte.tif").as_posix(), "test_date_5"
         )
 
-        for rl in [rl1, rl2, rl3, rl4, rl5]:
+        # layer children of a restricted (not published) group, should never appeared
+        rl6 = QgsRasterLayer(
+            self.get_test_data_path("raster/byte.tif").as_posix(), "test_date_6"
+        )
+
+        for rl in [rl1, rl2, rl3, rl4, rl5, rl6]:
             timeProps = rl.temporalProperties()
             timeProps.setIsActive(True)
             timeProps.setMode(Qgis.RasterTemporalMode.FixedTemporalRange)
@@ -3129,14 +3134,20 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
             )
         )
 
+        rl6.temporalProperties().setFixedTemporalRange(
+            QgsDateTimeRange(
+                QDateTime.fromString("2025-01-15T00:00:00Z", Qt.DateFormat.ISODate),
+                QDateTime.fromString("2025-01-15T00:00:00Z", Qt.DateFormat.ISODate),
+            )
+        )
+
         project = QgsProject()
 
         # Set a filename to avoid capabilities cache breaking test
         project.setFileName("test_get_capabilities_time_dimension")
 
-        project.addMapLayers([rl1, rl2, rl3, rl4, rl5], False)
+        project.addMapLayers([rl1, rl2, rl3, rl4, rl5, rl6], False)
 
-        project.writeEntry("WMSRestrictedLayers", "/", ["test_date_5"])
         groupWithTimeDim = project.layerTreeRoot().addGroup("GroupWithTimeDimension")
         groupWithTimeDim.setHasWmsTimeDimension(True)
         groupWithoutTimeDim = project.layerTreeRoot().addGroup(
@@ -3150,6 +3161,9 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         group.addLayer(rl4)
         group.addLayer(rl5)
         groupWithTimeDim.addGroup("SubGroupWithoutTimeDimension").addLayer(rl3)
+        group = groupWithTimeDim.addGroup("RestrictedSubGroupWithTimeDimension")
+        group.setHasWmsTimeDimension(True)
+        group.addLayer(rl6)
 
         groupWithoutTimeDim.addLayer(rl1)
         group = groupWithoutTimeDim.addGroup("OtherSubGroupWithTimeDimension")
@@ -3174,6 +3188,12 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         group.addLayer(rl2)
         group.addLayer(rl4)
         group.addLayer(rl5)
+
+        project.writeEntry(
+            "WMSRestrictedLayers",
+            "/",
+            ["test_date_5", "RestrictedSubGroupWithTimeDimension"],
+        )
 
         def get_time_dim(layer_name):
             r, h = self._result(self._execute_request_project(qs, project))

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -3090,7 +3090,13 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         rl4 = QgsRasterLayer(
             self.get_test_data_path("raster/byte.tif").as_posix(), "test_date_4"
         )
-        for rl in [rl1, rl2, rl3, rl4]:
+
+        # not published layer
+        rl5 = QgsRasterLayer(
+            self.get_test_data_path("raster/byte.tif").as_posix(), "test_date_5"
+        )
+
+        for rl in [rl1, rl2, rl3, rl4, rl5]:
             timeProps = rl.temporalProperties()
             timeProps.setIsActive(True)
             timeProps.setMode(Qgis.RasterTemporalMode.FixedTemporalRange)
@@ -3116,13 +3122,21 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
             )
         )
 
+        rl5.temporalProperties().setFixedTemporalRange(
+            QgsDateTimeRange(
+                QDateTime.fromString("2025-01-14T00:00:00Z", Qt.DateFormat.ISODate),
+                QDateTime.fromString("2025-01-14T00:00:00Z", Qt.DateFormat.ISODate),
+            )
+        )
+
         project = QgsProject()
 
         # Set a filename to avoid capabilities cache breaking test
         project.setFileName("test_get_capabilities_time_dimension")
 
-        project.addMapLayers([rl1, rl2, rl3, rl4], False)
+        project.addMapLayers([rl1, rl2, rl3, rl4, rl5], False)
 
+        project.writeEntry("WMSRestrictedLayers", "/", ["test_date_5"])
         groupWithTimeDim = project.layerTreeRoot().addGroup("GroupWithTimeDimension")
         groupWithTimeDim.setHasWmsTimeDimension(True)
         groupWithoutTimeDim = project.layerTreeRoot().addGroup(
@@ -3134,6 +3148,7 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         group.setHasWmsTimeDimension(True)
         group.addLayer(rl2)
         group.addLayer(rl4)
+        group.addLayer(rl5)
         groupWithTimeDim.addGroup("SubGroupWithoutTimeDimension").addLayer(rl3)
 
         groupWithoutTimeDim.addLayer(rl1)
@@ -3141,6 +3156,7 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         group.setHasWmsTimeDimension(True)
         group.addLayer(rl2)
         group.addLayer(rl4)
+        group.addLayer(rl5)
         groupWithoutTimeDim.addGroup("OtherSubGroupWithoutTimeDimension").addLayer(rl3)
 
         # Test group with Opaque Mode
@@ -3157,6 +3173,7 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         group.setWmsGroupRequestMode(Qgis.WmsGroupRequestMode.Opaque)
         group.addLayer(rl2)
         group.addLayer(rl4)
+        group.addLayer(rl5)
 
         def get_time_dim(layer_name):
             r, h = self._result(self._execute_request_project(qs, project))

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -3143,8 +3143,24 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         group.addLayer(rl4)
         groupWithoutTimeDim.addGroup("OtherSubGroupWithoutTimeDimension").addLayer(rl3)
 
+        # Test group with Opaque Mode
+
+        opaqueGroupWithTimeDim = project.layerTreeRoot().addGroup(
+            "OpaqueGroupWithTimeDimension"
+        )
+        opaqueGroupWithTimeDim.setHasWmsTimeDimension(True)
+        opaqueGroupWithTimeDim.setWmsGroupRequestMode(Qgis.WmsGroupRequestMode.Opaque)
+
+        opaqueGroupWithTimeDim.addLayer(rl1)
+        group = opaqueGroupWithTimeDim.addGroup("OpaqueSubGroupWithTimeDimension")
+        group.setHasWmsTimeDimension(True)
+        group.setWmsGroupRequestMode(Qgis.WmsGroupRequestMode.Opaque)
+        group.addLayer(rl2)
+        group.addLayer(rl4)
+
         def get_time_dim(layer_name):
             r, h = self._result(self._execute_request_project(qs, project))
+
             t = et.fromstring(r)
             ns = t.nsmap
             del ns[None]
@@ -3212,6 +3228,16 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
 
         date_dimension = get_time_dim("OtherSubGroupWithoutTimeDimension")
         self.assertEqual(date_dimension, None)
+
+        # Now test with Opaque mode, we should get exactly the same result than with Normal mode
+
+        # group with time dimension option
+        date_dimension = get_time_dim("OpaqueGroupWithTimeDimension")
+        self.assertEqual(date_dimension.attrib, {"units": "ISO8601", "name": "TIME"})
+        self.assertEqual(
+            date_dimension.text,
+            "2025-01-12T12:34:56Z/2025-01-15T09:12:34Z,2025-01-12T00:00:00Z",
+        )
 
     def test_get_map_labeling_opacities(self):
         """Test if OPACITIES is also applied to labels"""


### PR DESCRIPTION
## Description

We [stop recursion](https://github.com/qgis/QGIS/blob/a0dba80c9dd1130e8ffcc2a207e7a086ad83ebbd/src/server/services/wms/qgswmsgetcapabilities.cpp#L797) when we met an opaque group, so this PR propose to extract the children time dimension retrieval in its own function.

cc @signedav 

## AI tool usage

None

**Funded by Ressources Naturelles Canada**