### PR TITLE
Annotation rotation (part 3): rotation aware map tools

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsannotationitemeditoperation.py
+++ b/python/PyQt6/core/auto_additions/qgsannotationitemeditoperation.py
@@ -5,6 +5,7 @@ QgsAbstractAnnotationItemEditOperation.Type.DeleteNode.__doc__ = "Delete a node"
 QgsAbstractAnnotationItemEditOperation.Type.AddNode.__doc__ = "Add a node"
 QgsAbstractAnnotationItemEditOperation.Type.TranslateItem.__doc__ = "Translate (move) an item"
 QgsAbstractAnnotationItemEditOperation.Type.RotateItem.__doc__ = "Rotate an item \n.. versionadded:: 4.0"
+QgsAbstractAnnotationItemEditOperation.Type.SetItemBounds.__doc__ = "Set the bounds of an item \n.. versionadded:: 4.4"
 QgsAbstractAnnotationItemEditOperation.Type.__doc__ = """Operation type
 
 * ``MoveNode``: Move a node
@@ -14,6 +15,10 @@ QgsAbstractAnnotationItemEditOperation.Type.__doc__ = """Operation type
 * ``RotateItem``: Rotate an item
 
   .. versionadded:: 4.0
+
+* ``SetItemBounds``: Set the bounds of an item
+
+  .. versionadded:: 4.4
 
 
 """
@@ -46,6 +51,11 @@ except (NameError, AttributeError):
 try:
     QgsAnnotationItemEditOperationRotateItem.__overridden_methods__ = ['type']
     QgsAnnotationItemEditOperationRotateItem.__group__ = ['annotations']
+except (NameError, AttributeError):
+    pass
+try:
+    QgsAnnotationItemEditOperationSetItemBounds.__overridden_methods__ = ['type']
+    QgsAnnotationItemEditOperationSetItemBounds.__group__ = ['annotations']
 except (NameError, AttributeError):
     pass
 try:

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
@@ -74,6 +74,7 @@ Abstract base class for annotation item edit operations.
       AddNode,
       TranslateItem,
       RotateItem,
+      SetItemBounds,
     };
 
     QgsAbstractAnnotationItemEditOperation( const QString &itemId );
@@ -322,6 +323,37 @@ with the specified ``itemId`` and rotation ``angle`` (in degrees)
     double angle() const;
 %Docstring
 Returns the rotation angle value (in degrees clockwise).
+%End
+
+};
+
+
+class QgsAnnotationItemEditOperationSetItemBounds : QgsAbstractAnnotationItemEditOperation
+{
+%Docstring(signature="appended")
+Annotation item edit operation consisting of setting the bounds of an
+item.
+
+.. versionadded:: 4.4
+%End
+
+%TypeHeaderCode
+#include "qgsannotationitemeditoperation.h"
+%End
+  public:
+    QgsAnnotationItemEditOperationSetItemBounds( const QString &itemId, const QgsRectangle &bounds );
+%Docstring
+Constructor for QgsAnnotationItemEditOperationSetItemBounds, setting the
+item with the specified ``itemId`` to the given ``bounds`` (in the
+annotation layer's CRS).
+%End
+
+    virtual Type type() const;
+
+
+    QgsRectangle bounds() const;
+%Docstring
+Returns the new item bounds (in the annotation layer's CRS).
 %End
 
 };

--- a/src/core/annotations/qgsannotationitemeditoperation.cpp
+++ b/src/core/annotations/qgsannotationitemeditoperation.cpp
@@ -120,6 +120,21 @@ QgsAbstractAnnotationItemEditOperation::Type QgsAnnotationItemEditOperationRotat
 
 
 //
+// QgsAnnotationItemEditOperationSetItemBounds
+//
+
+QgsAnnotationItemEditOperationSetItemBounds::QgsAnnotationItemEditOperationSetItemBounds( const QString &itemId, const QgsRectangle &bounds )
+  : QgsAbstractAnnotationItemEditOperation( itemId )
+  , mBounds( bounds )
+{}
+
+QgsAbstractAnnotationItemEditOperation::Type QgsAnnotationItemEditOperationSetItemBounds::type() const
+{
+  return Type::SetItemBounds;
+}
+
+
+//
 // QgsAnnotationItemEditOperationAddNode
 //
 

--- a/src/core/annotations/qgsannotationitemeditoperation.h
+++ b/src/core/annotations/qgsannotationitemeditoperation.h
@@ -86,6 +86,7 @@ class CORE_EXPORT QgsAbstractAnnotationItemEditOperation
       AddNode,       //!< Add a node
       TranslateItem, //!< Translate (move) an item
       RotateItem,    //!< Rotate an item \since QGIS 4.0
+      SetItemBounds, //!< Set the bounds of an item \since QGIS 4.4
     };
 
     /**
@@ -313,6 +314,32 @@ class CORE_EXPORT QgsAnnotationItemEditOperationRotateItem : public QgsAbstractA
 
   private:
     double mAngle = 0;
+};
+
+
+/**
+ * \ingroup core
+ * \brief Annotation item edit operation consisting of setting the bounds of an item.
+ * \since QGIS 4.4
+ */
+class CORE_EXPORT QgsAnnotationItemEditOperationSetItemBounds : public QgsAbstractAnnotationItemEditOperation
+{
+  public:
+    /**
+     * Constructor for QgsAnnotationItemEditOperationSetItemBounds, setting the item with the specified \a itemId
+     * to the given \a bounds (in the annotation layer's CRS).
+     */
+    QgsAnnotationItemEditOperationSetItemBounds( const QString &itemId, const QgsRectangle &bounds );
+
+    Type type() const override;
+
+    /**
+     * Returns the new item bounds (in the annotation layer's CRS).
+     */
+    QgsRectangle bounds() const { return mBounds; }
+
+  private:
+    QgsRectangle mBounds;
 };
 
 

--- a/src/core/annotations/qgsannotationlineitem.cpp
+++ b/src/core/annotations/qgsannotationlineitem.cpp
@@ -142,6 +142,9 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationLineItem::applyEditV2( QgsA
       mCurve->transform( transform );
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
+      break;
   }
 
   return Qgis::AnnotationItemEditOperationResult::Invalid;
@@ -183,6 +186,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationLineItem::transient
       return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedCurve ) ) );
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;

--- a/src/core/annotations/qgsannotationlinetextitem.cpp
+++ b/src/core/annotations/qgsannotationlinetextitem.cpp
@@ -169,6 +169,9 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationLineTextItem::applyEditV2( 
       mCurve->transform( transform );
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
+      break;
   }
 
   return Qgis::AnnotationItemEditOperationResult::Invalid;
@@ -210,6 +213,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationLineTextItem::trans
       return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedCurve ) ) );
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;

--- a/src/core/annotations/qgsannotationmarkeritem.cpp
+++ b/src/core/annotations/qgsannotationmarkeritem.cpp
@@ -118,6 +118,7 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationMarkerItem::applyEditV2( Qg
       break;
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;
   }
@@ -142,6 +143,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationMarkerItem::transie
     }
 
     case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;

--- a/src/core/annotations/qgsannotationpointtextitem.cpp
+++ b/src/core/annotations/qgsannotationpointtextitem.cpp
@@ -277,6 +277,7 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationPointTextItem::applyEditV2(
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;
   }
@@ -301,6 +302,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationPointTextItem::tran
     }
 
     case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;

--- a/src/core/annotations/qgsannotationpolygonitem.cpp
+++ b/src/core/annotations/qgsannotationpolygonitem.cpp
@@ -170,6 +170,9 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationPolygonItem::applyEditV2( Q
       mPolygon->transform( transform );
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
+      break;
   }
 
   return Qgis::AnnotationItemEditOperationResult::Invalid;
@@ -211,6 +214,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationPolygonItem::transi
       return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedPolygon ) ) );
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;

--- a/src/core/annotations/qgsannotationrectitem.cpp
+++ b/src/core/annotations/qgsannotationrectitem.cpp
@@ -422,6 +422,12 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationRectItem::applyEditV2( QgsA
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
+    {
+      mBounds = qgis::down_cast< QgsAnnotationItemEditOperationSetItemBounds * >( operation )->bounds();
+      return Qgis::AnnotationItemEditOperationResult::Success;
+    }
+
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;
@@ -564,6 +570,12 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationRectItem::transient
         }
       }
       break;
+    }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::SetItemBounds:
+    {
+      const QgsRectangle newBounds = qgis::down_cast< QgsAnnotationItemEditOperationSetItemBounds * >( operation )->bounds();
+      return new QgsAnnotationItemEditOperationTransientResults( rotatedBoundsGeometry( newBounds, context.renderContext() ) );
     }
 
     case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
@@ -16,12 +16,16 @@
 
 #include "qgsmaptoolmodifyannotation.h"
 
+#include <cmath>
+
 #include "RTree.h"
 #include "qgsannotationitem.h"
 #include "qgsannotationitemeditoperation.h"
 #include "qgsannotationitemnode.h"
 #include "qgsannotationlayer.h"
+#include "qgsannotationrectitem.h"
 #include "qgsmapcanvas.h"
+#include "qgsmaptopixel.h"
 #include "qgsproject.h"
 #include "qgsrenderedannotationitemdetails.h"
 #include "qgsrendereditemdetails.h"
@@ -82,6 +86,58 @@ class QgsAnnotationItemNodesSpatialIndex : public RTree<int, float, 2, float>
     }
 };
 ///@endcond
+
+
+QgsRectangle QgsMapToolModifyAnnotation::reconstructRotatedResizeBounds( const QgsMapToPixel *mapToPixel, double angle, const QgsPointXY &fixedMapPoint, const QgsPointXY &cursorMapPoint )
+{
+  const QgsPointXY fixedPixel = mapToPixel->transform( fixedMapPoint );
+  const QgsPointXY cursorPixel = mapToPixel->transform( cursorMapPoint );
+
+  // Un-rotating the diagonal between the fixed and dragged corners
+  QTransform unrotate;
+  unrotate.rotate( -angle );
+  const QPointF diagonal = unrotate.map( QPointF( cursorPixel.x() - fixedPixel.x(), cursorPixel.y() - fixedPixel.y() ) );
+  const double widthPixels = std::fabs( diagonal.x() );
+  const double heightPixels = std::fabs( diagonal.y() );
+  const QPointF centerPixel( ( fixedPixel.x() + cursorPixel.x() ) / 2.0, ( fixedPixel.y() + cursorPixel.y() ) / 2.0 );
+
+  return QgsAnnotationRectItem::boundsFromPixelRect( mapToPixel, centerPixel, widthPixels, heightPixels );
+}
+
+QgsPointXY QgsMapToolModifyAnnotation::oppositeVertexMapPoint( const QList<QgsAnnotationItemNode> &nodes, int draggedVertex, bool &found )
+{
+  found = false;
+  const int fixedVertex = ( draggedVertex + 2 ) % 4;
+  for ( const QgsAnnotationItemNode &node : nodes )
+  {
+    if ( node.id().part == 0 && node.id().vertex == fixedVertex )
+    {
+      found = true;
+      return node.point();
+    }
+  }
+  return QgsPointXY();
+}
+
+std::optional<QgsRectangle> QgsMapToolModifyAnnotation::rotatedResizeLayerBounds( const QgsAnnotationRectItem *rectItem, QgsAnnotationLayer *layer, const QgsPointXY &cursorMapPoint )
+{
+  const int draggedVertex = mTargetNode.id().vertex;
+  const double angle = rectItem->appliedRotation( canvas()->mapSettings().rotation() );
+  if ( rectItem->placementMode() != Qgis::AnnotationPlacementMode::SpatialBounds || mTargetNode.id().part != 0 || draggedVertex < 0 || draggedVertex >= 4 || qgsDoubleNear( angle, 0 ) )
+    return std::nullopt;
+
+  bool foundFixed = false;
+  const QgsPointXY fixedMapPoint = oppositeVertexMapPoint( mHoveredItemNodes, draggedVertex, foundFixed );
+  if ( !foundFixed )
+    return std::nullopt;
+
+  const QgsRectangle newMapBounds = reconstructRotatedResizeBounds( canvas()->getCoordinateTransform(), angle, fixedMapPoint, cursorMapPoint );
+  const QgsRectangle newLayerBounds = toLayerCoordinates( layer, newMapBounds );
+  if ( qgsDoubleNear( newLayerBounds.width(), 0 ) || qgsDoubleNear( newLayerBounds.height(), 0 ) )
+    return std::nullopt;
+
+  return newLayerBounds;
+}
 
 
 QgsMapToolModifyAnnotation::QgsMapToolModifyAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
@@ -151,26 +207,44 @@ void QgsMapToolModifyAnnotation::cadCanvasMoveEvent( QgsMapMouseEvent *event )
     {
       if ( QgsAnnotationItem *item = annotationItemFromId( mSelectedItemLayerId, mSelectedItemId ) )
       {
-        const QgsPointXY endPointLayer = toLayerCoordinates( layer, event->mapPoint() );
-        QgsAnnotationItemEditOperationMoveNode operation(
-          mSelectedItemId,
-          mTargetNode.id(),
-          QgsPoint( mTargetNode.point() ),
-          QgsPoint( endPointLayer ),
-          event->pixelPoint().x() - mMoveStartPointPixels.x(),
-          event->pixelPoint().y() - mMoveStartPointPixels.y()
-        );
-        std::unique_ptr<QgsAnnotationItemEditOperationTransientResults> operationResults( item->transientEditResultsV2( &operation, context ) );
-        if ( operationResults )
+        bool previewDone = false;
+
+        if ( const QgsAnnotationRectItem *rectItem = dynamic_cast<const QgsAnnotationRectItem *>( item ) )
         {
-          mTemporaryRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, operationResults->representativeGeometry().type() );
-          const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
-          mTemporaryRubberBand->setWidth( scaleFactor );
-          mTemporaryRubberBand->setToGeometry( operationResults->representativeGeometry(), layer->crs() );
+          if ( const std::optional<QgsRectangle> newLayerBounds = rotatedResizeLayerBounds( rectItem, layer, event->mapPoint() ) )
+          {
+            const QgsGeometry preview = rectItem->rotatedBoundsGeometry( *newLayerBounds, context.renderContext() );
+            mTemporaryRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, preview.type() );
+            const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
+            mTemporaryRubberBand->setWidth( scaleFactor );
+            mTemporaryRubberBand->setToGeometry( preview, layer->crs() );
+            previewDone = true;
+          }
         }
-        else
+
+        if ( !previewDone )
         {
-          mTemporaryRubberBand.reset();
+          const QgsPointXY endPointLayer = toLayerCoordinates( layer, event->mapPoint() );
+          QgsAnnotationItemEditOperationMoveNode operation(
+            mSelectedItemId,
+            mTargetNode.id(),
+            QgsPoint( mTargetNode.point() ),
+            QgsPoint( endPointLayer ),
+            event->pixelPoint().x() - mMoveStartPointPixels.x(),
+            event->pixelPoint().y() - mMoveStartPointPixels.y()
+          );
+          std::unique_ptr<QgsAnnotationItemEditOperationTransientResults> operationResults( item->transientEditResultsV2( &operation, context ) );
+          if ( operationResults )
+          {
+            mTemporaryRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, operationResults->representativeGeometry().type() );
+            const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
+            mTemporaryRubberBand->setWidth( scaleFactor );
+            mTemporaryRubberBand->setToGeometry( operationResults->representativeGeometry(), layer->crs() );
+          }
+          else
+          {
+            mTemporaryRubberBand.reset();
+          }
         }
       }
       break;
@@ -314,25 +388,45 @@ void QgsMapToolModifyAnnotation::cadCanvasPressEvent( QgsMapMouseEvent *event )
       {
         if ( layer )
         {
-          const QgsPointXY endPointLayer = toLayerCoordinates( layer, event->mapPoint() );
-          QgsAnnotationItemEditOperationMoveNode operation(
-            mSelectedItemId,
-            mTargetNode.id(),
-            QgsPoint( mTargetNode.point() ),
-            QgsPoint( endPointLayer ),
-            event->pixelPoint().x() - mMoveStartPointPixels.x(),
-            event->pixelPoint().y() - mMoveStartPointPixels.y()
-          );
-          switch ( layer->applyEditV2( &operation, context ) )
-          {
-            case Qgis::AnnotationItemEditOperationResult::Success:
-              QgsProject::instance()->setDirty( true );
-              mRefreshSelectedItemAfterRedraw = true;
-              break;
+          bool handled = false;
 
-            case Qgis::AnnotationItemEditOperationResult::Invalid:
-            case Qgis::AnnotationItemEditOperationResult::ItemCleared:
-              break;
+          const QgsAnnotationItem *resizedItem = annotationItemFromId( mSelectedItemLayerId, mSelectedItemId );
+          if ( const QgsAnnotationRectItem *rectItem = dynamic_cast<const QgsAnnotationRectItem *>( resizedItem ) )
+          {
+            if ( const std::optional<QgsRectangle> newLayerBounds = rotatedResizeLayerBounds( rectItem, layer, event->mapPoint() ) )
+            {
+              QgsAnnotationItemEditOperationSetItemBounds operation( mSelectedItemId, *newLayerBounds );
+              if ( layer->applyEditV2( &operation, context ) == Qgis::AnnotationItemEditOperationResult::Success )
+              {
+                handled = true;
+                QgsProject::instance()->setDirty( true );
+                mRefreshSelectedItemAfterRedraw = true;
+              }
+            }
+          }
+
+          if ( !handled )
+          {
+            const QgsPointXY endPointLayer = toLayerCoordinates( layer, event->mapPoint() );
+            QgsAnnotationItemEditOperationMoveNode operation(
+              mSelectedItemId,
+              mTargetNode.id(),
+              QgsPoint( mTargetNode.point() ),
+              QgsPoint( endPointLayer ),
+              event->pixelPoint().x() - mMoveStartPointPixels.x(),
+              event->pixelPoint().y() - mMoveStartPointPixels.y()
+            );
+            switch ( layer->applyEditV2( &operation, context ) )
+            {
+              case Qgis::AnnotationItemEditOperationResult::Success:
+                QgsProject::instance()->setDirty( true );
+                mRefreshSelectedItemAfterRedraw = true;
+                break;
+
+              case Qgis::AnnotationItemEditOperationResult::Invalid:
+              case Qgis::AnnotationItemEditOperationResult::ItemCleared:
+                break;
+            }
           }
         }
 
@@ -569,19 +663,54 @@ void QgsMapToolModifyAnnotation::setHoveredItem( const QgsRenderedAnnotationItem
 
   mHoverRubberBand->show();
 
-  mHoverRubberBand->reset( Qgis::GeometryType::Line );
-  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMinimum() ) );
-  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMaximum(), itemMapBounds.yMinimum() ) );
-  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMaximum(), itemMapBounds.yMaximum() ) );
-  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMaximum() ) );
-  mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMinimum() ) );
-
-  QgsAnnotationLayer *layer = annotationLayerFromId( item->layerId() );
   const QgsAnnotationItem *annotationItem = annotationItemFromId( item->layerId(), item->itemId() );
-  if ( !annotationItem )
+  QgsAnnotationLayer *layer = annotationLayerFromId( item->layerId() );
+  if ( !annotationItem || !layer )
+  {
+    // fall back to a plain axis-aligned hover rectangle
+    mHoverRubberBand->reset( Qgis::GeometryType::Line );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMinimum() ) );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMaximum(), itemMapBounds.yMinimum() ) );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMaximum(), itemMapBounds.yMaximum() ) );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMaximum() ) );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMinimum() ) );
     return;
+  }
 
-  QgsCoordinateTransform layerToMapTransform = QgsCoordinateTransform( layer->crs(), canvas()->mapSettings().destinationCrs(), canvas()->mapSettings().transformContext() );
+  const QgsCoordinateTransform layerToMapTransform = QgsCoordinateTransform( layer->crs(), canvas()->mapSettings().destinationCrs(), canvas()->mapSettings().transformContext() );
+
+  // Rotate corners around the center in pixel space. Node points already went
+  // through mapToPixel (which includes map rotation), so only the item's own
+  // rotation is added here. The callout anchor is fixed and never rotated.
+  const QgsAnnotationRectItem *rectItem = dynamic_cast<const QgsAnnotationRectItem *>( annotationItem );
+  const double mapRotation = canvas()->mapSettings().rotation();
+  const double frameRotation = rectItem ? rectItem->appliedRotation( mapRotation ) - mapRotation : 0;
+  const QgsMapToPixel *mapToPixel = canvas()->getCoordinateTransform();
+  const bool rotated = rectItem && !qgsDoubleNear( frameRotation, 0 );
+
+  QTransform rotationTransform;
+  if ( rotated )
+  {
+    QgsPointXY centerMap = itemMapBounds.center();
+    try
+    {
+      centerMap = layerToMapTransform.transform( rectItem->bounds().center() );
+    }
+    catch ( QgsCsException & )
+    {}
+    const QgsPointXY centerPixel = mapToPixel->transform( centerMap );
+    rotationTransform.translate( centerPixel.x(), centerPixel.y() );
+    rotationTransform.rotate( frameRotation );
+    rotationTransform.translate( -centerPixel.x(), -centerPixel.y() );
+  }
+
+  auto rotateMapPoint = [&]( const QgsPointXY &p ) -> QgsPointXY {
+    if ( !rotated )
+      return p;
+    const QgsPointXY pPixel = mapToPixel->transform( p );
+    const QPointF r = rotationTransform.map( QPointF( pPixel.x(), pPixel.y() ) );
+    return mapToPixel->toMapCoordinates( r.x(), r.y() );
+  };
 
   const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
 
@@ -609,6 +738,7 @@ void QgsMapToolModifyAnnotation::setHoveredItem( const QgsRenderedAnnotationItem
   int index = 0;
   mHoveredItemNodes.clear();
   mHoveredItemNodes.reserve( itemNodes.size() );
+  QVector<QgsPointXY> vertexFramePoints;
   for ( const QgsAnnotationItemNode &node : itemNodes )
   {
     QgsPointXY nodeMapPoint;
@@ -624,7 +754,10 @@ void QgsMapToolModifyAnnotation::setHoveredItem( const QgsRenderedAnnotationItem
     switch ( node.type() )
     {
       case Qgis::AnnotationItemNodeType::VertexHandle:
+        // vertex handles rotate together with the item body
+        nodeMapPoint = rotateMapPoint( nodeMapPoint );
         vertexNodeBand->addPoint( nodeMapPoint );
+        vertexFramePoints.append( nodeMapPoint );
         break;
 
       case Qgis::AnnotationItemNodeType::CalloutHandle:
@@ -643,6 +776,24 @@ void QgsMapToolModifyAnnotation::setHoveredItem( const QgsRenderedAnnotationItem
 
   mHoveredItemNodeRubberBands.emplace_back( vertexNodeBand );
   mHoveredItemNodeRubberBands.emplace_back( calloutNodeBand );
+
+  // Draw the hover frame. For spatial-bounds rectangles it follows the four
+  // (rotated) corner handles; other modes use the axis-aligned bounds.
+  mHoverRubberBand->reset( Qgis::GeometryType::Line );
+  if ( rectItem && rectItem->placementMode() == Qgis::AnnotationPlacementMode::SpatialBounds && vertexFramePoints.size() == 4 )
+  {
+    for ( const QgsPointXY &framePoint : vertexFramePoints )
+      mHoverRubberBand->addPoint( framePoint );
+    mHoverRubberBand->addPoint( vertexFramePoints.constFirst() );
+  }
+  else
+  {
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMinimum() ) );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMaximum(), itemMapBounds.yMinimum() ) );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMaximum(), itemMapBounds.yMaximum() ) );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMaximum() ) );
+    mHoverRubberBand->addPoint( QgsPointXY( itemMapBounds.xMinimum(), itemMapBounds.yMinimum() ) );
+  }
 }
 
 QSizeF QgsMapToolModifyAnnotation::deltaForKeyEvent( QgsAnnotationLayer *layer, const QgsPointXY &originalCanvasPoint, QKeyEvent *event )

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
@@ -24,6 +24,7 @@
 #include "qgsannotationitemnode.h"
 #include "qgsannotationlayer.h"
 #include "qgsannotationrectitem.h"
+#include "qgslogger.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaptopixel.h"
 #include "qgsproject.h"
@@ -34,10 +35,13 @@
 #include "qgssnapindicator.h"
 
 #include <QScreen>
+#include <QString>
 #include <QTransform>
 #include <QWindow>
 
 #include "moc_qgsmaptoolmodifyannotation.cpp"
+
+using namespace Qt::StringLiterals;
 
 ///@cond PRIVATE
 class QgsAnnotationItemNodesSpatialIndex : public RTree<int, float, 2, float>
@@ -664,8 +668,7 @@ void QgsMapToolModifyAnnotation::setHoveredItem( const QgsRenderedAnnotationItem
   mHoverRubberBand->show();
 
   const QgsAnnotationItem *annotationItem = annotationItemFromId( item->layerId(), item->itemId() );
-  QgsAnnotationLayer *layer = annotationLayerFromId( item->layerId() );
-  if ( !annotationItem || !layer )
+  if ( !annotationItem )
   {
     // fall back to a plain axis-aligned hover rectangle
     mHoverRubberBand->reset( Qgis::GeometryType::Line );
@@ -677,6 +680,7 @@ void QgsMapToolModifyAnnotation::setHoveredItem( const QgsRenderedAnnotationItem
     return;
   }
 
+  QgsAnnotationLayer *layer = annotationLayerFromId( item->layerId() );
   const QgsCoordinateTransform layerToMapTransform = QgsCoordinateTransform( layer->crs(), canvas()->mapSettings().destinationCrs(), canvas()->mapSettings().transformContext() );
 
   // Rotate corners around the center in pixel space. Node points already went
@@ -686,18 +690,26 @@ void QgsMapToolModifyAnnotation::setHoveredItem( const QgsRenderedAnnotationItem
   const double mapRotation = canvas()->mapSettings().rotation();
   const double frameRotation = rectItem ? rectItem->appliedRotation( mapRotation ) - mapRotation : 0;
   const QgsMapToPixel *mapToPixel = canvas()->getCoordinateTransform();
-  const bool rotated = rectItem && !qgsDoubleNear( frameRotation, 0 );
+  bool rotated = rectItem && !qgsDoubleNear( frameRotation, 0 );
 
-  QTransform rotationTransform;
+  QgsPointXY centerMap;
   if ( rotated )
   {
-    QgsPointXY centerMap = itemMapBounds.center();
     try
     {
       centerMap = layerToMapTransform.transform( rectItem->bounds().center() );
     }
     catch ( QgsCsException & )
-    {}
+    {
+      // no reliable pivot, so fall back to an unrotated band
+      QgsDebugError( u"Error transforming annotation item center"_s );
+      rotated = false;
+    }
+  }
+
+  QTransform rotationTransform;
+  if ( rotated )
+  {
     const QgsPointXY centerPixel = mapToPixel->transform( centerMap );
     rotationTransform.translate( centerPixel.x(), centerPixel.y() );
     rotationTransform.rotate( frameRotation );

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.h
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.h
@@ -17,6 +17,8 @@
 #ifndef QGSMAPTOOLMODIFYANNOTATION_H
 #define QGSMAPTOOLMODIFYANNOTATION_H
 
+#include <optional>
+
 #include "qgis_gui.h"
 #include "qgis_sip.h"
 #include "qgsannotationitemnode.h"
@@ -31,8 +33,10 @@ class QgsRubberBand;
 class QgsRenderedAnnotationItemDetails;
 class QgsAnnotationItem;
 class QgsAnnotationLayer;
+class QgsAnnotationRectItem;
 class QgsAnnotationItemNodesSpatialIndex;
 class QgsSnapIndicator;
+class QgsMapToPixel;
 
 
 /**
@@ -95,6 +99,27 @@ class GUI_EXPORT QgsMapToolModifyAnnotation : public QgsAnnotationMapTool
      * for the given key \a event.
      */
     QSizeF deltaForKeyEvent( QgsAnnotationLayer *layer, const QgsPointXY &originalCanvasPoint, QKeyEvent *event );
+
+    /**
+     * Reconstructs the new (unrotated) bounds, in map coordinates, for a rotated rectangle whose
+     * corner is being dragged. The diagonally-opposite corner (at \a fixedMapPoint) stays anchored
+     * on screen while the dragged corner follows \a cursorMapPoint. \a angle is the applied rotation
+     * in degrees clockwise on screen.
+     */
+    static QgsRectangle reconstructRotatedResizeBounds( const QgsMapToPixel *mapToPixel, double angle, const QgsPointXY &fixedMapPoint, const QgsPointXY &cursorMapPoint );
+
+    /**
+     * Returns the current on-screen (rotated) map position of the vertex diagonally opposite to
+     * \a draggedVertex, searching \a nodes. Sets \a found accordingly.
+     */
+    static QgsPointXY oppositeVertexMapPoint( const QList<QgsAnnotationItemNode> &nodes, int draggedVertex, bool &found );
+
+    /**
+     * Returns the new bounds, in \a layer coordinates, for the rotated \a rectItem whose corner
+     * is currently being dragged towards \a cursorMapPoint, or nothing if the current node drag is
+     * not a rotated resize.
+     */
+    std::optional<QgsRectangle> rotatedResizeLayerBounds( const QgsAnnotationRectItem *rectItem, QgsAnnotationLayer *layer, const QgsPointXY &cursorMapPoint );
 
     Action mCurrentAction = Action::NoAction;
 

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -16,14 +16,22 @@
 
 #include "qgsmaptoolselectannotation.h"
 
+#include <algorithm>
+#include <limits>
+
 #include "qgsannotationitem.h"
 #include "qgsannotationitemeditoperation.h"
 #include "qgsannotationitemnode.h"
 #include "qgsannotationlayer.h"
+#include "qgsannotationrectitem.h"
 #include "qgsapplication.h"
+#include "qgscoordinatetransform.h"
+#include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaptoolselectannotationmousehandles.h"
+#include "qgsmaptopixel.h"
 #include "qgsproject.h"
+#include "qgsrendercontext.h"
 #include "qgsrenderedannotationitemdetails.h"
 #include "qgsrendereditemdetails.h"
 #include "qgsrendereditemresults.h"
@@ -75,11 +83,83 @@ void QgsAnnotationItemRubberBand::updateBoundingBox( const QgsRectangle &boundin
   mNeedsUpdatedBoundingBox = annotationItem && ( annotationItem->flags() & Qgis::AnnotationItemFlag::ScaleDependentBoundingBox );
 
   reset( Qgis::GeometryType::Line );
-  addPoint( QgsPointXY( boundingBox.xMinimum(), boundingBox.yMinimum() ) );
-  addPoint( QgsPointXY( boundingBox.xMaximum(), boundingBox.yMinimum() ) );
-  addPoint( QgsPointXY( boundingBox.xMaximum(), boundingBox.yMaximum() ) );
-  addPoint( QgsPointXY( boundingBox.xMinimum(), boundingBox.yMaximum() ) );
-  addPoint( QgsPointXY( boundingBox.xMinimum(), boundingBox.yMinimum() ) );
+
+  const QgsMapToPixel *transform = mMapCanvas->getCoordinateTransform();
+
+  const QgsAnnotationRectItem *rectItem = dynamic_cast< const QgsAnnotationRectItem * >( annotationItem );
+  const double mapRotation = mMapCanvas->mapSettings().rotation();
+  const double frameRotation = rectItem ? rectItem->appliedRotation( mapRotation ) - mapRotation : 0;
+
+  if ( rectItem && !qgsDoubleNear( frameRotation, 0 ) )
+  {
+    double minX = std::numeric_limits<double>::max();
+    double minY = std::numeric_limits<double>::max();
+    double maxX = std::numeric_limits<double>::lowest();
+    double maxY = std::numeric_limits<double>::lowest();
+    auto includePixel = [&]( const QPointF &p ) {
+      minX = std::min( minX, p.x() );
+      minY = std::min( minY, p.y() );
+      maxX = std::max( maxX, p.x() );
+      maxY = std::max( maxY, p.y() );
+    };
+
+    // rotated item corners, as drawn on screen
+    if ( QgsAnnotationLayer *lyr = layer() )
+    {
+      const QgsCoordinateTransform layerToMap( lyr->crs(), mMapCanvas->mapSettings().destinationCrs(), mMapCanvas->mapSettings().transformContext() );
+      const QgsRenderContext renderContext = QgsRenderContext::fromMapSettings( mMapCanvas->mapSettings() );
+      const QPolygonF corners = rectItem->rotatedBoundsGeometry( rectItem->bounds(), renderContext ).asQPolygonF();
+      for ( const QPointF &corner : corners )
+      {
+        QgsPointXY mapPoint( corner.x(), corner.y() );
+        try
+        {
+          mapPoint = layerToMap.transform( mapPoint );
+        }
+        catch ( QgsCsException & )
+        {}
+        includePixel( toCanvasCoordinates( mapPoint ) );
+      }
+    }
+
+    // callout anchor and everything else reported by the incoming bounding box
+    const QgsPointXY bboxCorners[4] = {
+      QgsPointXY( boundingBox.xMinimum(), boundingBox.yMinimum() ),
+      QgsPointXY( boundingBox.xMaximum(), boundingBox.yMinimum() ),
+      QgsPointXY( boundingBox.xMaximum(), boundingBox.yMaximum() ),
+      QgsPointXY( boundingBox.xMinimum(), boundingBox.yMaximum() ),
+    };
+    for ( const QgsPointXY &corner : bboxCorners )
+      includePixel( toCanvasCoordinates( corner ) );
+
+    const QgsPointXY topLeft = transform->toMapCoordinates( minX, minY );
+    const QgsPointXY topRight = transform->toMapCoordinates( maxX, minY );
+    const QgsPointXY bottomRight = transform->toMapCoordinates( maxX, maxY );
+    const QgsPointXY bottomLeft = transform->toMapCoordinates( minX, maxY );
+    addPoint( topLeft );
+    addPoint( topRight );
+    addPoint( bottomRight );
+    addPoint( bottomLeft );
+    addPoint( topLeft );
+  }
+  else
+  {
+    // Build the rubber band as a screen-aligned rectangle matching the item's
+    // on-screen size.
+    const QPointF centerCanvas = toCanvasCoordinates( boundingBox.center() );
+    const double mupp = mMapCanvas->mapSettings().mapUnitsPerPixel();
+    const double halfWidth = 0.5 * boundingBox.width() / mupp;
+    const double halfHeight = 0.5 * boundingBox.height() / mupp;
+    const QgsPointXY topLeft = transform->toMapCoordinates( centerCanvas.x() - halfWidth, centerCanvas.y() - halfHeight );
+    const QgsPointXY topRight = transform->toMapCoordinates( centerCanvas.x() + halfWidth, centerCanvas.y() - halfHeight );
+    const QgsPointXY bottomRight = transform->toMapCoordinates( centerCanvas.x() + halfWidth, centerCanvas.y() + halfHeight );
+    const QgsPointXY bottomLeft = transform->toMapCoordinates( centerCanvas.x() - halfWidth, centerCanvas.y() + halfHeight );
+    addPoint( topLeft );
+    addPoint( topRight );
+    addPoint( bottomRight );
+    addPoint( bottomLeft );
+    addPoint( topLeft );
+  }
 
   show();
   setSelected( true );
@@ -95,6 +175,11 @@ QgsMapToolSelectAnnotation::QgsMapToolSelectAnnotation( QgsMapCanvas *canvas, Qg
   : QgsAnnotationMapTool( canvas, cadDockWidget )
 {
   connect( QgsMapToolSelectAnnotation::canvas(), &QgsMapCanvas::mapCanvasRefreshed, this, &QgsMapToolSelectAnnotation::onCanvasRefreshed );
+
+  connect( QgsMapToolSelectAnnotation::canvas(), &QgsMapCanvas::rotationChanged, this, [this] {
+    for ( std::unique_ptr<QgsAnnotationItemRubberBand> &selectedItem : mSelectedItems )
+      selectedItem->updateBoundingBox( selectedItem->boundingBox() );
+  } );
 
   setAdvancedDigitizingAllowed( false );
 }
@@ -415,29 +500,30 @@ void QgsMapToolSelectAnnotation::onCanvasRefreshed()
     return;
   }
 
+  const bool interactiveOperation = mMouseHandles && ( mMouseHandles->isDragging() || mMouseHandles->isResizing() || mMouseHandles->isRotating() );
+
   const QList<QgsRenderedItemDetails *> items = renderedItemResults->renderedItems();
   bool needsSelectedItemsUpdate = false;
   for ( std::unique_ptr<QgsAnnotationItemRubberBand> &selectedItem : mSelectedItems )
   {
-    if ( selectedItem->needsUpdatedBoundingBox() )
+    if ( interactiveOperation && !selectedItem->needsUpdatedBoundingBox() )
+      continue;
+
+    auto it = std::find_if( items.begin(), items.end(), [&selectedItem]( const QgsRenderedItemDetails *item ) {
+      if ( const QgsRenderedAnnotationItemDetails *annotationItem = dynamic_cast<const QgsRenderedAnnotationItemDetails *>( item ) )
+      {
+        if ( annotationItem->itemId() == selectedItem->itemId() && annotationItem->layerId() == selectedItem->layerId() )
+        {
+          return true;
+        }
+      }
+      return false;
+    } );
+
+    if ( it != items.end() )
     {
       needsSelectedItemsUpdate = true;
-
-      auto it = std::find_if( items.begin(), items.end(), [&selectedItem]( const QgsRenderedItemDetails *item ) {
-        if ( const QgsRenderedAnnotationItemDetails *annotationItem = dynamic_cast<const QgsRenderedAnnotationItemDetails *>( item ) )
-        {
-          if ( annotationItem->itemId() == selectedItem->itemId() && annotationItem->layerId() == selectedItem->layerId() )
-          {
-            return true;
-          }
-        }
-        return false;
-      } );
-
-      if ( it != items.end() )
-      {
-        selectedItem->updateBoundingBox( ( *it )->boundingBox() );
-      }
+      selectedItem->updateBoundingBox( ( *it )->boundingBox() );
     }
   }
 
@@ -594,8 +680,11 @@ void QgsMapToolSelectAnnotation::attemptMoveBy( QgsAnnotationItemRubberBand *ann
   if ( QgsAnnotationItem *annotationItem = annotationItemRubberBand->item() )
   {
     QgsRectangle boundingBox = annotationItemRubberBand->boundingBox();
-    const double mupp = mCanvas->mapSettings().mapUnitsPerPixel();
-    QgsVector translation( deltaX * mupp, -deltaY * mupp );
+    // take map rotation into account in translation
+    const QgsMapToPixel *transform = mCanvas->getCoordinateTransform();
+    const QgsPointXY mapOrigin = transform->toMapCoordinates( 0.0, 0.0 );
+    const QgsPointXY mapMoved = transform->toMapCoordinates( deltaX, deltaY );
+    const QgsVector translation( mapMoved.x() - mapOrigin.x(), mapMoved.y() - mapOrigin.y() );
     QgsAnnotationLayer *annotationLayer = annotationItemRubberBand->layer();
 
     QgsAnnotationItemEditContext context;
@@ -653,41 +742,66 @@ void QgsMapToolSelectAnnotation::attemptRotateBy( QgsAnnotationItemRubberBand *a
 
 void QgsMapToolSelectAnnotation::attemptSetSceneRect( QgsAnnotationItemRubberBand *annotationItemRubberBand, const QRectF &rect )
 {
-  if ( QgsAnnotationItem *annotationItem = annotationItemRubberBand->item() )
+  QgsAnnotationItem *annotationItem = annotationItemRubberBand->item();
+  if ( !annotationItem )
+    return;
+
+  QgsAnnotationLayer *annotationLayer = annotationItemRubberBand->layer();
+  if ( !annotationLayer )
+    return;
+
+  // on-screen rotation = the item's own rotation plus the map rotation when
+  // the item follows it.
+  double rotation = 0;
+  if ( const QgsAnnotationRectItem *rectItem = dynamic_cast<const QgsAnnotationRectItem *>( annotationItem ) )
   {
-    const double widthRatio = rect.width() / annotationItemRubberBand->boundingRect().width();
-    const double heightRatio = rect.height() / annotationItemRubberBand->boundingRect().height();
-    const double deltaX = rect.x() - annotationItemRubberBand->x() + 1;
-    const double deltaY = rect.y() - annotationItemRubberBand->y() + 1;
-    attemptMoveBy( annotationItemRubberBand, deltaX, deltaY );
+    rotation = rectItem->appliedRotation( mCanvas->mapSettings().rotation() );
+  }
 
-    QgsAnnotationLayer *annotationLayer = annotationItemRubberBand->layer();
-    const QgsRectangle boundingBox = mCanvas->mapSettings().mapToLayerCoordinates( annotationLayer, annotationItemRubberBand->boundingBox() );
-    const QgsRectangle
-      modifiedBoundingBox( boundingBox.xMinimum(), boundingBox.yMaximum() - boundingBox.height() * heightRatio, boundingBox.xMinimum() + boundingBox.width() * widthRatio, boundingBox.yMaximum() );
+  // Rebuild the unrotated (screen-aligned) rectangle so that, after rotating
+  // around its center, the dragged corner stays where the user placed it.
+  const double w = rect.width();
+  const double h = rect.height();
+  const QPointF halfDiagonal( w / 2.0, h / 2.0 );
+  QTransform itemRotation;
+  itemRotation.rotate( rotation );
+  const QPointF unrotatedTopLeftScene = rect.topLeft() + itemRotation.map( halfDiagonal ) - halfDiagonal;
+  const QRectF newSceneRect( unrotatedTopLeftScene, QSizeF( w, h ) );
 
-    QgsAnnotationItemEditContext context;
-    context.setCurrentItemBounds( boundingBox );
-    context.setRenderContext( QgsRenderContext::fromMapSettings( mCanvas->mapSettings() ) );
+  // Derive the bounds from the center and pixel size, which stays correct
+  // when the map is rotated.
+  const QgsMapToPixel *transform = mCanvas->getCoordinateTransform();
+  const QgsRectangle newMapBounds = QgsAnnotationRectItem::boundsFromPixelRect( transform, newSceneRect.center(), w, h );
 
-    const QList<QgsAnnotationItemNode> itemNodes = annotationItem->nodesV2( context );
-    for ( const QgsAnnotationItemNode &node : itemNodes )
+  const QgsRectangle oldBounds = mCanvas->mapSettings().mapToLayerCoordinates( annotationLayer, annotationItemRubberBand->boundingBox() );
+  const QgsRectangle newBounds = mCanvas->mapSettings().mapToLayerCoordinates( annotationLayer, newMapBounds );
+
+  if ( oldBounds.width() == 0 || oldBounds.height() == 0 )
+    return;
+
+  QgsAnnotationItemEditContext context;
+  context.setCurrentItemBounds( oldBounds );
+  context.setRenderContext( QgsRenderContext::fromMapSettings( mCanvas->mapSettings() ) );
+
+  const QList<QgsAnnotationItemNode> itemNodes = annotationItem->nodesV2( context );
+  for ( const QgsAnnotationItemNode &node : itemNodes )
+  {
+    const double modifiedX = newBounds.xMinimum() + newBounds.width() * ( ( node.point().x() - oldBounds.xMinimum() ) / oldBounds.width() );
+    const double modifiedY = newBounds.yMaximum() - newBounds.height() * ( ( oldBounds.yMaximum() - node.point().y() ) / oldBounds.height() );
+    QgsPointXY modifiedPoint( modifiedX, modifiedY );
+    QgsAnnotationItemEditOperationMoveNode operation( annotationItemRubberBand->itemId(), node.id(), QgsPoint( node.point() ), QgsPoint( modifiedPoint ) );
+    switch ( annotationLayer->applyEditV2( &operation, context ) )
     {
-      const double modifiedX = modifiedBoundingBox.xMinimum() + modifiedBoundingBox.width() * ( ( node.point().x() - boundingBox.xMinimum() ) / boundingBox.width() );
-      const double modifiedY = modifiedBoundingBox.yMaximum() - modifiedBoundingBox.height() * ( ( boundingBox.yMaximum() - node.point().y() ) / boundingBox.height() );
-      QgsPointXY modifiedPoint( modifiedX, modifiedY );
-      QgsAnnotationItemEditOperationMoveNode operation( annotationItemRubberBand->itemId(), node.id(), QgsPoint( node.point() ), QgsPoint( modifiedPoint ) );
-      switch ( annotationLayer->applyEditV2( &operation, context ) )
-      {
-        case Qgis::AnnotationItemEditOperationResult::Success:
-          QgsProject::instance()->setDirty( true );
-          annotationItemRubberBand->setNeedsUpdatedBoundingBox( true );
-          break;
+      case Qgis::AnnotationItemEditOperationResult::Success:
+        QgsProject::instance()->setDirty( true );
+        annotationItemRubberBand->setNeedsUpdatedBoundingBox( true );
+        break;
 
-        case Qgis::AnnotationItemEditOperationResult::Invalid:
-        case Qgis::AnnotationItemEditOperationResult::ItemCleared:
-          break;
-      }
+      case Qgis::AnnotationItemEditOperationResult::Invalid:
+      case Qgis::AnnotationItemEditOperationResult::ItemCleared:
+        break;
     }
   }
+
+  annotationItemRubberBand->updateBoundingBox( newMapBounds );
 }

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -27,6 +27,7 @@
 #include "qgsapplication.h"
 #include "qgscoordinatetransform.h"
 #include "qgsgeometry.h"
+#include "qgslogger.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaptoolselectannotationmousehandles.h"
 #include "qgsmaptopixel.h"
@@ -41,10 +42,13 @@
 #include <QGraphicsSceneHoverEvent>
 #include <QKeySequence>
 #include <QScreen>
+#include <QString>
 #include <QTransform>
 #include <QWindow>
 
 #include "moc_qgsmaptoolselectannotation.cpp"
+
+using namespace Qt::StringLiterals;
 
 QgsAnnotationItemRubberBand::QgsAnnotationItemRubberBand( const QString &layerId, const QString &itemId, QgsMapCanvas *canvas )
   : QgsRubberBand( canvas, Qgis::GeometryType::Line )
@@ -111,13 +115,17 @@ void QgsAnnotationItemRubberBand::updateBoundingBox( const QgsRectangle &boundin
       const QPolygonF corners = rectItem->rotatedBoundsGeometry( rectItem->bounds(), renderContext ).asQPolygonF();
       for ( const QPointF &corner : corners )
       {
-        QgsPointXY mapPoint( corner.x(), corner.y() );
+        QgsPointXY mapPoint;
         try
         {
-          mapPoint = layerToMap.transform( mapPoint );
+          mapPoint = layerToMap.transform( QgsPointXY( corner.x(), corner.y() ) );
         }
         catch ( QgsCsException & )
-        {}
+        {
+          // the band is still bounded by the item bounding box corners below
+          QgsDebugError( u"Error transforming annotation item corner"_s );
+          continue;
+        }
         includePixel( toCanvasCoordinates( mapPoint ) );
       }
     }
@@ -747,8 +755,6 @@ void QgsMapToolSelectAnnotation::attemptSetSceneRect( QgsAnnotationItemRubberBan
     return;
 
   QgsAnnotationLayer *annotationLayer = annotationItemRubberBand->layer();
-  if ( !annotationLayer )
-    return;
 
   // on-screen rotation = the item's own rotation plus the map rotation when
   // the item follows it.

--- a/tests/src/app/testqgsmaptoolselectannotation.cpp
+++ b/tests/src/app/testqgsmaptoolselectannotation.cpp
@@ -16,6 +16,7 @@
 #include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsannotationlayer.h"
 #include "qgsannotationpolygonitem.h"
+#include "qgsannotationrectangletextitem.h"
 #include "qgsapplication.h"
 #include "qgsguiutils.h"
 #include "qgslinestring.h"
@@ -51,6 +52,9 @@ class TestQgsMapToolSelectAnnotation : public QObject
     void testSelectItem();
     void testDeleteItem();
     void testMoveItem();
+    void testMoveItemRotatedCanvas();
+    void testRotateItem();
+    void testResizeRotatedItem();
 };
 
 void TestQgsMapToolSelectAnnotation::initTestCase()
@@ -325,6 +329,197 @@ void TestQgsMapToolSelectAnnotation::testMoveItem()
 
   // check that item was moved
   QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt( 1 ), u"Polygon ((0.9 1, 4.9 1, 4.9 5, 0.9 5, 0.9 1))"_s );
+}
+
+
+void TestQgsMapToolSelectAnnotation::testMoveItemRotatedCanvas()
+{
+  QgsProject::instance()->clear();
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
+  canvas.setFrameStyle( QFrame::NoFrame );
+  canvas.resize( 600, 600 );
+  canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  // rotate the map canvas: a screen-space drag must still translate the item
+  // correctly, taking the canvas rotation into account.
+  canvas.setRotation( 90 );
+  canvas.show(); // to make the canvas resize
+
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( u"test"_s, QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer->isValid() );
+  QgsProject::instance()->addMapLayers( { layer } );
+
+  QgsAnnotationPolygonItem *item1 = new QgsAnnotationPolygonItem(
+    new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 1 ), QgsPoint( 5, 1 ), QgsPoint( 5, 5 ), QgsPoint( 1, 5 ), QgsPoint( 1, 1 ) } ) )
+  );
+  item1->setZIndex( 1 );
+  const QString i1id = layer->addItem( item1 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt(), u"Polygon ((1 1, 5 1, 5 5, 1 5, 1 1))"_s );
+
+  layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
+
+  canvas.setLayers( { layer } );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
+
+  QgsAdvancedDigitizingDockWidget cadDock( &canvas );
+  QgsMapToolSelectAnnotation tool( &canvas, &cadDock );
+  canvas.setMapTool( &tool );
+
+  QSignalSpy spy( &tool, &QgsMapToolSelectAnnotation::singleItemSelected );
+  TestQgsMapToolUtils utils( &tool );
+
+  // click on item to select it
+  utils.mouseMove( 1.5, 1.5 );
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 1 ).toString(), i1id );
+
+  // a mouse press on the item will start moving the item
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  // drag from map (1.5, 1.5) to map (4.5, 4.5): despite the 90 degree canvas
+  // rotation, the item should follow the cursor and move by (3, 3) in map units.
+  utils.mouseMove( 4.5, 4.5, Qt::LeftButton );
+  utils.mouseMove( 4.5, 4.5, Qt::LeftButton );
+  utils.mouseClick( 4.5, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
+
+  // check that the item was moved by (3, 3) in map units
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt( 0 ), u"Polygon ((4 4, 8 4, 8 8, 4 8, 4 4))"_s );
+}
+
+
+void TestQgsMapToolSelectAnnotation::testRotateItem()
+{
+  QgsProject::instance()->clear();
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
+  canvas.setFrameStyle( QFrame::NoFrame );
+  canvas.resize( 600, 600 );
+  canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  canvas.show(); // to make the canvas resize
+
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( u"test"_s, QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer->isValid() );
+  QgsProject::instance()->addMapLayers( { layer } );
+
+  QgsAnnotationRectangleTextItem *item1 = new QgsAnnotationRectangleTextItem( u"test"_s, QgsRectangle( 2, 2, 6, 6 ) );
+  item1->setZIndex( 1 );
+  const QString i1id = layer->addItem( item1 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->rotation(), 0.0 );
+
+  layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
+
+  canvas.setLayers( { layer } );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
+
+  QgsAdvancedDigitizingDockWidget cadDock( &canvas );
+  QgsMapToolSelectAnnotation tool( &canvas, &cadDock );
+  canvas.setMapTool( &tool );
+
+  QSignalSpy spy( &tool, &QgsMapToolSelectAnnotation::singleItemSelected );
+  TestQgsMapToolUtils utils( &tool );
+
+  // click on the item to select it
+  utils.mouseMove( 4, 4 );
+  utils.mouseClick( 4, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 1 ).toString(), i1id );
+
+  QList<QgsAnnotationItemRubberBand *> selected = tool.selectedItems();
+  QCOMPARE( selected.size(), 1 );
+
+  // rotating the rubber band via its handles rotates the underlying item
+  tool.attemptRotateBy( selected.first(), 30 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->rotation(), 30.0 );
+
+  // a further rotation accumulates
+  tool.attemptRotateBy( selected.first(), 20 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->rotation(), 50.0 );
+
+  // the item bounds (center and size) are unchanged by rotation
+  const QgsRectangle bounds = qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->bounds();
+  QGSCOMPARENEAR( bounds.xMinimum(), 2.0, 0.001 );
+  QGSCOMPARENEAR( bounds.yMinimum(), 2.0, 0.001 );
+  QGSCOMPARENEAR( bounds.xMaximum(), 6.0, 0.001 );
+  QGSCOMPARENEAR( bounds.yMaximum(), 6.0, 0.001 );
+}
+
+
+void TestQgsMapToolSelectAnnotation::testResizeRotatedItem()
+{
+  QgsProject::instance()->clear();
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
+  canvas.setFrameStyle( QFrame::NoFrame );
+  canvas.resize( 600, 600 );
+  canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  canvas.show(); // to make the canvas resize
+
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( u"test"_s, QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer->isValid() );
+  QgsProject::instance()->addMapLayers( { layer } );
+
+  QgsAnnotationRectangleTextItem *item1 = new QgsAnnotationRectangleTextItem( u"test"_s, QgsRectangle( 2, 2, 6, 6 ) );
+  item1->setZIndex( 1 );
+  // rotate the item: resizing must keep the dragged corner anchored, so the
+  // reconstructed (unrotated) bounds are shifted accordingly.
+  item1->setRotation( 90 );
+  const QString i1id = layer->addItem( item1 );
+
+  layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
+
+  canvas.setLayers( { layer } );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
+
+  QgsAdvancedDigitizingDockWidget cadDock( &canvas );
+  QgsMapToolSelectAnnotation tool( &canvas, &cadDock );
+  canvas.setMapTool( &tool );
+
+  TestQgsMapToolUtils utils( &tool );
+
+  // click on the item to select it
+  utils.mouseMove( 4, 4 );
+  utils.mouseClick( 4, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  QList<QgsAnnotationItemRubberBand *> selected = tool.selectedItems();
+  QCOMPARE( selected.size(), 1 );
+
+  // map (2,2)-(6,6) maps to the scene rectangle (120,240)-(360,480) with the
+  // 600x600 canvas covering the 10x10 extent. The new scene rectangle is 300x240
+  // pixels (5x4 map units). Because the item is rotated 90 degrees, the dragged
+  // corner is kept anchored: the resulting unrotated bounds are recentred.
+  tool.attemptSetSceneRect( selected.first(), QRectF( 120, 240, 300, 240 ) );
+
+  const QgsRectangle bounds = qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->bounds();
+  // the resized bounds keep the new pixel size (5 x 4 map units) ...
+  QGSCOMPARENEAR( bounds.width(), 5.0, 0.01 );
+  QGSCOMPARENEAR( bounds.height(), 4.0, 0.01 );
+  // ... recentred to anchor the rotated corner
+  QGSCOMPARENEAR( bounds.xMinimum(), -2.5, 0.01 );
+  QGSCOMPARENEAR( bounds.yMinimum(), 1.5, 0.01 );
+  QGSCOMPARENEAR( bounds.xMaximum(), 2.5, 0.01 );
+  QGSCOMPARENEAR( bounds.yMaximum(), 5.5, 0.01 );
 }
 
 

--- a/tests/src/app/testqgsmaptoolselectannotation.cpp
+++ b/tests/src/app/testqgsmaptoolselectannotation.cpp
@@ -353,8 +353,8 @@ void TestQgsMapToolSelectAnnotation::testMoveItemRotatedCanvas()
     new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 1 ), QgsPoint( 5, 1 ), QgsPoint( 5, 5 ), QgsPoint( 1, 5 ), QgsPoint( 1, 1 ) } ) )
   );
   item1->setZIndex( 1 );
-  const QString i1id = layer->addItem( item1 );
-  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt(), u"Polygon ((1 1, 5 1, 5 5, 1 5, 1 1))"_s );
+  const QString item1Id = layer->addItem( item1 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( item1Id ) )->geometry()->asWkt(), u"Polygon ((1 1, 5 1, 5 5, 1 5, 1 1))"_s );
 
   layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
 
@@ -377,7 +377,7 @@ void TestQgsMapToolSelectAnnotation::testMoveItemRotatedCanvas()
   utils.mouseMove( 1.5, 1.5 );
   utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   QCOMPARE( spy.count(), 1 );
-  QCOMPARE( spy.at( 0 ).at( 1 ).toString(), i1id );
+  QCOMPARE( spy.at( 0 ).at( 1 ).toString(), item1Id );
 
   // a mouse press on the item will start moving the item
   utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
@@ -395,7 +395,7 @@ void TestQgsMapToolSelectAnnotation::testMoveItemRotatedCanvas()
   QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
 
   // check that the item was moved by (3, 3) in map units
-  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt( 0 ), u"Polygon ((4 4, 8 4, 8 8, 4 8, 4 4))"_s );
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( item1Id ) )->geometry()->asWkt( 0 ), u"Polygon ((4 4, 8 4, 8 8, 4 8, 4 4))"_s );
 }
 
 
@@ -415,8 +415,8 @@ void TestQgsMapToolSelectAnnotation::testRotateItem()
 
   QgsAnnotationRectangleTextItem *item1 = new QgsAnnotationRectangleTextItem( u"test"_s, QgsRectangle( 2, 2, 6, 6 ) );
   item1->setZIndex( 1 );
-  const QString i1id = layer->addItem( item1 );
-  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->rotation(), 0.0 );
+  const QString item1Id = layer->addItem( item1 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( item1Id ) )->rotation(), 0.0 );
 
   layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
 
@@ -439,21 +439,21 @@ void TestQgsMapToolSelectAnnotation::testRotateItem()
   utils.mouseMove( 4, 4 );
   utils.mouseClick( 4, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   QCOMPARE( spy.count(), 1 );
-  QCOMPARE( spy.at( 0 ).at( 1 ).toString(), i1id );
+  QCOMPARE( spy.at( 0 ).at( 1 ).toString(), item1Id );
 
   QList<QgsAnnotationItemRubberBand *> selected = tool.selectedItems();
   QCOMPARE( selected.size(), 1 );
 
   // rotating the rubber band via its handles rotates the underlying item
   tool.attemptRotateBy( selected.first(), 30 );
-  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->rotation(), 30.0 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( item1Id ) )->rotation(), 30.0 );
 
   // a further rotation accumulates
   tool.attemptRotateBy( selected.first(), 20 );
-  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->rotation(), 50.0 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( item1Id ) )->rotation(), 50.0 );
 
   // the item bounds (center and size) are unchanged by rotation
-  const QgsRectangle bounds = qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->bounds();
+  const QgsRectangle bounds = qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( item1Id ) )->bounds();
   QGSCOMPARENEAR( bounds.xMinimum(), 2.0, 0.001 );
   QGSCOMPARENEAR( bounds.yMinimum(), 2.0, 0.001 );
   QGSCOMPARENEAR( bounds.xMaximum(), 6.0, 0.001 );
@@ -480,7 +480,7 @@ void TestQgsMapToolSelectAnnotation::testResizeRotatedItem()
   // rotate the item: resizing must keep the dragged corner anchored, so the
   // reconstructed (unrotated) bounds are shifted accordingly.
   item1->setRotation( 90 );
-  const QString i1id = layer->addItem( item1 );
+  const QString item1Id = layer->addItem( item1 );
 
   layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
 
@@ -511,7 +511,7 @@ void TestQgsMapToolSelectAnnotation::testResizeRotatedItem()
   // corner is kept anchored: the resulting unrotated bounds are recentred.
   tool.attemptSetSceneRect( selected.first(), QRectF( 120, 240, 300, 240 ) );
 
-  const QgsRectangle bounds = qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( i1id ) )->bounds();
+  const QgsRectangle bounds = qgis::down_cast<QgsAnnotationRectangleTextItem *>( layer->item( item1Id ) )->bounds();
   // the resized bounds keep the new pixel size (5 x 4 map units) ...
   QGSCOMPARENEAR( bounds.width(), 5.0, 0.01 );
   QGSCOMPARENEAR( bounds.height(), 4.0, 0.01 );


### PR DESCRIPTION
## Description

Makes the annotation map tools aware of item rotation, completing the work split
out of #66610 (after #67035 and #67036).

https://github.com/user-attachments/assets/862abcda-ea9e-4f87-9132-e0b75326984f


`QgsMapToolSelectAnnotation` draws the selection band and its mouse handles
rotated together with the item, and `QgsMapToolModifyAnnotation` places the
vertex handles on the rotated corners and supports resizing a rotated item by
dragging one of them. The drag keeps the opposite corner fixed on screen and
reconstructs the new (axis aligned) item bounds from the un-rotated diagonal.

To apply such a resize a new `QgsAnnotationItemEditOperationSetItemBounds`
edit operation is added, since the existing `MoveNode` operation can only set a
single corner of the unrotated bounds, which is not what a rotated resize
produces.

Tests are added for moving an item on a rotated canvas, rotating an item and
resizing a rotated item.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
