### PR TITLE
Defer value relation cache until its filter can be evaluated

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -622,7 +622,7 @@ void QgsValueRelationWidgetWrapper::populate()
     // Only build the cache once the filter can actually be evaluated.
     // During QgsAttributeForm::init() (before setFeature() is called)
     // the form feature is not yet set, so the filter expression cannot be evaluated.
-    // Postpone building the cache until the form feature is set, which will trigger a call to populate() again.
+    // Not building the cache until the form feature is set, which will trigger a call to populate() again.
     if ( QgsValueRelationFieldFormatter::expressionIsUsable( mExpression, formFeature(), context().parentFormFeature() ) )
     {
       if ( context().parentFormFeature().isValid() )

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -619,16 +619,23 @@ void QgsValueRelationWidgetWrapper::populate()
   // Initialize, note that signals are blocked, to avoid double signals on new features
   if ( QgsValueRelationFieldFormatter::expressionRequiresFormScope( mExpression ) || QgsValueRelationFieldFormatter::expressionRequiresParentFormScope( mExpression ) )
   {
-    if ( context().parentFormFeature().isValid() )
+    // Only build the cache once the filter can actually be evaluated.
+    // During QgsAttributeForm::init() (before setFeature() is called)
+    // the form feature is not yet set, so the filter expression cannot be evaluated.
+    // Postpone building the cache until the form feature is set, which will trigger a call to populate() again.
+    if ( QgsValueRelationFieldFormatter::expressionIsUsable( mExpression, formFeature(), context().parentFormFeature() ) )
     {
-      mCache = QgsValueRelationFieldFormatter::createCache( config(), formFeature(), context().parentFormFeature() );
-    }
-    else
-    {
-      mCache = QgsValueRelationFieldFormatter::createCache( config(), formFeature() );
+      if ( context().parentFormFeature().isValid() )
+      {
+        mCache = QgsValueRelationFieldFormatter::createCache( config(), formFeature(), context().parentFormFeature() );
+      }
+      else
+      {
+        mCache = QgsValueRelationFieldFormatter::createCache( config(), formFeature() );
+      }
     }
   }
-  else if ( mCache.empty() )
+  else if ( mCache.isEmpty() )
   {
     mCache = QgsValueRelationFieldFormatter::createCache( config() );
   }

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -169,9 +169,8 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
 
 void TestQgsValueRelationWidgetWrapper::testUnEvaluableFilterDoesNotFetchWholeTable()
 {
-  // A filter using current_value() cannot be evaluated until the form feature is set. The
-  // related table must not be fetched unfiltered in the meantime: that request returns the
-  // values the filter exists to exclude, and it reads the whole table to do so.
+  // A filter using current_value() cannot be evaluated until the form feature is set. To avoid
+  // fetching the entire table of unneeded data, the related table is not loaded beforehand.
   QgsVectorLayer vl1( u"Polygon?crs=epsg:4326&field=pk:int&field=province:int&field=municipality:string"_s, u"vl1"_s, u"memory"_s );
   QgsVectorLayer vl2( u"Point?crs=epsg:4326&field=pk:int&field=fk_province:int&field=fk_municipality:int"_s, u"vl2"_s, u"memory"_s );
   QgsProject::instance()->addMapLayer( &vl1, false, false );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -52,6 +52,7 @@ class TestQgsValueRelationWidgetWrapper : public QObject
     void cleanup();         // will be called after every testfunction.
 
     void testScrollBarUnlocked();
+    void testUnEvaluableFilterDoesNotFetchWholeTable();
     void testDrillDown();
     void testDrillDownMulti();
     //! Checks that a related value of 0 is not interpreted as a NULL
@@ -166,6 +167,59 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
   QCOMPARE( itemEnabled, true );
 }
 
+void TestQgsValueRelationWidgetWrapper::testUnEvaluableFilterDoesNotFetchWholeTable()
+{
+  // A filter using current_value() cannot be evaluated until the form feature is set. The
+  // related table must not be fetched unfiltered in the meantime: that request returns the
+  // values the filter exists to exclude, and it reads the whole table to do so.
+  QgsVectorLayer vl1( u"Polygon?crs=epsg:4326&field=pk:int&field=province:int&field=municipality:string"_s, u"vl1"_s, u"memory"_s );
+  QgsVectorLayer vl2( u"Point?crs=epsg:4326&field=pk:int&field=fk_province:int&field=fk_municipality:int"_s, u"vl2"_s, u"memory"_s );
+  QgsProject::instance()->addMapLayer( &vl1, false, false );
+  QgsProject::instance()->addMapLayer( &vl2, false, false );
+
+  QgsFeature f1( vl1.fields() );
+  f1.setAttribute( u"pk"_s, 1 );
+  f1.setAttribute( u"province"_s, 123 );
+  f1.setAttribute( u"municipality"_s, u"Some Place By The River"_s );
+  QgsFeature f2( vl1.fields() );
+  f2.setAttribute( u"pk"_s, 2 );
+  f2.setAttribute( u"province"_s, 245 );
+  f2.setAttribute( u"municipality"_s, u"Dreamland By The Clouds"_s );
+  QVERIFY( vl1.dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 ) );
+
+  QgsFeature f3( vl2.fields() );
+  f3.setAttribute( u"pk"_s, 1 );
+  f3.setAttribute( u"fk_province"_s, 123 );
+  QVERIFY( vl2.dataProvider()->addFeature( f3 ) );
+
+  QgsValueRelationWidgetWrapper w( &vl2, vl2.fields().indexOf( "fk_municipality"_L1 ), nullptr, nullptr );
+  QVariantMap cfg;
+  cfg.insert( u"Layer"_s, vl1.id() );
+  cfg.insert( u"Key"_s, u"pk"_s );
+  cfg.insert( u"Value"_s, u"municipality"_s );
+  cfg.insert( u"AllowMulti"_s, false );
+  cfg.insert( u"NofColumns"_s, 1 );
+  cfg.insert( u"AllowNull"_s, false );
+  cfg.insert( u"OrderByValue"_s, true );
+  cfg.insert( u"FilterExpression"_s, u"\"province\" = current_value('fk_province')"_s );
+  cfg.insert( u"UseCompleter"_s, false );
+  w.setConfig( cfg );
+  w.widget();
+
+  // no form feature yet, so the filter is not evaluable and nothing is fetched
+  QCOMPARE( w.mCache.size(), 0 );
+  QCOMPARE( w.mComboBox->count(), 0 );
+
+  // once the feature is known the filter applies and only the matching value is fetched
+  w.setFeature( f3 );
+  QCOMPARE( w.mCache.size(), 1 );
+  QCOMPARE( w.mComboBox->count(), 1 );
+  QCOMPARE( w.mComboBox->itemText( 0 ), u"Some Place By The River"_s );
+
+  QgsProject::instance()->removeMapLayer( &vl2 );
+  QgsProject::instance()->removeMapLayer( &vl1 );
+}
+
 void TestQgsValueRelationWidgetWrapper::testDrillDown()
 {
   // create a vector layer
@@ -213,8 +267,9 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   w_municipality.widget();
   w_municipality.setEnabled( true );
 
-  QCOMPARE( w_municipality.mCache.size(), 2 );
-  QCOMPARE( w_municipality.mComboBox->count(), 2 );
+  // the filter needs the form feature, so nothing is fetched yet
+  QCOMPARE( w_municipality.mCache.size(), 0 );
+  QCOMPARE( w_municipality.mComboBox->count(), 0 );
 
   // Set a feature
   w_municipality.setFeature( vl2.getFeature( 1 ) );
@@ -334,8 +389,9 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
   w_municipality.widget();
   w_municipality.setEnabled( true );
 
-  QCOMPARE( w_municipality.mCache.size(), 2 );
-  QCOMPARE( w_municipality.mTableWidget->rowCount(), 2 );
+  // the filter needs the form feature, so nothing is fetched yet
+  QCOMPARE( w_municipality.mCache.size(), 0 );
+  QCOMPARE( w_municipality.mTableWidget->rowCount(), 0 );
   w_municipality.setFeature( f3 );
   QCOMPARE( w_municipality.mCache.size(), 1 );
 

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -136,6 +136,9 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
   w.setConfig( cfg );
   w.widget();
 
+  // the filter uses current_value(), so it can only be evaluated once a form feature is set
+  w.setFeature( f3 );
+
   // when the widget wrapper is enabled, the container should be enabled
   // as well as items
   w.setEnabled( true );


### PR DESCRIPTION
## Description

Defer value relation cache until its filter can be evaluated.

If the expression filter requires the form scope and the feature to be set (if it uses `current_value` for instance), the cache is not built in the first run of populate (on init) but on the second one when the feature is available.

Before this, the filter was dropped and the entire table was read.

This was causing important slowness in a form opening.

Tests were modified to pass but this should not affect real word scenarios where the feature is always set.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
