### PR TITLE
 [expressions] Guard from null vector layer pointer crash in the represent_value function

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -7324,21 +7324,24 @@ static QVariant fcnRepresentValue( const QVariantList &values, const QgsExpressi
         return context->cachedValue( cacheValueKey );
       }
 
-      const QgsEditorWidgetSetup setup = fields.at( fieldIndex ).editorWidgetSetup();
-      const QgsFieldFormatter *formatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
-
-      const QString cacheKey = u"repvalfcn:%1:%2"_s.arg( layer ? layer->id() : u"[None]"_s, fieldName );
-
-      QVariant cache;
-      if ( !context->hasCachedValue( cacheKey ) )
+      if ( layer )
       {
-        cache = formatter->createCache( layer, fieldIndex, setup.config() );
-        context->setCachedValue( cacheKey, cache );
-      }
-      else
-        cache = context->cachedValue( cacheKey );
+        const QgsEditorWidgetSetup setup = fields.at( fieldIndex ).editorWidgetSetup();
+        const QgsFieldFormatter *formatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
 
-      result = formatter->representValue( layer, fieldIndex, setup.config(), cache, value );
+        const QString cacheKey = u"repvalfcn:%1:%2"_s.arg( layer ? layer->id() : u"[None]"_s, fieldName );
+
+        QVariant cache;
+        if ( !context->hasCachedValue( cacheKey ) )
+        {
+          cache = formatter->createCache( layer, fieldIndex, setup.config() );
+          context->setCachedValue( cacheKey, cache );
+        }
+        else
+          cache = context->cachedValue( cacheKey );
+
+        result = formatter->representValue( layer, fieldIndex, setup.config(), cache, value );
+      }
 
       context->setCachedValue( cacheValueKey, result );
     }

--- a/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
@@ -129,6 +129,11 @@ QVariant QgsRelationReferenceFieldFormatter::createCache( QgsVectorLayer *layer,
   Q_UNUSED( fieldIndex )
   QMap<QVariant, QString> cache;
 
+  if ( !layer )
+  {
+    return QVariant();
+  }
+
   const QString fieldName = fieldIndex < layer->fields().size() ? layer->fields().at( fieldIndex ).name() : QObject::tr( "<unknown>" );
 
   // Some sanity checks

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -13,6 +13,7 @@ __copyright__ = "Copyright 2012, The QGIS Project"
 from qgis.core import (
     NULL,
     QgsCoordinateReferenceSystem,
+    QgsEditorWidgetSetup,
     QgsExpression,
     QgsExpressionContext,
     QgsExpressionContextUtils,
@@ -22,9 +23,11 @@ from qgis.core import (
     QgsFields,
     QgsVectorLayer,
 )
-from qgis.PyQt.QtCore import QVariant
-from qgis.testing import unittest
+from qgis.PyQt.QtCore import QMetaType, QVariant
+from qgis.testing import start_app, unittest
 from qgis.utils import qgsfunction
+
+start_app()
 
 
 class TestQgsExpressionCustomFunctions(unittest.TestCase):
@@ -607,6 +610,24 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
 
         exp = QgsExpression('6 NOT IN ("c", 1 + 1, 2 * 3, "a")')
         self.assertEqual(exp.simplified().dump(), "FALSE")
+
+    def testRepresentValueNonExistingLayerContext(self):
+        editor_widget_setup = QgsEditorWidgetSetup("RelationReference", {})
+        field = QgsField("test", QMetaType.Type.QString)
+        field.setEditorWidgetSetup(editor_widget_setup)
+        fields = QgsFields()
+        fields.append(field)
+
+        f = QgsFeature(fields)
+        f.setAttributes(["stay safe"])
+
+        expression = QgsExpression('represent_value("test")')
+
+        context = QgsExpressionContext()
+        context.setFeature(f)
+        context.setFields(fields)
+
+        v = expression.evaluate(context)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR addresses a crash when calling represent_value() with a missing layer context. The actual crash is caused by the QgsRelationReferenceFieldFormatter class which is fixed too, but to make sure we never crash when other formatters are added, the represent_value() function now returns QVariant() when the layer context is missing.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
