### PR TITLE
[feature] Add checkboxes to quickly enable or disable a symbol layer

### DIFF
--- a/src/gui/symbology/qgssymbollayermodel.cpp
+++ b/src/gui/symbology/qgssymbollayermodel.cpp
@@ -259,9 +259,16 @@ Qt::ItemFlags QgsSymbolLayerModel::flags( const QModelIndex &index ) const
   if ( !index.isValid() )
     return Qt::ItemFlags();
 
-  return Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsSelectable | Qt::ItemFlag::ItemIsUserCheckable;
-}
+  Qt::ItemFlags f = Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsSelectable;
 
+  QgsSymbolLayerModelNode *node = index2node( index );
+  if ( node->isLayer() )
+  {
+    f |= Qt::ItemFlag::ItemIsUserCheckable;
+  }
+
+  return f;
+}
 
 QVariant QgsSymbolLayerModel::data( const QModelIndex &index, int role ) const
 {
@@ -290,7 +297,7 @@ bool QgsSymbolLayerModel::setData( const QModelIndex &index, const QVariant &val
       return false;
 
 
-    bool checked = static_cast< Qt::CheckState >( value.toInt() ) == Qt::Checked;
+    bool checked = value.value<Qt::CheckState>() == Qt::Checked;
     QgsSymbolLayer *symbolLayer = node->layer();
     symbolLayer->setEnabled( checked );
 

--- a/src/gui/symbology/qgssymbollayermodel.cpp
+++ b/src/gui/symbology/qgssymbollayermodel.cpp
@@ -302,7 +302,7 @@ bool QgsSymbolLayerModel::setData( const QModelIndex &index, const QVariant &val
     symbolLayer->setEnabled( checked );
 
     emit dataChanged( index, index, { Qt::CheckStateRole } );
-    updatePreview( node );
+    updatePreviewIcons( node );
     return true;
   }
   return QAbstractItemModel::setData( index, value, role );
@@ -557,17 +557,17 @@ void QgsSymbolLayerModel::changeLayer( QgsSymbolLayerModelNode *node, QgsSymbolL
     updateNode( newLayer->subSymbol(), node );
   }
 
-  updatePreview( node );
+  updatePreviewIcons( node );
 }
 
-void QgsSymbolLayerModel::updatePreview( QgsSymbolLayerModelNode *node )
+void QgsSymbolLayerModel::updatePreviewIcons( QgsSymbolLayerModelNode *node )
 {
   const QModelIndex index = node2index( node );
   emit dataChanged( index, index, QVector<int>() << Qt::DecorationRole );
 
   // Recursively update the parent's preview up to the root node.
   if ( QgsSymbolLayerModelNode *lParent = node->parent() )
-    updatePreview( lParent );
+    updatePreviewIcons( lParent );
 }
 
 
@@ -593,7 +593,7 @@ void QgsSymbolLayerModel::setScreen( QScreen *screen )
   {
     QgsSymbolLayerModelNode *node = stack.takeLast();
     node->setScreen( mScreen );
-    updatePreview( node );
+    updatePreviewIcons( node );
 
     for ( int i = 0; i < node->rowCount(); ++i )
     {

--- a/src/gui/symbology/qgssymbollayermodel.cpp
+++ b/src/gui/symbology/qgssymbollayermodel.cpp
@@ -148,6 +148,17 @@ QVariant QgsSymbolLayerModelNode::data( int role ) const
     font.setBold( true );
     return font;
   }
+  else if ( role == Qt::CheckStateRole && mIsLayer )
+  {
+    if ( mLayer->enabled() )
+    {
+      return Qt::CheckState::Checked;
+    }
+    else
+    {
+      return Qt::CheckState::Unchecked;
+    }
+  }
   return QVariant();
 }
 
@@ -243,6 +254,14 @@ QgsSymbolLayerModel::QgsSymbolLayerModel( QgsVectorLayer *vl, QObject *parent, Q
   , mScreen( screen )
 {}
 
+Qt::ItemFlags QgsSymbolLayerModel::flags( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return Qt::ItemFlags();
+
+  return Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsSelectable | Qt::ItemFlag::ItemIsUserCheckable;
+}
+
 
 QVariant QgsSymbolLayerModel::data( const QModelIndex &index, int role ) const
 {
@@ -255,6 +274,32 @@ QVariant QgsSymbolLayerModel::data( const QModelIndex &index, int role ) const
 
   return node->data( role );
 };
+
+bool QgsSymbolLayerModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( !index.isValid() )
+    return false;
+
+  QgsSymbolLayerModelNode *node = index2node( index );
+  if ( !node )
+    return false;
+
+  if ( role == Qt::CheckStateRole )
+  {
+    if ( !node->isLayer() )
+      return false;
+
+
+    bool checked = static_cast< Qt::CheckState >( value.toInt() ) == Qt::Checked;
+    QgsSymbolLayer *symbolLayer = node->layer();
+    symbolLayer->setEnabled( checked );
+
+    emit dataChanged( index, index, { Qt::CheckStateRole } );
+    updatePreview( node );
+    return true;
+  }
+  return QAbstractItemModel::setData( index, value, role );
+}
 
 int QgsSymbolLayerModel::rowCount( const QModelIndex &parent ) const
 {

--- a/src/gui/symbology/qgssymbollayermodel.h
+++ b/src/gui/symbology/qgssymbollayermodel.h
@@ -218,7 +218,7 @@ class GUI_EXPORT QgsSymbolLayerModel : public QAbstractItemModel
     /**
      * Updates the preview icon of the given \a node. And recursively updates the parents of the node.
      */
-    void updatePreview( QgsSymbolLayerModelNode *node );
+    void updatePreviewIcons( QgsSymbolLayerModelNode *node );
 
     /**
      * Sets the \a symbol associated with the model.

--- a/src/gui/symbology/qgssymbollayermodel.h
+++ b/src/gui/symbology/qgssymbollayermodel.h
@@ -177,7 +177,9 @@ class GUI_EXPORT QgsSymbolLayerModel : public QAbstractItemModel
      */
     QgsSymbolLayerModel( QgsVectorLayer *vl, QObject *parent SIP_TRANSFERTHIS = nullptr, QScreen *screen = nullptr );
 
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
     int columnCount( const QModelIndex & = QModelIndex() ) const override;
     QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -788,11 +788,14 @@ void QgsSymbolSelectorWidget::projectDataChanged()
   mBlockModified = false;
 }
 
-void QgsSymbolSelectorWidget::modelDataChanged()
+void QgsSymbolSelectorWidget::modelDataChanged( const QModelIndex &, const QModelIndex &, const QList<int> &roles )
 {
-  updatePreview();
-  emitSymbolModified();
-  layerChanged();
+  if ( roles.contains( Qt::CheckStateRole ) )
+  {
+    emitSymbolModified();
+    layerChanged();
+    updatePreview();
+  }
 }
 
 void QgsSymbolSelectorWidget::layersAboutToBeRemoved( const QList<QgsMapLayer *> &layers )

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -372,7 +372,7 @@ void QgsSymbolSelectorWidget::updateLayerPreview()
 
   QgsSymbolLayerModelNode *node = currentLayerNode();
   if ( node )
-    mSymbolLayersModel->updatePreview( node );
+    mSymbolLayersModel->updatePreviewIcons( node );
   // update also preview of the whole symbol
   updatePreview();
 }

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -178,6 +178,7 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
   btnDown->setIcon( QIcon( QgsApplication::iconPath( "mActionArrowDown.svg" ) ) );
 
   mSymbolLayersModel = new QgsSymbolLayerModel( mVectorLayer, layersTree, screen() );
+  connect( mSymbolLayersModel, &QAbstractItemModel::dataChanged, this, &QgsSymbolSelectorWidget::modelDataChanged );
 
   // Set the symbol
   layersTree->setModel( mSymbolLayersModel );
@@ -785,6 +786,13 @@ void QgsSymbolSelectorWidget::projectDataChanged()
   symbolChanged();
   updatePreview();
   mBlockModified = false;
+}
+
+void QgsSymbolSelectorWidget::modelDataChanged()
+{
+  updatePreview();
+  emitSymbolModified();
+  layerChanged();
 }
 
 void QgsSymbolSelectorWidget::layersAboutToBeRemoved( const QList<QgsMapLayer *> &layers )

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -218,6 +218,13 @@ class GUI_EXPORT QgsSymbolSelectorWidget : public QgsPanelWidget, private Ui::Qg
      */
     void projectDataChanged();
 
+
+    /**
+     * Called when the symbol layer model data has changed (e.g enable property). Updates
+     * the symbol preview, widget to take changes into account.
+     */
+    void modelDataChanged();
+
     /**
      * Called when layers are about to be removed from the project.
      */

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -223,7 +223,7 @@ class GUI_EXPORT QgsSymbolSelectorWidget : public QgsPanelWidget, private Ui::Qg
      * Called when the symbol layer model data has changed (e.g enable property). Updates
      * the symbol preview, widget to take changes into account.
      */
-    void modelDataChanged();
+    void modelDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles = QList<int>() );
 
     /**
      * Called when layers are about to be removed from the project.


### PR DESCRIPTION


## Description

Supersede #66914 

This PR adds checkbox next to the symbol layer to quickly enable or disable it, instead to have to scroll down to disable it 


https://github.com/user-attachments/assets/9a762596-bee7-43b9-998d-ae5652803d71


fix #33861

Funded by the [Switzerland QGIS user group](https://www.qgis.ch/fr/)

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
