### PR TITLE
Fix the failing of identify tool in 3D view for categorized renderer

### DIFF
--- a/src/3d/qgs3dhighlightfeaturehandler.cpp
+++ b/src/3d/qgs3dhighlightfeaturehandler.cpp
@@ -52,7 +52,10 @@ Qgs3DHighlightFeatureHandler::~Qgs3DHighlightFeatureHandler()
   }
   for ( auto it = mHighlightCategorizedHandlers.constBegin(); it != mHighlightCategorizedHandlers.constEnd(); ++it )
   {
-    qDeleteAll( it.value() );
+    QSet<QgsFeature3DHandler *> uniqueHandlers;
+    for ( QgsFeature3DHandler *handler : it.value() )
+      uniqueHandlers.insert( handler );
+    qDeleteAll( uniqueHandlers );
   }
 }
 
@@ -173,12 +176,15 @@ void Qgs3DHighlightFeatureHandler::highlightFeature( QgsFeature feature, QgsMapL
               continue;
 
             handler->prepare( renderContext, attributeNames, box );
-            QgsFeature3DHandler *handlerPtr = handler.release();
 
             const QVariant value = category.value();
             if ( value.userType() == QMetaType::Type::QVariantList )
             {
               const QVariantList variantList = value.toList();
+              if ( variantList.isEmpty() )
+                continue;
+
+              QgsFeature3DHandler *handlerPtr = handler.release();
               for ( const QVariant &listElt : variantList )
               {
                 handlersHash.insert( listElt.toString(), handlerPtr );
@@ -186,6 +192,7 @@ void Qgs3DHighlightFeatureHandler::highlightFeature( QgsFeature feature, QgsMapL
             }
             else
             {
+              QgsFeature3DHandler *handlerPtr = handler.release();
               handlersHash.insert( QgsVariantUtils::isNull( value ) ? QString() : value.toString(), handlerPtr );
             }
           }

--- a/src/3d/qgs3dhighlightfeaturehandler.cpp
+++ b/src/3d/qgs3dhighlightfeaturehandler.cpp
@@ -20,12 +20,14 @@
 #include "qgs3dsymbolregistry.h"
 #include "qgsabstract3dengine.h"
 #include "qgsapplication.h"
+#include "qgscategorized3drenderer.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeature3dhandler_p.h"
 #include "qgsframegraph.h"
 #include "qgshighlightsrenderview.h"
 #include "qgspointcloudlayer3drenderer.h"
 #include "qgsrubberband3d.h"
+#include "qgsvariantutils.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayer3drenderer.h"
 
@@ -44,6 +46,10 @@ Qgs3DHighlightFeatureHandler::~Qgs3DHighlightFeatureHandler()
 {
   qDeleteAll( mHighlightHandlers );
   for ( auto it = mHighlightRuleBasedHandlers.constBegin(); it != mHighlightRuleBasedHandlers.constEnd(); ++it )
+  {
+    qDeleteAll( it.value() );
+  }
+  for ( auto it = mHighlightCategorizedHandlers.constBegin(); it != mHighlightCategorizedHandlers.constEnd(); ++it )
   {
     qDeleteAll( it.value() );
   }
@@ -145,9 +151,69 @@ void Qgs3DHighlightFeatureHandler::highlightFeature( QgsFeature feature, QgsMapL
 
         rootRule->registerFeature( feature, renderContext, mHighlightRuleBasedHandlers[layer] );
       }
+      else if ( renderer->type() == "categorized"_L1 )
+      {
+        QgsCategorized3DRenderer *categorizedRenderer = static_cast<QgsCategorized3DRenderer *>( renderer );
+        if ( !mHighlightCategorizedHandlers.contains( layer ) )
+        {
+          QHash<QString, QgsFeature3DHandler *> handlersHash;
+          const QgsGeometry geom = feature.geometry();
+          // We want to ignore the geometry's elevation and use a box with symmetric +Z/-Z extents so the chunk origin has Z == 0.
+          QgsBox3D box = geom.boundingBox().toBox3d( 0, 0 );
+          QSet<QString> attributeNames;
+
+          for ( const Qgs3DRendererCategory &category : categorizedRenderer->categories() )
+          {
+            if ( !category.renderState() || !category.symbol() )
+              continue;
+
+            std::unique_ptr<QgsFeature3DHandler> handler( QgsApplication::symbol3DRegistry()->createHandlerForSymbol( vLayer, category.symbol() ) );
+            if ( !handler )
+              continue;
+
+            handler->prepare( renderContext, attributeNames, box );
+            QgsFeature3DHandler *handlerPtr = handler.release();
+
+            const QVariant value = category.value();
+            if ( value.userType() == QMetaType::Type::QVariantList )
+            {
+              const QVariantList variantList = value.toList();
+              for ( const QVariant &listElt : variantList )
+              {
+                handlersHash.insert( listElt.toString(), handlerPtr );
+              }
+            }
+            else
+            {
+              handlersHash.insert( QgsVariantUtils::isNull( value ) ? QString() : value.toString(), handlerPtr );
+            }
+          }
+          mHighlightCategorizedHandlers[layer] = handlersHash;
+        }
+
+        QVariant value;
+        int attrIdx = vLayer->fields().lookupField( categorizedRenderer->classAttribute() );
+        if ( attrIdx == -1 )
+        {
+          QgsExpression expr( categorizedRenderer->classAttribute() );
+          expr.prepare( &exprContext );
+          value = expr.evaluate( &exprContext );
+        }
+        else
+        {
+          value = feature.attributes().value( attrIdx );
+        }
+
+        QString valueStr = QgsVariantUtils::isNull( value ) ? QString() : value.toString();
+        auto handlerIt = mHighlightCategorizedHandlers[layer].constFind( valueStr );
+        if ( handlerIt != mHighlightCategorizedHandlers[layer].constEnd() )
+        {
+          ( *handlerIt )->processFeature( feature, renderContext );
+        }
+      }
 
       // We'll use a singleshot timer to handle the entity creation, it will be served once we stop receiving highlighted features
-      if ( !mHighlightHandlerTimer && ( !mHighlightHandlers.isEmpty() || !mHighlightRuleBasedHandlers.isEmpty() ) )
+      if ( !mHighlightHandlerTimer && ( !mHighlightHandlers.isEmpty() || !mHighlightRuleBasedHandlers.isEmpty() || !mHighlightCategorizedHandlers.isEmpty() ) )
       {
         mHighlightHandlerTimer = std::make_unique<QTimer>();
         mHighlightHandlerTimer->setSingleShot( true );
@@ -172,6 +238,26 @@ void Qgs3DHighlightFeatureHandler::highlightFeature( QgsFeature feature, QgsMapL
             for ( auto handlersIt = rulesIt.value().constBegin(); handlersIt != rulesIt.value().constEnd(); ++handlersIt )
             {
               QgsFeature3DHandler *handler = handlersIt.value();
+              handler->setHighlightingEnabled( true );
+              handler->finalize( entity, renderContext );
+            }
+
+            finalizeAndAddToScene( entity );
+          }
+
+          for ( auto catIt = mHighlightCategorizedHandlers.constBegin(); catIt != mHighlightCategorizedHandlers.constEnd(); ++catIt )
+          {
+            Qgs3DMapSceneEntity *entity = new Qgs3DMapSceneEntity( mScene->mapSettings(), nullptr );
+            entity->setObjectName( u"%1_highlight"_s.arg( catIt.key()->name() ) );
+
+            QSet<QgsFeature3DHandler *> uniqueHandlers;
+            for ( QgsFeature3DHandler *handler : catIt.value() )
+            {
+              uniqueHandlers.insert( handler );
+            }
+
+            for ( QgsFeature3DHandler *handler : std::as_const( uniqueHandlers ) )
+            {
               handler->setHighlightingEnabled( true );
               handler->finalize( entity, renderContext );
             }
@@ -246,6 +332,14 @@ void Qgs3DHighlightFeatureHandler::clearHighlights()
     qDeleteAll( it.value() );
   }
   mHighlightRuleBasedHandlers.clear();
+  for ( auto it = mHighlightCategorizedHandlers.constBegin(); it != mHighlightCategorizedHandlers.constEnd(); ++it )
+  {
+    QSet<QgsFeature3DHandler *> uniqueHandlers;
+    for ( QgsFeature3DHandler *handler : it.value() )
+      uniqueHandlers.insert( handler );
+    qDeleteAll( uniqueHandlers );
+  }
+  mHighlightCategorizedHandlers.clear();
   // vector layer highlights
   for ( Qt3DCore::QEntity *e : std::as_const( mHighlightEntities ) )
   {

--- a/src/3d/qgs3dhighlightfeaturehandler.cpp
+++ b/src/3d/qgs3dhighlightfeaturehandler.cpp
@@ -31,6 +31,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayer3drenderer.h"
 
+#include <QSet>
 #include <QString>
 #include <QTimer>
 

--- a/src/3d/qgs3dhighlightfeaturehandler.h
+++ b/src/3d/qgs3dhighlightfeaturehandler.h
@@ -76,6 +76,8 @@ class _3D_EXPORT Qgs3DHighlightFeatureHandler : public QObject
     QMap<QgsMapLayer *, QgsFeature3DHandler *> mHighlightHandlers;
     //! Per layer feature handlers for rule based 3d renderers
     QMap<QgsMapLayer *, QgsRuleBased3DRenderer::RuleToHandlerMap> mHighlightRuleBasedHandlers;
+    //! Per layer feature handlers for categorized 3d renderers
+    QMap<QgsMapLayer *, QHash<QString, QgsFeature3DHandler *>> mHighlightCategorizedHandlers;
     //! Singleshot timer is used to trigger finalizing the 3d entities and adding them to the scene
     std::unique_ptr<QTimer> mHighlightHandlerTimer;
 };

--- a/src/3d/qgs3dhighlightfeaturehandler.h
+++ b/src/3d/qgs3dhighlightfeaturehandler.h
@@ -19,6 +19,7 @@
 #include "qgis_3d.h"
 #include "qgsrulebased3drenderer.h"
 
+#include <QHash>
 #include <QMap>
 #include <QObject>
 #include <QVector>


### PR DESCRIPTION
## Description

Fix the bug reported at [67054](https://github.com/qgis/qgis/issues/67054).

**Root Cause**
The issue is caused by the Qgs3DHighlightFeatureHandler::highlightFeature() function in QGIS not having an implementation to handle the newly introduced categorized 3D renderer. The handler explicitly checked if the renderer type was "vector" (Single Symbol) or "rulebased" (Rule-based) to instantiate and run the respective feature 3D handlers. When categorized was introduced in QGIS 4.2, it was missing from this conditional logic, which meant that trying to highlight features with this renderer silently failed and returned without creating any 3D highlight entities.

**Updated**
I have modified qgs3dhighlightfeaturehandler.h and qgs3dhighlightfeaturehandler.cpp to add support for the categorized renderer. 

1. Identifying if the renderer type is categorized.  
2. Extracting all renderer categories and compiling them into a QHash that correlates the value string with its corresponding QgsFeature3DHandler, instantiated similarly to how QgsCategorizedChunkLoader does for the main 3D scene.  
3. Evaluating the feature attributes against the class attribute (field or expression) defined on the layer to fetch the right 3D handler.  
4. Calling handler->processFeature(feature, renderContext) to process the geometry using that handler.  
5.  In the timer callback, the fix collects unique handlers (since multiple categories can share the same handler for lists of values) and calls finalize() to create the entity in the 3D scene.  
6.  The clearHighlights() function was also updated to correctly clear and delete the categorized handlers using a QSet to prevent double deletion (a risk due to value aliasing).

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
