### PR TITLE
Rename GRASS Location into GRASS Project

### DIFF
--- a/src/plugins/grass/modules/default.qgc
+++ b/src/plugins/grass/modules/default.qgc
@@ -4,18 +4,18 @@
 <modules>
 
 <section label="GRASS MODULES">
-    <section label="Create new GRASS location and transfer data into it">
-        <section label="Create new GRASS location from metadata file">
+    <section label="Create new GRASS project and transfer data into it">
+        <section label="Create new GRASS project from metadata file">
             <grass name="g.proj.wkt"/>
         </section>
-        <section label="Create new GRASS location from raster data">
+        <section label="Create new GRASS project from raster data">
             <grass name="r.in.gdal.qgis.loc"/>
             <grass name="r.in.gdal.qgis"/>
         </section>
-        <section label="Create new GRASS location from vector data">
+        <section label="Create new GRASS project from vector data">
             <grass name="v.in.ogr.qgis.loc"/>
         </section>
-        <section label="Print projection information from a georeferenced file and create a new location based on it">
+        <section label="Print projection information from a georeferenced file and create a new project based on it">
             <grass name="g.proj.geo.new"/>
             <grass name="g.proj.ascii.new"/>
             <grass name="g.proj.proj.new"/>
@@ -132,7 +132,7 @@
         <grass name="g.region.multiple.vector"/>
     </section>
     <section label="Projection management">
-        <section label="Print projection information of the current location">
+        <section label="Print projection information of the current project">
             <grass name="g.proj.print"/>
         </section>
         <section label="Print projection information from a georeferenced file">
@@ -169,7 +169,7 @@
                 <grass name="r.support"/>
                 <grass name="r.support.stats"/>
             </section>
-            <section label="Reproject raster from another Location">
+            <section label="Reproject raster from another Project">
                 <grass name="r.proj"/>
             </section>
         </section>
@@ -362,7 +362,7 @@
                 <grass name="v.extrude.fixed"/>
                 <grass name="v.extrude.attr"/>
             </section>
-            <section label="Transform or reproject vector from another Location">
+            <section label="Transform or reproject vector from another Project">
                 <grass name="v.transform"/>
                 <grass name="v.proj"/>
             </section>

--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -126,7 +126,7 @@ QgsGrassNewMapset::QgsGrassNewMapset( QgisInterface *iface, QgsGrassPlugin *plug
   mDirectoryWidget->setFilePath( gisdbase );
   databaseChanged();
 
-  // LOCATION
+  // PROJECT
   const thread_local QRegularExpression rx( "[A-Za-z0-9_.]+" );
   mLocationLineEdit->setValidator( new QRegularExpressionValidator( rx, mLocationLineEdit ) );
 
@@ -169,7 +169,7 @@ void QgsGrassNewMapset::databaseChanged()
   }
   else
   {
-    // Check if at least one writable location exists or database is writable
+    // Check if at least one writable project exists or database is writable
     bool locationExists = false;
     QDir dir( gisdbase() );
     for ( unsigned int i = 0; i < dir.count(); i++ )
@@ -195,7 +195,7 @@ void QgsGrassNewMapset::databaseChanged()
     }
     else
     {
-      setError( mDatabaseErrorLabel, tr( "No writable locations, the database is not writable!" ) );
+      setError( mDatabaseErrorLabel, tr( "No writable projects, the database is not writable!" ) );
     }
   }
 }
@@ -211,7 +211,7 @@ bool QgsGrassNewMapset::gisdbaseExists()
   return databaseInfo.exists();
 }
 
-/*************************** LOCATION *******************************/
+/*************************** PROJECT *******************************/
 void QgsGrassNewMapset::setLocationPage()
 {
   setLocations();
@@ -322,14 +322,14 @@ void QgsGrassNewMapset::checkLocation()
     if ( location.isEmpty() )
     {
       button( QWizard::NextButton )->setEnabled( false );
-      setError( mLocationErrorLabel, tr( "Enter location name!" ) );
+      setError( mLocationErrorLabel, tr( "Enter project name!" ) );
     }
     else
     {
       if ( QFile::exists( gisdbase() + "/" + location ) )
       {
         button( QWizard::NextButton )->setEnabled( false );
-        setError( mLocationErrorLabel, tr( "The location exists!" ) );
+        setError( mLocationErrorLabel, tr( "The project exists!" ) );
       }
     }
   }
@@ -604,7 +604,7 @@ void QgsGrassNewMapset::loadRegions()
   }
   if ( !file.open( QIODevice::ReadOnly ) )
   {
-    QgsGrass::warning( tr( "Cannot open locations file (%1)" ).arg( path ) );
+    QgsGrass::warning( tr( "Cannot open projects file (%1)" ).arg( path ) );
     return;
   }
 
@@ -614,7 +614,7 @@ void QgsGrassNewMapset::loadRegions()
 
   if ( !doc.setContent( &file, &err, &line, &column ) )
   {
-    QString errmsg = tr( "Cannot read locations file (%1):" ).arg( path ) + tr( "\n%1\nat line %2 column %3" ).arg( err ).arg( line ).arg( column );
+    QString errmsg = tr( "Cannot read projects file (%1):" ).arg( path ) + tr( "\n%1\nat line %2 column %3" ).arg( err ).arg( line ).arg( column );
     QgsDebugError( errmsg );
     QgsGrass::warning( errmsg );
     file.close();
@@ -1037,7 +1037,7 @@ void QgsGrassNewMapset::setFinishPage()
   {
     location = mLocationLineEdit->text();
   }
-  mLocationLabel->setText( tr( "Location" ) + " : " + location );
+  mLocationLabel->setText( tr( "Project" ) + " : " + location );
 
   mMapsetLabel->setText( tr( "Mapset" ) + " : " + mMapsetLineEdit->text() );
 }
@@ -1080,11 +1080,11 @@ void QgsGrassNewMapset::createMapset()
 
     if ( ret != 0 )
     {
-      QgsGrass::warning( tr( "Cannot create new location: %1" ).arg( error ) );
+      QgsGrass::warning( tr( "Cannot create new project: %1" ).arg( error ) );
       return;
     }
 
-    // Location created -> reset widgets
+    // Project created -> reset widgets
     setLocations();
     mSelectLocationRadioButton->setChecked( true );
     mLocationComboBox->setItemText( mLocationComboBox->currentIndex(), location );

--- a/src/plugins/grass/qgsgrassnewmapsetbase.ui
+++ b/src/plugins/grass/qgsgrassnewmapsetbase.ui
@@ -96,7 +96,7 @@
   </widget>
   <widget class="QWizardPage" name="WizardPage2">
    <property name="title">
-    <string>GRASS Location</string>
+    <string>GRASS Project</string>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
@@ -110,7 +110,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Select location</string>
+         <string>Select project</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -140,7 +140,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Create new location</string>
+         <string>Create new project</string>
         </property>
        </widget>
       </item>
@@ -162,7 +162,7 @@
        </sizepolicy>
       </property>
       <property name="text">
-       <string>Location Error</string>
+       <string>Project Error</string>
       </property>
      </widget>
     </item>
@@ -176,7 +176,7 @@
     <item>
      <widget class="QLabel" name="mLocationHelpLabel">
       <property name="text">
-       <string>The GRASS location is a collection of maps for a particular territory or project.</string>
+       <string>The GRASS project is a collection of maps for a particular territory or topic.</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -369,7 +369,7 @@
        </sizepolicy>
       </property>
       <property name="text">
-       <string>The GRASS region defines a workspace for raster modules. The default region is valid for one location. It is possible to set a different region in each mapset. It is possible to change the default location region later.</string>
+       <string>The GRASS region defines a workspace for raster modules. The default region is valid for one project. It is possible to set a different region in each mapset. It is possible to change the default project region later.</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -472,7 +472,7 @@
     <item>
      <widget class="QLabel" name="mMapsetHelpLabel">
       <property name="text">
-       <string>The GRASS mapset is a collection of maps used by one user. A user can read maps from all mapsets in the location but he can open for writing only his mapset (owned by user).</string>
+       <string>The GRASS mapset is a collection of maps used by one user. A user can read maps from all mapsets in the project but he can open for writing only his mapset (owned by user).</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -533,7 +533,7 @@
        </size>
       </property>
       <property name="text">
-       <string>Location</string>
+       <string>Project</string>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
Since [GRASS 8.4](https://grass.osgeo.org/news/2024_07_27_grass_gis_8_4_0_released/) Location is called Project. This PR mainly covers user facing strings. Settings, variables and methods might need renaming (for coherence).

## AI tool usage

 - No AI