### PR TITLE
Elevation controller improvements

### DIFF
--- a/python/PyQt6/core/auto_additions/qgselevationutils.py
+++ b/python/PyQt6/core/auto_additions/qgselevationutils.py
@@ -1,6 +1,7 @@
 # The following has been generated automatically from src/core/qgselevationutils.h
 try:
     QgsElevationUtils.calculateZRangeForProject = staticmethod(QgsElevationUtils.calculateZRangeForProject)
+    QgsElevationUtils.calculateZRangeForLayers = staticmethod(QgsElevationUtils.calculateZRangeForLayers)
     QgsElevationUtils.significantZValuesForProject = staticmethod(QgsElevationUtils.significantZValuesForProject)
     QgsElevationUtils.significantZValuesForLayers = staticmethod(QgsElevationUtils.significantZValuesForLayers)
     QgsElevationUtils.canEnableElevationForLayer = staticmethod(QgsElevationUtils.canEnableElevationForLayer)

--- a/python/PyQt6/core/auto_additions/qgsmathutils.py
+++ b/python/PyQt6/core/auto_additions/qgsmathutils.py
@@ -1,5 +1,7 @@
 # The following has been generated automatically from src/core/qgsmathutils.h
 try:
     QgsMathUtils.doubleToRational = staticmethod(QgsMathUtils.doubleToRational)
+    QgsMathUtils.roundingInterval = staticmethod(QgsMathUtils.roundingInterval)
+    QgsMathUtils.roundedRange = staticmethod(QgsMathUtils.roundedRange)
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/qgselevationutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgselevationutils.sip.in
@@ -31,6 +31,17 @@ contained within the project and returns the maximal combined elevation
 range of these layers.
 %End
 
+    static QgsDoubleRange calculateZRangeForLayers( const QList< QgsMapLayer * > &layers );
+%Docstring
+Calculates the elevation range for the specified ``layers``.
+
+This method considers the elevation (or z) range available from each of
+the ``layers`` and returns the maximal combined elevation range of these
+layers.
+
+.. versionadded:: 4.4
+%End
+
     static QList< double > significantZValuesForProject( QgsProject *project );
 %Docstring
 Returns a list of significant elevation/z-values for the specified

--- a/python/PyQt6/core/auto_generated/qgselevationutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgselevationutils.sip.in
@@ -35,7 +35,7 @@ range of these layers.
 %Docstring
 Calculates the elevation range for the specified ``layers``.
 
-This method considers the elevation (or z) range available from each of
+This method considers the elevation (or Z) range available from each of
 the ``layers`` and returns the maximal combined elevation range of these
 layers.
 

--- a/python/PyQt6/core/auto_generated/qgsmathutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmathutils.sip.in
@@ -38,6 +38,32 @@ Converts a double ``value`` to a rational fraction.
 :return: - numerator: calculated numerator
          - denominator: calculated denominator
 %End
+
+    static double roundingInterval( double span, int divisions = 10 );
+%Docstring
+Returns a round interval, a power of ten, which splits the given
+``span`` into at least ``divisions`` parts. E.g. a span of 2222 returns
+100 for 10 divisions and 10 for 100 divisions.
+
+Returns 0 if ``span`` is not finite or is not greater than 0, or if
+``divisions`` is lower than 1.
+
+.. versionadded:: 4.4
+%End
+
+    static QgsDoubleRange roundedRange( const QgsDoubleRange &range );
+%Docstring
+Expands a ``range`` outward to round values, e.g. a range of 1234.5 -
+3456.7 is expanded to 1200 - 3500.
+
+The bounds are rounded to a tenth of the order of magnitude of the
+range's size, so that the returned range stays close to the original
+one.
+
+Infinite and empty ranges are returned unchanged.
+
+.. versionadded:: 4.4
+%End
 };
 
 /************************************************************************

--- a/python/PyQt6/gui/auto_additions/qgselevationcontrollerwidget.py
+++ b/python/PyQt6/gui/auto_additions/qgselevationcontrollerwidget.py
@@ -6,7 +6,3 @@ try:
     QgsElevationControllerWidget.__group__ = ['elevation']
 except (NameError, AttributeError):
     pass
-try:
-    QgsElevationControllerSettingsAction.__group__ = ['elevation']
-except (NameError, AttributeError):
-    pass

--- a/python/PyQt6/gui/auto_generated/elevation/qgselevationcontrollerwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/elevation/qgselevationcontrollerwidget.sip.in
@@ -13,17 +13,6 @@
 
 
 
-class QgsElevationControllerSettingsAction : QWidgetAction
-{
-%TypeHeaderCode
-#include "qgselevationcontrollerwidget.h"
-%End
-  public:
-    QgsElevationControllerSettingsAction( QWidget *parent = 0 );
-
-    QgsDoubleSpinBox *sizeSpin();
-
-};
 
 
 

--- a/python/PyQt6/gui/auto_generated/elevation/qgselevationcontrollerwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/elevation/qgselevationcontrollerwidget.sip.in
@@ -71,6 +71,15 @@ Returns a reference to the widget's configuration menu, which can be
 used to add actions to the menu.
 %End
 
+    QgsMapCanvas *mapCanvas() const;
+%Docstring
+Returns the map canvas the widget takes its layers from.
+
+.. seealso:: :py:func:`setMapCanvas`
+
+.. versionadded:: 4.4
+%End
+
     double fixedRangeSize() const;
 %Docstring
 Returns the fixed range size, or -1 if no fixed size is set.
@@ -122,6 +131,19 @@ Sets whether the elevation slider should be inverted.
     void setSignificantElevations( const QList<double> &elevations );
 %Docstring
 Sets a list of significant ``elevations`` to highlight in the widget.
+%End
+
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets the map ``canvas`` the widget takes its layers from.
+
+The canvas provides the layer used by the "Current Layer" entry of the
+range limits button, and its layers give the initial limits when the
+project defines no elevation range of its own.
+
+.. seealso:: :py:func:`mapCanvas`
+
+.. versionadded:: 4.4
 %End
 
   signals:

--- a/src/app/canvas/qgsappcanvasfiltering.cpp
+++ b/src/app/canvas/qgsappcanvasfiltering.cpp
@@ -20,9 +20,11 @@
 #include "qgselevationutils.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaplayerelevationproperties.h"
+#include "qgsproject.h"
 #include "qgsprojectelevationproperties.h"
 
-#include <QInputDialog>
+#include <QMenu>
+#include <QPointer>
 
 #include "moc_qgsappcanvasfiltering.cpp"
 
@@ -53,9 +55,8 @@ void QgsAppCanvasFiltering::createElevationController( QAction *senderAction, Qg
 {
   QgsElevationControllerWidget *controller = new QgsElevationControllerWidget();
 
-  QAction *setProjectLimitsAction = new QAction( tr( "Set Elevation Range…" ), controller );
-  controller->menu()->addAction( setProjectLimitsAction );
-  connect( setProjectLimitsAction, &QAction::triggered, QgisApp::instance(), [] { QgisApp::instance()->showProjectProperties( tr( "Elevation" ) ); } );
+  controller->menu()->addSeparator();
+
   QAction *disableAction = new QAction( tr( "Disable Elevation Filter" ), controller );
   controller->menu()->addAction( disableAction );
   connect( disableAction, &QAction::triggered, senderAction, [senderAction] { senderAction->setChecked( false ); } );
@@ -93,6 +94,8 @@ QgsCanvasElevationControllerBridge::QgsCanvasElevationControllerBridge( QgsEleva
   }
 
   connect( mCanvas, &QgsMapCanvas::layersChanged, this, &QgsCanvasElevationControllerBridge::canvasLayersChanged );
+
+  mController->setMapCanvas( mCanvas );
 
   canvasLayersChanged();
 }

--- a/src/app/canvas/qgsappcanvasfiltering.cpp
+++ b/src/app/canvas/qgsappcanvasfiltering.cpp
@@ -106,7 +106,7 @@ void QgsCanvasElevationControllerBridge::canvasLayersChanged()
     return;
 
   // disconnect from old layers
-  for ( QgsMapLayer *layer : std::as_const( mCanvasLayers ) )
+  for ( QgsMapLayer *layer : std::as_const( mElevationLayers ) )
   {
     if ( layer )
     {
@@ -115,12 +115,17 @@ void QgsCanvasElevationControllerBridge::canvasLayersChanged()
   }
 
   // and connect to new
+  QList<QgsMapLayer *> elevationLayers;
   const QList<QgsMapLayer *> layers = mCanvas->layers( true );
   for ( QgsMapLayer *layer : layers )
   {
+    if ( !layer->elevationProperties() )
+      continue;
+
     connect( layer->elevationProperties(), &QgsMapLayerElevationProperties::changed, this, &QgsCanvasElevationControllerBridge::updateSignificantElevations );
+    elevationLayers << layer;
   }
-  mCanvasLayers = _qgis_listRawToQPointer( layers );
+  mElevationLayers = _qgis_listRawToQPointer( elevationLayers );
 
   updateSignificantElevations();
 }
@@ -130,7 +135,7 @@ void QgsCanvasElevationControllerBridge::updateSignificantElevations()
   if ( !mCanvas )
     return;
 
-  mController->setSignificantElevations( QgsElevationUtils::significantZValuesForLayers( _qgis_listQPointerToRaw( mCanvasLayers ) ) );
+  mController->setSignificantElevations( QgsElevationUtils::significantZValuesForLayers( _qgis_listQPointerToRaw( mElevationLayers ) ) );
 }
 
 void QgsCanvasElevationControllerBridge::controllerZRangeChanged( const QgsDoubleRange & )

--- a/src/app/canvas/qgsappcanvasfiltering.h
+++ b/src/app/canvas/qgsappcanvasfiltering.h
@@ -45,7 +45,7 @@ class QgsCanvasElevationControllerBridge : public QObject
     QTimer *mUpdateCanvasTimer = nullptr;
     QgsElevationControllerWidget *mController = nullptr;
     QPointer<QgsMapCanvas> mCanvas;
-    QgsWeakMapLayerPointerList mCanvasLayers;
+    QgsWeakMapLayerPointerList mElevationLayers;
 };
 
 class QgsAppCanvasFiltering : public QObject

--- a/src/core/qgselevationutils.cpp
+++ b/src/core/qgselevationutils.cpp
@@ -22,15 +22,24 @@
 QgsDoubleRange QgsElevationUtils::calculateZRangeForProject( QgsProject *project )
 {
   const QMap<QString, QgsMapLayer *> &mapLayers = project->mapLayers();
-  QgsMapLayer *currentLayer = nullptr;
+  QList< QgsMapLayer * > layers;
+  layers.reserve( mapLayers.size() );
+  for ( QMap<QString, QgsMapLayer *>::const_iterator it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
+  {
+    if ( it.value() )
+      layers << it.value();
+  }
 
+  return calculateZRangeForLayers( layers );
+}
+
+QgsDoubleRange QgsElevationUtils::calculateZRangeForLayers( const QList< QgsMapLayer * > &layers )
+{
   double min = std::numeric_limits<double>::quiet_NaN();
   double max = std::numeric_limits<double>::quiet_NaN();
 
-  for ( QMap<QString, QgsMapLayer *>::const_iterator it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
+  for ( QgsMapLayer *currentLayer : layers )
   {
-    currentLayer = it.value();
-
     if ( !currentLayer->elevationProperties() || !currentLayer->elevationProperties()->hasElevation() )
       continue;
 

--- a/src/core/qgselevationutils.h
+++ b/src/core/qgselevationutils.h
@@ -41,6 +41,16 @@ class CORE_EXPORT QgsElevationUtils
     static QgsDoubleRange calculateZRangeForProject( QgsProject *project );
 
     /**
+     * Calculates the elevation range for the specified \a layers.
+     *
+     * This method considers the elevation (or z) range available from each of the \a layers and
+     * returns the maximal combined elevation range of these layers.
+     *
+     * \since QGIS 4.4
+     */
+    static QgsDoubleRange calculateZRangeForLayers( const QList< QgsMapLayer * > &layers );
+
+    /**
      * Returns a list of significant elevation/z-values for the specified \a project, using
      * the values from layers contained by the project.
      *

--- a/src/core/qgselevationutils.h
+++ b/src/core/qgselevationutils.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsElevationUtils
     /**
      * Calculates the elevation range for the specified \a layers.
      *
-     * This method considers the elevation (or z) range available from each of the \a layers and
+     * This method considers the elevation (or Z) range available from each of the \a layers and
      * returns the maximal combined elevation range of these layers.
      *
      * \since QGIS 4.4

--- a/src/core/qgsmathutils.cpp
+++ b/src/core/qgsmathutils.cpp
@@ -16,6 +16,8 @@
 
 #include "qgsmathutils.h"
 
+#include <cmath>
+
 #include "qgis.h"
 
 #include "moc_qgsmathutils.cpp"
@@ -85,4 +87,31 @@ void QgsMathUtils::doubleToRational( double value, qlonglong &numerator, qlonglo
 
   numerator = sign * currentAConvergent;
   denominator = currentBConvergent;
+}
+
+double QgsMathUtils::roundingInterval( double span, int divisions )
+{
+  if ( !std::isfinite( span ) || span <= 0 || divisions < 1 )
+    return 0;
+
+  return std::pow( 10.0, std::floor( std::log10( span / divisions ) ) );
+}
+
+QgsDoubleRange QgsMathUtils::roundedRange( const QgsDoubleRange &range )
+{
+  const double interval = roundingInterval( range.upper() - range.lower() );
+  if ( interval <= 0 )
+    return range;
+
+  double lower = std::floor( range.lower() / interval ) * interval;
+  double upper = std::ceil( range.upper() / interval ) * interval;
+
+  const int decimals = -static_cast<int>( std::floor( std::log10( interval ) ) );
+  if ( decimals > 0 )
+  {
+    // strip the noise the multiplication above leaves in fractional values
+    lower = qgsRound( lower, decimals );
+    upper = qgsRound( upper, decimals );
+  }
+  return QgsDoubleRange( lower, upper );
 }

--- a/src/core/qgsmathutils.h
+++ b/src/core/qgsmathutils.h
@@ -15,6 +15,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgsrange.h"
 
 #include <QObject>
 
@@ -41,6 +42,29 @@ class CORE_EXPORT QgsMathUtils
      * \param maxIterations maximum number of iterations. Higher values result in better approximations, but at the cost of additional computation.
      */
     Q_INVOKABLE static void doubleToRational( double value, qlonglong &numerator SIP_OUT, qlonglong &denominator SIP_OUT, double tolerance = 1.0e-9, int maxIterations = 100 );
+
+    /**
+     * Returns a round interval, a power of ten, which splits the given \a span into at least
+     * \a divisions parts. E.g. a span of 2222 returns 100 for 10 divisions and 10 for 100 divisions.
+     *
+     * Returns 0 if \a span is not finite or is not greater than 0, or if \a divisions is lower than 1.
+     *
+     * \since QGIS 4.4
+     */
+    static double roundingInterval( double span, int divisions = 10 );
+
+    /**
+     * Expands a \a range outward to round values, e.g. a range of 1234.5 - 3456.7 is expanded
+     * to 1200 - 3500.
+     *
+     * The bounds are rounded to a tenth of the order of magnitude of the range's size, so that
+     * the returned range stays close to the original one.
+     *
+     * Infinite and empty ranges are returned unchanged.
+     *
+     * \since QGIS 4.4
+     */
+    static QgsDoubleRange roundedRange( const QgsDoubleRange &range );
 };
 
 #endif // QGSMATHUTILS_H

--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -357,8 +357,24 @@ QgsDoubleRange QgsRasterLayerElevationProperties::calculateZRange( QgsMapLayer *
     }
 
     case Qgis::RasterElevationMode::RepresentsElevationSurface:
-      // TODO -- determine actual z range from raster statistics
+    {
+      if ( QgsRasterLayer *rl = qobject_cast< QgsRasterLayer * >( layer ) )
+      {
+        if ( QgsRasterDataProvider *provider = rl->dataProvider() )
+        {
+          if ( mBandNumber > 0 && mBandNumber <= provider->bandCount() )
+          {
+            const QgsRasterBandStats stats
+              = provider->bandStatistics( mBandNumber, Qgis::RasterBandStatistic::Min | Qgis::RasterBandStatistic::Max, provider->extent(), static_cast< int >( QgsRasterLayer::SAMPLE_SIZE ) );
+            if ( stats.statsGathered.testFlags( Qgis::RasterBandStatistic::Min | Qgis::RasterBandStatistic::Max ) && stats.minimumValue <= stats.maximumValue )
+            {
+              return QgsDoubleRange( stats.minimumValue * mZScale + mZOffset, stats.maximumValue * mZScale + mZOffset );
+            }
+          }
+        }
+      }
       return QgsDoubleRange();
+    }
   }
   BUILTIN_UNREACHABLE
 }

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -20,6 +20,7 @@
 #include "qgsapplication.h"
 #include "qgsdoublespinbox.h"
 #include "qgselevationutils.h"
+#include "qgsguiutils.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaplayer.h"
 #include "qgsmaplayerelevationproperties.h"
@@ -79,12 +80,12 @@ QgsElevationControllerWidget::QgsElevationControllerWidget( QWidget *parent )
   } );
 
   QAction *limitsFromProjectLayersAction = limitsMenu->addAction( tr( "Project Layers" ) );
-  connect( limitsFromProjectLayersAction, &QAction::triggered, this, [this] { setLimitsFromRange( QgsElevationUtils::calculateZRangeForProject( QgsProject::instance() ) ); } );
+  connect( limitsFromProjectLayersAction, &QAction::triggered, this, [this] { setLimitsFromLayers( QgsProject::instance()->mapLayers().values() ); } );
 
   QAction *limitsFromCurrentLayerAction = limitsMenu->addAction( tr( "Current Layer" ) );
   connect( limitsFromCurrentLayerAction, &QAction::triggered, this, [this] {
     if ( mMapCanvas )
-      setLimitsFromRange( QgsElevationUtils::calculateZRangeForLayers( { mMapCanvas->currentLayer() } ) );
+      setLimitsFromLayers( { mMapCanvas->currentLayer() } );
   } );
 
   // the project and the current layer change at any time, so refresh availability when the menu opens
@@ -220,15 +221,23 @@ void QgsElevationControllerWidget::setMapCanvas( QgsMapCanvas *canvas )
 {
   mMapCanvas = canvas;
 
-  // a project which defines no elevation range of its own leaves the widget with a guessed
-  // range, the canvas layers give a usable one instead
+  // a project which defines no elevation range of its own leaves
+  // the widget with an estimated range, the canvas layers give a usable one instead
   if ( mMapCanvas && QgsProject::instance()->elevationProperties()->elevationRange().isInfinite() )
-    setLimitsFromRange( QgsElevationUtils::calculateZRangeForLayers( mMapCanvas->layers( true ) ) );
+    setLimitsFromLayers( mMapCanvas->layers( true ) );
 }
 
 bool QgsElevationControllerWidget::layerHasElevation( QgsMapLayer *layer )
 {
   return layer && layer->elevationProperties() && layer->elevationProperties()->hasElevation();
+}
+
+void QgsElevationControllerWidget::setLimitsFromLayers( const QList<QgsMapLayer *> &layers )
+{
+  // raster layers gather statistics over their elevation band for this, which is not instant
+  const QgsTemporaryCursorOverride waitCursor( Qt::WaitCursor );
+
+  setLimitsFromRange( QgsElevationUtils::calculateZRangeForLayers( layers ) );
 }
 
 void QgsElevationControllerWidget::setLimitsFromRange( const QgsDoubleRange &range )
@@ -621,7 +630,7 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
   mLimitsButton = new QToolButton();
   mLimitsButton->setIcon( QgsApplication::getThemeIcon( u"/mActionRefresh.svg"_s ) );
   mLimitsButton->setPopupMode( QToolButton::InstantPopup );
-  mLimitsButton->setToolTip( tr( "Set the elevation limits from a predefined source" ) );
+  mLimitsButton->setToolTip( tr( "Take the elevation limits from the project or the layers" ) );
   mLimitsMenu = new QMenu( mLimitsButton );
   mLimitsButton->setMenu( mLimitsMenu );
 
@@ -641,7 +650,7 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
   mSizeSpin->setDecimals( 4 );
   mSizeSpin->setMinimum( 0.0 );
   mSizeSpin->setMaximum( 999999999.0 );
-  mSizeSpin->setClearValue( 0, tr( "Full Range" ) );
+  mSizeSpin->setClearValue( 0, tr( "Full range" ) );
   mSizeSpin->setKeyboardTracking( false );
   mSizeSpin->setToolTip( rangeToolTip );
 

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -138,9 +138,10 @@ QgsElevationControllerWidget::QgsElevationControllerWidget( QWidget *parent )
     if ( mBlockSliderChanges )
       return;
 
-    const QgsDoubleRange snapped = snappedRange( range() );
+    const QgsDoubleRange snapped = snappedRange( sliderRange() );
 
-    // move the handles onto the snapped values
+    // a drag within one snapping interval leaves the snapped range identical to the current
+    // one, but the handles still have to be moved back onto it, hence before the early return
     mBlockSliderChanges++;
     mSlider->setRange( static_cast<int>( std::floor( snapped.lower() * mSliderPrecision ) ), static_cast<int>( std::ceil( snapped.upper() * mSliderPrecision ) ) );
     mBlockSliderChanges--;
@@ -178,26 +179,7 @@ void QgsElevationControllerWidget::resizeEvent( QResizeEvent *event )
 
 QgsDoubleRange QgsElevationControllerWidget::range() const
 {
-  // if the current slider range is just the current range, but snapped to the slider precision, then losslessly return the current range
-  const int snappedLower = static_cast<int>( std::floor( mCurrentRange.lower() * mSliderPrecision ) );
-  const int snappedUpper = static_cast<int>( std::ceil( mCurrentRange.upper() * mSliderPrecision ) );
-  if ( snappedLower == mSlider->lowerValue() && snappedUpper == mSlider->upperValue() )
-    return mCurrentRange;
-
-  const QgsDoubleRange sliderRange( mSlider->lowerValue() / mSliderPrecision, mSlider->upperValue() / mSliderPrecision );
-  if ( mFixedRangeSize >= 0 )
-  {
-    // adjust range so that it has exactly the fixed width (given slider int precision the slider range
-    // will not have the exact fixed width)
-    if ( sliderRange.upper() + mFixedRangeSize <= mRangeLimits.upper() )
-      return QgsDoubleRange( sliderRange.lower(), sliderRange.lower() + mFixedRangeSize );
-    else
-      return QgsDoubleRange( sliderRange.upper() - mFixedRangeSize, sliderRange.upper() );
-  }
-  else
-  {
-    return sliderRange;
-  }
+  return mCurrentRange;
 }
 
 QgsDoubleRange QgsElevationControllerWidget::rangeLimits() const
@@ -255,14 +237,15 @@ void QgsElevationControllerWidget::setLimitsFromRange( const QgsDoubleRange &ran
 
 void QgsElevationControllerWidget::setRange( const QgsDoubleRange &range )
 {
-  if ( range == mCurrentRange )
+  const QgsDoubleRange newRange = mFixedRangeSize >= 0 ? fixedSizeRangeFrom( range.lower() ) : range;
+  if ( newRange == mCurrentRange )
     return;
 
-  mCurrentRange = range;
+  mCurrentRange = newRange;
   mBlockSliderChanges = true;
-  mSlider->setRange( static_cast<int>( std::floor( range.lower() * mSliderPrecision ) ), static_cast<int>( std::ceil( range.upper() * mSliderPrecision ) ) );
+  mSlider->setRange( static_cast<int>( std::floor( mCurrentRange.lower() * mSliderPrecision ) ), static_cast<int>( std::ceil( mCurrentRange.upper() * mSliderPrecision ) ) );
   mBlockSliderChanges = false;
-  emit rangeChanged( range );
+  emit rangeChanged( mCurrentRange );
 
   mSliderLabels->setRange( mCurrentRange );
 }
@@ -298,8 +281,9 @@ void QgsElevationControllerWidget::setRangeLimits( const QgsDoubleRange &limits 
   if ( mFixedRangeSize >= 0 )
   {
     // a locked size is kept, the range moves inside the new limits instead of being clipped
-    newCurrentUpper = std::min( newCurrentLower + mFixedRangeSize, limits.upper() );
-    newCurrentLower = std::max( newCurrentUpper - mFixedRangeSize, limits.lower() );
+    const QgsDoubleRange fitted = fixedSizeRangeFrom( newCurrentLower );
+    newCurrentLower = fitted.lower();
+    newCurrentUpper = fitted.upper();
   }
   const bool rangeHasChanged = newCurrentLower != mCurrentRange.lower() || newCurrentUpper != mCurrentRange.upper();
 
@@ -320,31 +304,20 @@ void QgsElevationControllerWidget::setRangeLimits( const QgsDoubleRange &limits 
 
 QgsDoubleRange QgsElevationControllerWidget::snappedRange( const QgsDoubleRange &range ) const
 {
-  if ( mSnapInterval <= 0 )
-    return range;
+  const double lower = snapValue( range.lower() );
 
-  double lower = snapValue( range.lower() );
-  double upper;
+  // snapping must not alter the locked range size
   if ( mFixedRangeSize >= 0 )
-  {
-    // snapping must not alter the locked range size
-    upper = lower + mFixedRangeSize;
-    if ( upper > mRangeLimits.upper() )
-    {
-      upper = mRangeLimits.upper();
-      lower = upper - mFixedRangeSize;
-    }
-  }
-  else
-  {
-    upper = std::max( snapValue( range.upper() ), lower );
-  }
+    return fixedSizeRangeFrom( lower );
 
-  return QgsDoubleRange( lower, upper );
+  return QgsDoubleRange( lower, std::max( snapValue( range.upper() ), lower ) );
 }
 
 double QgsElevationControllerWidget::snapValue( double value ) const
 {
+  if ( mSnapInterval <= 0 )
+    return std::clamp( value, mRangeLimits.lower(), mRangeLimits.upper() );
+
   double snapped = std::round( value / mSnapInterval ) * mSnapInterval;
   if ( mSnapDecimals > 0 )
   {
@@ -360,6 +333,23 @@ double QgsElevationControllerWidget::snapValue( double value ) const
   }
 
   return std::clamp( snapped, mRangeLimits.lower(), mRangeLimits.upper() );
+}
+
+QgsDoubleRange QgsElevationControllerWidget::sliderRange() const
+{
+  return QgsDoubleRange( mSlider->lowerValue() / mSliderPrecision, mSlider->upperValue() / mSliderPrecision );
+}
+
+QgsDoubleRange QgsElevationControllerWidget::fixedSizeRangeFrom( double lower ) const
+{
+  double upper = lower + mFixedRangeSize;
+  if ( upper > mRangeLimits.upper() )
+  {
+    upper = mRangeLimits.upper();
+    lower = std::max( upper - mFixedRangeSize, mRangeLimits.lower() );
+  }
+
+  return QgsDoubleRange( lower, upper );
 }
 
 void QgsElevationControllerWidget::updateWidgetMask()

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -30,7 +30,6 @@
 #include "qgsrange.h"
 #include "qgsrangeslider.h"
 
-#include <QCheckBox>
 #include <QEvent>
 #include <QHBoxLayout>
 #include <QKeyEvent>
@@ -65,6 +64,10 @@ QgsElevationControllerWidget::QgsElevationControllerWidget( QWidget *parent )
 
   mSettingsAction = new QgsElevationControllerSettingsAction( mMenu );
   mMenu->addAction( mSettingsAction );
+
+  mInvertDirectionAction = new QAction( tr( "Invert Direction" ), this );
+  mInvertDirectionAction->setCheckable( true );
+  mMenu->addAction( mInvertDirectionAction );
 
   QMenu *limitsMenu = mSettingsAction->limitsMenu();
 
@@ -155,7 +158,7 @@ QgsElevationControllerWidget::QgsElevationControllerWidget( QWidget *parent )
     mSettingsAction->updateRangeSize( range().upper() - range().lower() );
   } );
 
-  connect( mSettingsAction, &QgsElevationControllerSettingsAction::invertedChanged, this, [this]( bool inverted ) {
+  connect( mInvertDirectionAction, &QAction::toggled, this, [this]( bool inverted ) {
     mSlider->setFlippedDirection( !inverted );
     mSliderLabels->setInverted( inverted );
 
@@ -400,7 +403,7 @@ void QgsElevationControllerWidget::setFixedRangeSize( double size )
 
 void QgsElevationControllerWidget::setInverted( bool inverted )
 {
-  mSettingsAction->setInverted( inverted );
+  mInvertDirectionAction->setChecked( inverted );
 }
 
 void QgsElevationControllerWidget::setSignificantElevations( const QList<double> &elevations )
@@ -617,6 +620,9 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
 
   gLayout->addWidget( mLowerSpin, 0, 1 );
 
+  QLabel *toLabel = new QLabel( tr( "to" ) );
+  gLayout->addWidget( toLabel, 0, 2 );
+
   mUpperSpin = new QgsDoubleSpinBox();
   mUpperSpin->setDecimals( 4 );
   mUpperSpin->setMinimum( -999999999.0 );
@@ -625,7 +631,7 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
   mUpperSpin->setKeyboardTracking( false );
   mUpperSpin->setToolTip( tr( "Highest elevation which can be selected" ) );
 
-  gLayout->addWidget( mUpperSpin, 0, 2 );
+  gLayout->addWidget( mUpperSpin, 0, 3 );
 
   mLimitsButton = new QToolButton();
   mLimitsButton->setIcon( QgsApplication::getThemeIcon( u"/mActionRefresh.svg"_s ) );
@@ -634,7 +640,7 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
   mLimitsMenu = new QMenu( mLimitsButton );
   mLimitsButton->setMenu( mLimitsMenu );
 
-  gLayout->addWidget( mLimitsButton, 0, 3 );
+  gLayout->addWidget( mLimitsButton, 0, 4 );
 
   const QString rangeToolTip = tr(
     "Size of the elevation range shown in the map, i.e. the difference between "
@@ -654,19 +660,18 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
   mSizeSpin->setKeyboardTracking( false );
   mSizeSpin->setToolTip( rangeToolTip );
 
-  gLayout->addWidget( mSizeSpin, 1, 1, 1, 2 );
+  gLayout->addWidget( mSizeSpin, 1, 1, 1, 3 );
 
   mLockButton = new QToolButton();
   mLockButton->setIcon( QgsApplication::getThemeIcon( u"/cadtools/lock.svg"_s ) );
   mLockButton->setCheckable( true );
   mLockButton->setToolTip( tr( "Lock the elevation range to a fixed size" ) );
 
-  gLayout->addWidget( mLockButton, 1, 3 );
+  gLayout->addWidget( mLockButton, 1, 4 );
 
-  mInvertCheckBox = new QCheckBox( tr( "Invert direction" ) );
-  mInvertCheckBox->setToolTip( tr( "Invert the direction of the elevation slider" ) );
-
-  gLayout->addWidget( mInvertCheckBox, 2, 0, 1, 4 );
+  // the spin boxes take the extra width, not the labels or the buttons
+  gLayout->setColumnStretch( 1, 1 );
+  gLayout->setColumnStretch( 3, 1 );
 
   const auto emitLimits = [this] { emit limitsChanged( QgsDoubleRange( mLowerSpin->value(), mUpperSpin->value() ) ); };
   connect( mLowerSpin, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, emitLimits );
@@ -684,8 +689,6 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
     }
   } );
   connect( mLockButton, &QToolButton::toggled, this, [this]( bool locked ) { emit fixedRangeSizeChanged( locked ? mSizeSpin->value() : -1 ); } );
-
-  connect( mInvertCheckBox, &QCheckBox::toggled, this, &QgsElevationControllerSettingsAction::invertedChanged );
 
   QWidget *w = new QWidget();
   w->setLayout( gLayout );
@@ -740,12 +743,6 @@ void QgsElevationControllerSettingsAction::updateRangeSize( double size )
 
   const QSignalBlocker blockSpin( mSizeSpin );
   mSizeSpin->setValue( size );
-}
-
-void QgsElevationControllerSettingsAction::setInverted( bool inverted )
-{
-  // not blocked, the widget follows the checkbox through invertedChanged()
-  mInvertCheckBox->setChecked( inverted );
 }
 
 bool QgsElevationControllerSettingsAction::eventFilter( QObject *watched, QEvent *event )

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -134,8 +134,19 @@ QgsElevationControllerWidget::QgsElevationControllerWidget( QWidget *parent )
     if ( mBlockSliderChanges )
       return;
 
-    emit rangeChanged( range() );
-    mSliderLabels->setRange( range() );
+    const QgsDoubleRange snapped = snappedRange( range() );
+
+    // move the handles onto the snapped values
+    mBlockSliderChanges++;
+    mSlider->setRange( static_cast<int>( std::floor( snapped.lower() * mSliderPrecision ) ), static_cast<int>( std::ceil( snapped.upper() * mSliderPrecision ) ) );
+    mBlockSliderChanges--;
+
+    if ( snapped == mCurrentRange )
+      return;
+
+    mCurrentRange = snapped;
+    emit rangeChanged( mCurrentRange );
+    mSliderLabels->setRange( mCurrentRange );
   } );
 
   connect( mMenu, &QMenu::aboutToShow, this, [this]() {
@@ -257,6 +268,11 @@ void QgsElevationControllerWidget::setRangeLimits( const QgsDoubleRange &limits 
   // pick a reasonable slider precision, given that the slider operates in integer values only
   mSliderPrecision = std::max( 1000, mSlider->height() ) / limitRange;
 
+  // snap the slider to a tenth of the interval used to round elevation ranges, so that dragging
+  // stays smooth while still selecting round values
+  mSnapInterval = QgsMathUtils::roundingInterval( limitRange, 100 );
+  mSnapDecimals = mSnapInterval > 0 ? std::max( 0, -static_cast<int>( std::floor( std::log10( mSnapInterval ) ) ) ) : 0;
+
   mBlockSliderChanges = true;
   mSlider->setRangeLimits( static_cast<int>( std::floor( limits.lower() * mSliderPrecision ) ), static_cast<int>( std::ceil( limits.upper() * mSliderPrecision ) ) );
 
@@ -272,6 +288,50 @@ void QgsElevationControllerWidget::setRangeLimits( const QgsDoubleRange &limits 
     emit rangeChanged( mCurrentRange );
 
   mSliderLabels->setLimits( mRangeLimits );
+}
+
+QgsDoubleRange QgsElevationControllerWidget::snappedRange( const QgsDoubleRange &range ) const
+{
+  if ( mSnapInterval <= 0 )
+    return range;
+
+  double lower = snapValue( range.lower() );
+  double upper;
+  if ( mFixedRangeSize >= 0 )
+  {
+    // snapping must not alter the locked range size
+    upper = lower + mFixedRangeSize;
+    if ( upper > mRangeLimits.upper() )
+    {
+      upper = mRangeLimits.upper();
+      lower = upper - mFixedRangeSize;
+    }
+  }
+  else
+  {
+    upper = std::max( snapValue( range.upper() ), lower );
+  }
+
+  return QgsDoubleRange( lower, upper );
+}
+
+double QgsElevationControllerWidget::snapValue( double value ) const
+{
+  double snapped = std::round( value / mSnapInterval ) * mSnapInterval;
+  if ( mSnapDecimals > 0 )
+  {
+    // strip the noise the multiplication above leaves in fractional values
+    snapped = qgsRound( snapped, mSnapDecimals );
+  }
+
+  // an elevation which is significant for the layers is a better snapping target than a round value
+  for ( double elevation : mSignificantElevations )
+  {
+    if ( std::fabs( elevation - value ) < std::fabs( snapped - value ) )
+      snapped = elevation;
+  }
+
+  return std::clamp( snapped, mRangeLimits.lower(), mRangeLimits.upper() );
 }
 
 void QgsElevationControllerWidget::updateWidgetMask()
@@ -320,6 +380,7 @@ void QgsElevationControllerWidget::setInverted( bool inverted )
 
 void QgsElevationControllerWidget::setSignificantElevations( const QList<double> &elevations )
 {
+  mSignificantElevations = elevations;
   mSliderLabels->setSignificantElevations( elevations );
 }
 

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -23,6 +23,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsmaplayer.h"
 #include "qgsmaplayerelevationproperties.h"
+#include "qgsmathutils.h"
 #include "qgsproject.h"
 #include "qgsprojectelevationproperties.h"
 #include "qgsrange.h"
@@ -224,8 +225,9 @@ void QgsElevationControllerWidget::setLimitsFromRange( const QgsDoubleRange &ran
   if ( range.isInfinite() || range.isEmpty() )
     return;
 
-  setRangeLimits( range );
-  setRange( range );
+  const QgsDoubleRange rounded = QgsMathUtils::roundedRange( range );
+  setRangeLimits( rounded );
+  setRange( rounded );
 }
 
 void QgsElevationControllerWidget::setRange( const QgsDoubleRange &range )

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -573,6 +573,7 @@ void QgsElevationControllerLabels::setSignificantElevations( const QList<double>
 
 QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWidget *parent )
   : QWidgetAction( parent )
+  , mMenu( qobject_cast<QMenu *>( parent ) )
 {
   QGridLayout *gLayout = new QGridLayout();
   gLayout->setContentsMargins( 3, 2, 3, 2 );
@@ -627,7 +628,6 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
   mSizeSpin->setClearValue( 0, tr( "Full Range" ) );
   mSizeSpin->setKeyboardTracking( false );
   mSizeSpin->setToolTip( rangeToolTip );
-  mSizeSpin->installEventFilter( this );
 
   gLayout->addWidget( mSizeSpin, 1, 1, 1, 2 );
 
@@ -664,6 +664,16 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
 
   QWidget *w = new QWidget();
   w->setLayout( gLayout );
+
+  // watch the whole panel, so that hovering any of its widgets marks this action as the
+  // active one and key presses are never handed over to the menu
+  w->installEventFilter( this );
+  const QList<QWidget *> children = w->findChildren<QWidget *>();
+  for ( QWidget *child : children )
+    child->installEventFilter( this );
+
+  connect( this, &QAction::hovered, this, &QgsElevationControllerSettingsAction::onHover );
+
   setDefaultWidget( w );
 }
 
@@ -715,17 +725,51 @@ void QgsElevationControllerSettingsAction::setInverted( bool inverted )
 
 bool QgsElevationControllerSettingsAction::eventFilter( QObject *watched, QEvent *event )
 {
-  if ( watched == mSizeSpin && event->type() == QEvent::KeyPress )
+  switch ( event->type() )
   {
-    const QKeyEvent *keyEvent = static_cast<QKeyEvent *>( event );
-    if ( keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter )
+    case QEvent::Enter:
+      onHover();
+      break;
+
+    case QEvent::KeyPress:
     {
-      mSizeSpin->interpretText();
-      if ( !mSizeSpin->isCleared() )
-        mLockButton->setChecked( true );
+      const QKeyEvent *keyEvent = static_cast<QKeyEvent *>( event );
+      if ( keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter )
+      {
+        // spin boxes leave the return key for their parents to handle, which would make the
+        // menu activate its highlighted action and close. Apply the typed value ourselves instead.
+        QgsDoubleSpinBox *spin = qobject_cast<QgsDoubleSpinBox *>( watched );
+        if ( !spin )
+          spin = qobject_cast<QgsDoubleSpinBox *>( watched->parent() );
+
+        if ( spin )
+        {
+          spin->interpretText();
+          if ( spin == mSizeSpin && !mSizeSpin->isCleared() )
+            mLockButton->setChecked( true );
+          return true;
+        }
+      }
+      break;
     }
+
+    default:
+      break;
   }
   return QWidgetAction::eventFilter( watched, event );
+}
+
+void QgsElevationControllerSettingsAction::onHover()
+{
+  // see https://bugreports.qt.io/browse/QTBUG-10427
+  // the menu keeps highlighting the action the mouse last passed over, and would trigger it
+  // when the user hits enter while interacting with this widget
+  if ( mSuppressRecurse || !mMenu )
+    return;
+
+  mSuppressRecurse = true;
+  mMenu->setActiveAction( this );
+  mSuppressRecurse = false;
 }
 
 ///@endcond PRIVATE

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -276,9 +276,19 @@ void QgsElevationControllerWidget::setRangeLimits( const QgsDoubleRange &limits 
   mBlockSliderChanges = true;
   mSlider->setRangeLimits( static_cast<int>( std::floor( limits.lower() * mSliderPrecision ) ), static_cast<int>( std::ceil( limits.upper() * mSliderPrecision ) ) );
 
+  // the slider holds the fixed size in its own integer units, which the new precision changed
+  if ( mFixedRangeSize >= 0 )
+    mSlider->setFixedRangeSize( static_cast<int>( std::round( mFixedRangeSize * mSliderPrecision ) ) );
+
   // clip current range to fit limits
-  const double newCurrentLower = std::max( mCurrentRange.lower(), limits.lower() );
-  const double newCurrentUpper = std::min( mCurrentRange.upper(), limits.upper() );
+  double newCurrentLower = std::max( mCurrentRange.lower(), limits.lower() );
+  double newCurrentUpper = std::min( mCurrentRange.upper(), limits.upper() );
+  if ( mFixedRangeSize >= 0 )
+  {
+    // a locked size is kept, the range moves inside the new limits instead of being clipped
+    newCurrentUpper = std::min( newCurrentLower + mFixedRangeSize, limits.upper() );
+    newCurrentLower = std::max( newCurrentUpper - mFixedRangeSize, limits.lower() );
+  }
   const bool rangeHasChanged = newCurrentLower != mCurrentRange.lower() || newCurrentUpper != mCurrentRange.upper();
 
   mSlider->setRange( static_cast<int>( std::floor( newCurrentLower * mSliderPrecision ) ), static_cast<int>( std::ceil( newCurrentUpper * mSliderPrecision ) ) );

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -19,13 +19,19 @@
 
 #include "qgsapplication.h"
 #include "qgsdoublespinbox.h"
+#include "qgselevationutils.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaplayer.h"
+#include "qgsmaplayerelevationproperties.h"
 #include "qgsproject.h"
 #include "qgsprojectelevationproperties.h"
 #include "qgsrange.h"
 #include "qgsrangeslider.h"
 
+#include <QCheckBox>
 #include <QEvent>
 #include <QHBoxLayout>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QMenu>
 #include <QMouseEvent>
@@ -57,14 +63,45 @@ QgsElevationControllerWidget::QgsElevationControllerWidget( QWidget *parent )
 
   mSettingsAction = new QgsElevationControllerSettingsAction( mMenu );
   mMenu->addAction( mSettingsAction );
-  mInvertDirectionAction = new QAction( tr( "Invert Direction" ), this );
-  mInvertDirectionAction->setCheckable( true );
-  mMenu->addAction( mInvertDirectionAction );
 
-  mSettingsAction->sizeSpin()->clear();
-  connect( mSettingsAction->sizeSpin(), qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, [this]( double size ) { setFixedRangeSize( size < 0 ? -1 : size ); } );
+  QMenu *limitsMenu = mSettingsAction->limitsMenu();
 
-  mMenu->addSeparator();
+  QAction *limitsFromProjectRangeAction = limitsMenu->addAction( tr( "Project Elevation Range" ) );
+  connect( limitsFromProjectRangeAction, &QAction::triggered, this, [this] {
+    const QgsDoubleRange range = QgsProject::instance()->elevationProperties()->elevationRange();
+    if ( range.isInfinite() )
+      return;
+
+    // an explicitly configured range is applied as it is
+    setRangeLimits( range );
+    setRange( range );
+  } );
+
+  QAction *limitsFromProjectLayersAction = limitsMenu->addAction( tr( "Project Layers" ) );
+  connect( limitsFromProjectLayersAction, &QAction::triggered, this, [this] { setLimitsFromRange( QgsElevationUtils::calculateZRangeForProject( QgsProject::instance() ) ); } );
+
+  QAction *limitsFromCurrentLayerAction = limitsMenu->addAction( tr( "Current Layer" ) );
+  connect( limitsFromCurrentLayerAction, &QAction::triggered, this, [this] {
+    if ( mMapCanvas )
+      setLimitsFromRange( QgsElevationUtils::calculateZRangeForLayers( { mMapCanvas->currentLayer() } ) );
+  } );
+
+  // the project and the current layer change at any time, so refresh availability when the menu opens
+  connect( limitsMenu, &QMenu::aboutToShow, this, [this, limitsFromProjectRangeAction, limitsFromProjectLayersAction, limitsFromCurrentLayerAction] {
+    limitsFromProjectRangeAction->setEnabled( !QgsProject::instance()->elevationProperties()->elevationRange().isInfinite() );
+
+    const QMap<QString, QgsMapLayer *> projectLayers = QgsProject::instance()->mapLayers();
+    limitsFromProjectLayersAction->setEnabled( std::any_of( projectLayers.begin(), projectLayers.end(), []( QgsMapLayer *layer ) { return layerHasElevation( layer ); } ) );
+
+    limitsFromCurrentLayerAction->setEnabled( mMapCanvas && layerHasElevation( mMapCanvas->currentLayer() ) );
+  } );
+
+  connect( mSettingsAction, &QgsElevationControllerSettingsAction::limitsChanged, this, &QgsElevationControllerWidget::setRangeLimits );
+  connect( mSettingsAction, &QgsElevationControllerSettingsAction::fixedRangeSizeChanged, this, &QgsElevationControllerWidget::setFixedRangeSize );
+  connect( mSettingsAction, &QgsElevationControllerSettingsAction::fullRangeRequested, this, [this] {
+    setRange( rangeLimits() );
+    mSettingsAction->updateRangeSize( rangeLimits().upper() - rangeLimits().lower() );
+  } );
 
   mSlider = new QgsRangeSlider( Qt::Vertical );
   mSlider->setFlippedDirection( true );
@@ -100,11 +137,16 @@ QgsElevationControllerWidget::QgsElevationControllerWidget( QWidget *parent )
     mSliderLabels->setRange( range() );
   } );
 
-  connect( mInvertDirectionAction, &QAction::toggled, this, [this]() {
-    mSlider->setFlippedDirection( !mInvertDirectionAction->isChecked() );
-    mSliderLabels->setInverted( mInvertDirectionAction->isChecked() );
+  connect( mMenu, &QMenu::aboutToShow, this, [this]() {
+    mSettingsAction->setLimits( mRangeLimits );
+    mSettingsAction->updateRangeSize( range().upper() - range().lower() );
+  } );
 
-    emit invertedChanged( mInvertDirectionAction->isChecked() );
+  connect( mSettingsAction, &QgsElevationControllerSettingsAction::invertedChanged, this, [this]( bool inverted ) {
+    mSlider->setFlippedDirection( !inverted );
+    mSliderLabels->setInverted( inverted );
+
+    emit invertedChanged( inverted );
   } );
 
   // default initial value to full range
@@ -157,6 +199,30 @@ QMenu *QgsElevationControllerWidget::menu()
   return mMenu;
 }
 
+QgsMapCanvas *QgsElevationControllerWidget::mapCanvas() const
+{
+  return mMapCanvas;
+}
+
+void QgsElevationControllerWidget::setMapCanvas( QgsMapCanvas *canvas )
+{
+  mMapCanvas = canvas;
+}
+
+bool QgsElevationControllerWidget::layerHasElevation( QgsMapLayer *layer )
+{
+  return layer && layer->elevationProperties() && layer->elevationProperties()->hasElevation();
+}
+
+void QgsElevationControllerWidget::setLimitsFromRange( const QgsDoubleRange &range )
+{
+  if ( range.isInfinite() || range.isEmpty() )
+    return;
+
+  setRangeLimits( range );
+  setRange( range );
+}
+
 void QgsElevationControllerWidget::setRange( const QgsDoubleRange &range )
 {
   if ( range == mCurrentRange )
@@ -173,10 +239,11 @@ void QgsElevationControllerWidget::setRange( const QgsDoubleRange &range )
 
 void QgsElevationControllerWidget::setRangeLimits( const QgsDoubleRange &limits )
 {
-  if ( limits.isInfinite() )
+  if ( limits.isInfinite() || limits.upper() <= limits.lower() )
     return;
 
   mRangeLimits = limits;
+  mSettingsAction->setLimits( mRangeLimits );
 
   const double limitRange = limits.upper() - limits.lower();
 
@@ -233,14 +300,15 @@ void QgsElevationControllerWidget::setFixedRangeSize( double size )
   {
     mSlider->setFixedRangeSize( static_cast<int>( std::round( mFixedRangeSize * mSliderPrecision ) ) );
   }
-  if ( mFixedRangeSize != mSettingsAction->sizeSpin()->value() )
-    mSettingsAction->sizeSpin()->setValue( mFixedRangeSize );
+
+  mSettingsAction->setFixedRangeSize( mFixedRangeSize );
+
   emit fixedRangeSizeChanged( mFixedRangeSize );
 }
 
 void QgsElevationControllerWidget::setInverted( bool inverted )
 {
-  mInvertDirectionAction->setChecked( inverted );
+  mSettingsAction->setInverted( inverted );
 }
 
 void QgsElevationControllerWidget::setSignificantElevations( const QList<double> &elevations )
@@ -441,27 +509,155 @@ QgsElevationControllerSettingsAction::QgsElevationControllerSettingsAction( QWid
   QGridLayout *gLayout = new QGridLayout();
   gLayout->setContentsMargins( 3, 2, 3, 2 );
 
-  QLabel *label = new QLabel( tr( "Fixed Range Size" ) );
-  gLayout->addWidget( label, 0, 0 );
+  QLabel *limitsLabel = new QLabel( tr( "Limits" ) );
+  limitsLabel->setToolTip( tr( "Lowest and highest elevations which can be selected with the slider" ) );
+  gLayout->addWidget( limitsLabel, 0, 0 );
+
+  mLowerSpin = new QgsDoubleSpinBox();
+  mLowerSpin->setDecimals( 4 );
+  mLowerSpin->setMinimum( -999999999.0 );
+  mLowerSpin->setMaximum( 999999999.0 );
+  mLowerSpin->setShowClearButton( false );
+  mLowerSpin->setKeyboardTracking( false );
+  mLowerSpin->setToolTip( tr( "Lowest elevation which can be selected" ) );
+
+  gLayout->addWidget( mLowerSpin, 0, 1 );
+
+  mUpperSpin = new QgsDoubleSpinBox();
+  mUpperSpin->setDecimals( 4 );
+  mUpperSpin->setMinimum( -999999999.0 );
+  mUpperSpin->setMaximum( 999999999.0 );
+  mUpperSpin->setShowClearButton( false );
+  mUpperSpin->setKeyboardTracking( false );
+  mUpperSpin->setToolTip( tr( "Highest elevation which can be selected" ) );
+
+  gLayout->addWidget( mUpperSpin, 0, 2 );
+
+  mLimitsButton = new QToolButton();
+  mLimitsButton->setIcon( QgsApplication::getThemeIcon( u"/mActionRefresh.svg"_s ) );
+  mLimitsButton->setPopupMode( QToolButton::InstantPopup );
+  mLimitsButton->setToolTip( tr( "Set the elevation limits from a predefined source" ) );
+  mLimitsMenu = new QMenu( mLimitsButton );
+  mLimitsButton->setMenu( mLimitsMenu );
+
+  gLayout->addWidget( mLimitsButton, 0, 3 );
+
+  const QString rangeToolTip = tr(
+    "Size of the elevation range shown in the map, i.e. the difference between "
+    "the upper and the lower handle of the slider. Lock it to keep this size while "
+    "moving the slider, or clear it to show the full range."
+  );
+
+  QLabel *rangeLabel = new QLabel( tr( "Range" ) );
+  rangeLabel->setToolTip( rangeToolTip );
+  gLayout->addWidget( rangeLabel, 1, 0 );
 
   mSizeSpin = new QgsDoubleSpinBox();
   mSizeSpin->setDecimals( 4 );
-  mSizeSpin->setMinimum( -1.0 );
+  mSizeSpin->setMinimum( 0.0 );
   mSizeSpin->setMaximum( 999999999.0 );
-  mSizeSpin->setClearValue( -1, tr( "Not set" ) );
+  mSizeSpin->setClearValue( 0, tr( "Full Range" ) );
   mSizeSpin->setKeyboardTracking( false );
-  mSizeSpin->setToolTip( tr( "Limit elevation range to a fixed size" ) );
+  mSizeSpin->setToolTip( rangeToolTip );
+  mSizeSpin->installEventFilter( this );
 
-  gLayout->addWidget( mSizeSpin, 0, 1 );
+  gLayout->addWidget( mSizeSpin, 1, 1, 1, 2 );
+
+  mLockButton = new QToolButton();
+  mLockButton->setIcon( QgsApplication::getThemeIcon( u"/cadtools/lock.svg"_s ) );
+  mLockButton->setCheckable( true );
+  mLockButton->setToolTip( tr( "Lock the elevation range to a fixed size" ) );
+
+  gLayout->addWidget( mLockButton, 1, 3 );
+
+  mInvertCheckBox = new QCheckBox( tr( "Invert direction" ) );
+  mInvertCheckBox->setToolTip( tr( "Invert the direction of the elevation slider" ) );
+
+  gLayout->addWidget( mInvertCheckBox, 2, 0, 1, 4 );
+
+  const auto emitLimits = [this] { emit limitsChanged( QgsDoubleRange( mLowerSpin->value(), mUpperSpin->value() ) ); };
+  connect( mLowerSpin, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, emitLimits );
+  connect( mUpperSpin, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, emitLimits );
+
+  connect( mSizeSpin, qOverload<double>( &QgsDoubleSpinBox::valueChanged ), this, [this]( double size ) {
+    if ( mSizeSpin->isCleared() )
+    {
+      emit fixedRangeSizeChanged( -1 );
+      emit fullRangeRequested();
+    }
+    else if ( mLockButton->isChecked() )
+    {
+      emit fixedRangeSizeChanged( size );
+    }
+  } );
+  connect( mLockButton, &QToolButton::toggled, this, [this]( bool locked ) { emit fixedRangeSizeChanged( locked ? mSizeSpin->value() : -1 ); } );
+
+  connect( mInvertCheckBox, &QCheckBox::toggled, this, &QgsElevationControllerSettingsAction::invertedChanged );
 
   QWidget *w = new QWidget();
   w->setLayout( gLayout );
   setDefaultWidget( w );
 }
 
-QgsDoubleSpinBox *QgsElevationControllerSettingsAction::sizeSpin()
+QMenu *QgsElevationControllerSettingsAction::limitsMenu()
 {
-  return mSizeSpin;
+  return mLimitsMenu;
+}
+
+void QgsElevationControllerSettingsAction::setLimits( const QgsDoubleRange &limits )
+{
+  const QSignalBlocker blockLower( mLowerSpin );
+  const QSignalBlocker blockUpper( mUpperSpin );
+  // the limits can always be widened, but never crossed over
+  mLowerSpin->setMaximum( limits.upper() );
+  mUpperSpin->setMinimum( limits.lower() );
+  mLowerSpin->setValue( limits.lower() );
+  mUpperSpin->setValue( limits.upper() );
+}
+
+void QgsElevationControllerSettingsAction::setFixedRangeSize( double size )
+{
+  {
+    const QSignalBlocker blockLock( mLockButton );
+    mLockButton->setChecked( size >= 0 );
+  }
+
+  if ( size >= 0 )
+  {
+    const QSignalBlocker blockSpin( mSizeSpin );
+    mSizeSpin->setValue( size );
+  }
+}
+
+void QgsElevationControllerSettingsAction::updateRangeSize( double size )
+{
+  // a locked size is the one the user asked for, it must not be overwritten
+  if ( mLockButton->isChecked() )
+    return;
+
+  const QSignalBlocker blockSpin( mSizeSpin );
+  mSizeSpin->setValue( size );
+}
+
+void QgsElevationControllerSettingsAction::setInverted( bool inverted )
+{
+  // not blocked, the widget follows the checkbox through invertedChanged()
+  mInvertCheckBox->setChecked( inverted );
+}
+
+bool QgsElevationControllerSettingsAction::eventFilter( QObject *watched, QEvent *event )
+{
+  if ( watched == mSizeSpin && event->type() == QEvent::KeyPress )
+  {
+    const QKeyEvent *keyEvent = static_cast<QKeyEvent *>( event );
+    if ( keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter )
+    {
+      mSizeSpin->interpretText();
+      if ( !mSizeSpin->isCleared() )
+        mLockButton->setChecked( true );
+    }
+  }
+  return QWidgetAction::eventFilter( watched, event );
 }
 
 ///@endcond PRIVATE

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -207,6 +207,11 @@ QgsMapCanvas *QgsElevationControllerWidget::mapCanvas() const
 void QgsElevationControllerWidget::setMapCanvas( QgsMapCanvas *canvas )
 {
   mMapCanvas = canvas;
+
+  // a project which defines no elevation range of its own leaves the widget with a guessed
+  // range, the canvas layers give a usable one instead
+  if ( mMapCanvas && QgsProject::instance()->elevationProperties()->elevationRange().isInfinite() )
+    setLimitsFromRange( QgsElevationUtils::calculateZRangeForLayers( mMapCanvas->layers( true ) ) );
 }
 
 bool QgsElevationControllerWidget::layerHasElevation( QgsMapLayer *layer )

--- a/src/gui/elevation/qgselevationcontrollerwidget.cpp
+++ b/src/gui/elevation/qgselevationcontrollerwidget.cpp
@@ -285,9 +285,15 @@ void QgsElevationControllerWidget::setRangeLimits( const QgsDoubleRange &limits 
   mCurrentRange = QgsDoubleRange( newCurrentLower, newCurrentUpper );
   mBlockSliderChanges = false;
   if ( rangeHasChanged )
+  {
     emit rangeChanged( mCurrentRange );
 
+    // the selected range was clipped by the new limits, so the range size shown in the menu is stale
+    mSettingsAction->updateRangeSize( mCurrentRange.upper() - mCurrentRange.lower() );
+  }
+
   mSliderLabels->setLimits( mRangeLimits );
+  mSliderLabels->setRange( mCurrentRange );
 }
 
 QgsDoubleRange QgsElevationControllerWidget::snappedRange( const QgsDoubleRange &range ) const

--- a/src/gui/elevation/qgselevationcontrollerwidget.h
+++ b/src/gui/elevation/qgselevationcontrollerwidget.h
@@ -265,6 +265,15 @@ class GUI_EXPORT QgsElevationControllerWidget : public QWidget
 
     static bool layerHasElevation( QgsMapLayer *layer );
 
+    /**
+     * Snaps a \a range selected through the slider to the round values (and significant
+     * elevations) which the slider snaps to.
+     */
+    QgsDoubleRange snappedRange( const QgsDoubleRange &range ) const;
+
+    //! Snaps a single elevation \a value to the closest snapping target.
+    double snapValue( double value ) const;
+
     QToolButton *mConfigureButton = nullptr;
     QgsElevationControllerSettingsAction *mSettingsAction = nullptr;
     QMenu *mMenu = nullptr;
@@ -273,6 +282,9 @@ class GUI_EXPORT QgsElevationControllerWidget : public QWidget
     QPointer<QgsMapCanvas> mMapCanvas;
     QgsDoubleRange mRangeLimits;
     QgsDoubleRange mCurrentRange;
+    QList<double> mSignificantElevations;
+    double mSnapInterval = 0;
+    int mSnapDecimals = 0;
     double mFixedRangeSize = -1;
     int mBlockSliderChanges = 0;
     double mSliderPrecision = 100;

--- a/src/gui/elevation/qgselevationcontrollerwidget.h
+++ b/src/gui/elevation/qgselevationcontrollerwidget.h
@@ -53,7 +53,7 @@ class GUI_EXPORT QgsElevationControllerLabels : public QWidget SIP_SKIP
     QList<double> mSignificantElevations;
 };
 
-class GUI_EXPORT QgsElevationControllerSettingsAction : public QWidgetAction
+class GUI_EXPORT QgsElevationControllerSettingsAction : public QWidgetAction SIP_SKIP
 {
     Q_OBJECT
 

--- a/src/gui/elevation/qgselevationcontrollerwidget.h
+++ b/src/gui/elevation/qgselevationcontrollerwidget.h
@@ -97,6 +97,10 @@ class GUI_EXPORT QgsElevationControllerSettingsAction : public QWidgetAction SIP
     bool eventFilter( QObject *watched, QEvent *event ) override;
 
   private:
+    void onHover();
+
+    QMenu *mMenu = nullptr;
+    bool mSuppressRecurse = false;
     QgsDoubleSpinBox *mLowerSpin = nullptr;
     QgsDoubleSpinBox *mUpperSpin = nullptr;
     QToolButton *mLimitsButton = nullptr;

--- a/src/gui/elevation/qgselevationcontrollerwidget.h
+++ b/src/gui/elevation/qgselevationcontrollerwidget.h
@@ -273,6 +273,15 @@ class GUI_EXPORT QgsElevationControllerWidget : public QWidget
     //! Snaps a single elevation \a value to the closest snapping target.
     double snapValue( double value ) const;
 
+    //! Returns the elevation range the slider handles currently sit on
+    QgsDoubleRange sliderRange() const;
+
+    /**
+     * Returns the range of the locked fixed size which starts at \a lower, moved down when it
+     * would reach past the upper limit. Only call this with a fixed size locked.
+     */
+    QgsDoubleRange fixedSizeRangeFrom( double lower ) const;
+
     QToolButton *mConfigureButton = nullptr;
     QgsElevationControllerSettingsAction *mSettingsAction = nullptr;
     QMenu *mMenu = nullptr;

--- a/src/gui/elevation/qgselevationcontrollerwidget.h
+++ b/src/gui/elevation/qgselevationcontrollerwidget.h
@@ -30,7 +30,6 @@ class QgsMapCanvas;
 class QgsMapLayer;
 class QgsRangeSlider;
 class QgsDoubleSpinBox;
-class QCheckBox;
 class QToolButton;
 class QMenu;
 
@@ -76,9 +75,6 @@ class GUI_EXPORT QgsElevationControllerSettingsAction : public QWidgetAction SIP
     //! Shows the current range \a size, unless a fixed size is locked
     void updateRangeSize( double size );
 
-    //! Shows whether the elevation slider is inverted
-    void setInverted( bool inverted );
-
   signals:
 
     //! Emitted when the limits are edited
@@ -89,9 +85,6 @@ class GUI_EXPORT QgsElevationControllerSettingsAction : public QWidgetAction SIP
 
     //! Emitted when the range size is cleared, asking for the full range to be shown
     void fullRangeRequested();
-
-    //! Emitted when the invert direction checkbox is toggled
-    void invertedChanged( bool inverted );
 
   protected:
     bool eventFilter( QObject *watched, QEvent *event ) override;
@@ -107,7 +100,6 @@ class GUI_EXPORT QgsElevationControllerSettingsAction : public QWidgetAction SIP
     QMenu *mLimitsMenu = nullptr;
     QgsDoubleSpinBox *mSizeSpin = nullptr;
     QToolButton *mLockButton = nullptr;
-    QCheckBox *mInvertCheckBox = nullptr;
 };
 
 
@@ -284,6 +276,7 @@ class GUI_EXPORT QgsElevationControllerWidget : public QWidget
     QToolButton *mConfigureButton = nullptr;
     QgsElevationControllerSettingsAction *mSettingsAction = nullptr;
     QMenu *mMenu = nullptr;
+    QAction *mInvertDirectionAction = nullptr;
     QgsRangeSlider *mSlider = nullptr;
     QgsElevationControllerLabels *mSliderLabels = nullptr;
     QPointer<QgsMapCanvas> mMapCanvas;

--- a/src/gui/elevation/qgselevationcontrollerwidget.h
+++ b/src/gui/elevation/qgselevationcontrollerwidget.h
@@ -267,6 +267,9 @@ class GUI_EXPORT QgsElevationControllerWidget : public QWidget
     //! Applies a \a range calculated from layer data to both the limits and the current range
     void setLimitsFromRange( const QgsDoubleRange &range );
 
+    //! Applies the elevation range of \a layers
+    void setLimitsFromLayers( const QList<QgsMapLayer *> &layers );
+
     static bool layerHasElevation( QgsMapLayer *layer );
 
     /**

--- a/src/gui/elevation/qgselevationcontrollerwidget.h
+++ b/src/gui/elevation/qgselevationcontrollerwidget.h
@@ -22,11 +22,15 @@
 #include "qgis_sip.h"
 #include "qgsrange.h"
 
+#include <QPointer>
 #include <QWidget>
 #include <QWidgetAction>
 
+class QgsMapCanvas;
+class QgsMapLayer;
 class QgsRangeSlider;
 class QgsDoubleSpinBox;
+class QCheckBox;
 class QToolButton;
 class QMenu;
 
@@ -60,10 +64,46 @@ class GUI_EXPORT QgsElevationControllerSettingsAction : public QWidgetAction SIP
   public:
     QgsElevationControllerSettingsAction( QWidget *parent = nullptr );
 
-    QgsDoubleSpinBox *sizeSpin();
+    //! Returns the menu of the button which takes the limits from a predefined source
+    QMenu *limitsMenu();
+
+    //! Shows \a limits in the limit spin boxes
+    void setLimits( const QgsDoubleRange &limits );
+
+    //! Shows a fixed range \a size and its lock state, -1 for no fixed size
+    void setFixedRangeSize( double size );
+
+    //! Shows the current range \a size, unless a fixed size is locked
+    void updateRangeSize( double size );
+
+    //! Shows whether the elevation slider is inverted
+    void setInverted( bool inverted );
+
+  signals:
+
+    //! Emitted when the limits are edited
+    void limitsChanged( const QgsDoubleRange &limits );
+
+    //! Emitted when a fixed range size is locked or edited, -1 when it is unlocked
+    void fixedRangeSizeChanged( double size );
+
+    //! Emitted when the range size is cleared, asking for the full range to be shown
+    void fullRangeRequested();
+
+    //! Emitted when the invert direction checkbox is toggled
+    void invertedChanged( bool inverted );
+
+  protected:
+    bool eventFilter( QObject *watched, QEvent *event ) override;
 
   private:
+    QgsDoubleSpinBox *mLowerSpin = nullptr;
+    QgsDoubleSpinBox *mUpperSpin = nullptr;
+    QToolButton *mLimitsButton = nullptr;
+    QMenu *mLimitsMenu = nullptr;
     QgsDoubleSpinBox *mSizeSpin = nullptr;
+    QToolButton *mLockButton = nullptr;
+    QCheckBox *mInvertCheckBox = nullptr;
 };
 
 
@@ -123,6 +163,14 @@ class GUI_EXPORT QgsElevationControllerWidget : public QWidget
     QMenu *menu();
 
     /**
+     * Returns the map canvas the widget takes its layers from.
+     *
+     * \see setMapCanvas()
+     * \since QGIS 4.4
+     */
+    QgsMapCanvas *mapCanvas() const;
+
+    /**
      * Returns the fixed range size, or -1 if no fixed size is set.
      *
      * A fixed size forces the selected elevation range to have a matching difference between
@@ -172,6 +220,18 @@ class GUI_EXPORT QgsElevationControllerWidget : public QWidget
      */
     void setSignificantElevations( const QList<double> &elevations );
 
+    /**
+     * Sets the map \a canvas the widget takes its layers from.
+     *
+     * The canvas provides the layer used by the "Current Layer" entry of the range limits
+     * button, and its layers give the initial limits when the project defines no elevation
+     * range of its own.
+     *
+     * \see mapCanvas()
+     * \since QGIS 4.4
+     */
+    void setMapCanvas( QgsMapCanvas *canvas );
+
   signals:
 
     /**
@@ -200,12 +260,17 @@ class GUI_EXPORT QgsElevationControllerWidget : public QWidget
   private:
     void updateWidgetMask();
 
+    //! Applies a \a range calculated from layer data to both the limits and the current range
+    void setLimitsFromRange( const QgsDoubleRange &range );
+
+    static bool layerHasElevation( QgsMapLayer *layer );
+
     QToolButton *mConfigureButton = nullptr;
     QgsElevationControllerSettingsAction *mSettingsAction = nullptr;
     QMenu *mMenu = nullptr;
-    QAction *mInvertDirectionAction = nullptr;
     QgsRangeSlider *mSlider = nullptr;
     QgsElevationControllerLabels *mSliderLabels = nullptr;
+    QPointer<QgsMapCanvas> mMapCanvas;
     QgsDoubleRange mRangeLimits;
     QgsDoubleRange mCurrentRange;
     double mFixedRangeSize = -1;

--- a/tests/src/python/test_qgselevationcontrollerwidget.py
+++ b/tests/src/python/test_qgselevationcontrollerwidget.py
@@ -113,11 +113,40 @@ class TestQgsElevationControllerWidget(QgisTestCase):
             int(w.slider().minimum() + slider_range * 0.4),
             int(w.slider().minimum() + slider_range * 0.7),
         )
+        # slider values are snapped to round values, here multiples of 1
         self.assertEqual(len(spy), 3)
-        self.assertAlmostEqual(spy[-1][0].lower(), 459.644, 3)
-        self.assertAlmostEqual(spy[-1][0].upper(), 729.495, 3)
-        self.assertAlmostEqual(w.range().lower(), 459.644, 3)
-        self.assertAlmostEqual(w.range().upper(), 729.495, 3)
+        self.assertEqual(spy[-1][0], QgsDoubleRange(460, 729))
+        self.assertEqual(w.range(), QgsDoubleRange(460, 729))
+
+    def test_slider_snapping(self):
+        """
+        Slider interaction should snap to round values and to significant elevations
+        """
+        w = QgsElevationControllerWidget()
+        w.setRangeLimits(QgsDoubleRange(0, 1000))
+
+        slider = w.slider()
+
+        def slider_pos(elevation):
+            """slider position matching an elevation, whatever precision the slider uses"""
+            return slider.minimum() + round(
+                elevation * (slider.maximum() - slider.minimum()) / 1000
+            )
+
+        slider.setRange(slider_pos(123), slider_pos(457))
+        # a 0 - 1000 range is rounded to multiples of 100, so the slider snaps to multiples of 10
+        self.assertEqual(w.range(), QgsDoubleRange(120, 460))
+
+        # an elevation which is significant for the layers is a closer snapping target than 120
+        w.setSignificantElevations([123.4])
+        slider.setRange(slider_pos(122), slider_pos(457))
+        self.assertEqual(w.range(), QgsDoubleRange(123.4, 460))
+
+        # a locked range size must not be altered by snapping
+        w.setFixedRangeSize(35.5)
+        slider.setRange(slider_pos(223), slider_pos(457))
+        self.assertAlmostEqual(w.range().lower(), 220, 6)
+        self.assertAlmostEqual(w.range().upper() - w.range().lower(), 35.5, 6)
 
     def testFixedRangeSize(self):
         """

--- a/tests/src/python/test_qgselevationcontrollerwidget.py
+++ b/tests/src/python/test_qgselevationcontrollerwidget.py
@@ -9,7 +9,7 @@ the Free Software Foundation; either version 2 of the License, or
 import unittest
 
 from qgis.core import QgsDoubleRange, QgsProject
-from qgis.gui import QgsElevationControllerWidget
+from qgis.gui import QgsElevationControllerWidget, QgsMapCanvas
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.testing import QgisTestCase, start_app
@@ -67,6 +67,29 @@ class TestQgsElevationControllerWidget(QgisTestCase):
         self.assertEqual(w.rangeLimits(), QgsDoubleRange(171, 815.5))
         self.assertEqual(w.range(), QgsDoubleRange(171, 815.5))
         self.assertEqual(len(spy), 6)
+
+        # zero width or inverted limits => should be ignored
+        w.setRangeLimits(QgsDoubleRange(200, 200))
+        self.assertEqual(w.rangeLimits(), QgsDoubleRange(171, 815.5))
+        w.setRangeLimits(QgsDoubleRange(500, 200))
+        self.assertEqual(w.rangeLimits(), QgsDoubleRange(171, 815.5))
+        self.assertEqual(len(spy), 6)
+
+    def test_map_canvas(self):
+        """
+        The canvas provides the layers the limits entries work on
+        """
+        w = QgsElevationControllerWidget()
+        self.assertIsNone(w.mapCanvas())
+
+        canvas = QgsMapCanvas()
+        w.setMapCanvas(canvas)
+        self.assertEqual(w.mapCanvas(), canvas)
+
+        # a canvas without layers must not alter the limits
+        limits = w.rangeLimits()
+        w.setMapCanvas(canvas)
+        self.assertEqual(w.rangeLimits(), limits)
 
     def test_slider_interaction(self):
         """

--- a/tests/src/python/test_qgselevationcontrollerwidget.py
+++ b/tests/src/python/test_qgselevationcontrollerwidget.py
@@ -183,6 +183,21 @@ class TestQgsElevationControllerWidget(QgisTestCase):
         self.assertAlmostEqual(w.range().lower(), 15, 6)
         self.assertAlmostEqual(w.range().upper(), 25, 6)
 
+    def test_set_range_with_locked_size(self):
+        """
+        A locked size must win over the range passed to setRange
+        """
+        w = QgsElevationControllerWidget()
+        w.setRangeLimits(QgsDoubleRange(0, 1000))
+        w.setFixedRangeSize(10)
+
+        w.setRange(QgsDoubleRange(100, 900))
+        self.assertEqual(w.range(), QgsDoubleRange(100, 110))
+
+        # a range which would reach past the upper limit moves down instead of growing
+        w.setRange(QgsDoubleRange(995, 999))
+        self.assertEqual(w.range(), QgsDoubleRange(990, 1000))
+
     def test_project_interaction(self):
         """
         Test interaction of widget with project

--- a/tests/src/python/test_qgselevationcontrollerwidget.py
+++ b/tests/src/python/test_qgselevationcontrollerwidget.py
@@ -162,6 +162,27 @@ class TestQgsElevationControllerWidget(QgisTestCase):
         w.slider().setLowerValue(50)
         self.assertAlmostEqual(w.range().upper() - w.range().lower(), 10.0001, 6)
 
+    def test_fixed_range_size_with_new_limits(self):
+        """
+        A locked range size must survive a change of the limits
+        """
+        w = QgsElevationControllerWidget()
+        w.setRangeLimits(QgsDoubleRange(0, 100))
+        w.setFixedRangeSize(10)
+        w.setRange(QgsDoubleRange(20, 30))
+        self.assertAlmostEqual(w.range().upper() - w.range().lower(), 10, 6)
+
+        # the slider holds the fixed size in its own integer units, which follow the limits
+        w.setRangeLimits(QgsDoubleRange(0, 1000))
+        self.assertEqual(w.slider().fixedRangeSize(), round(w.slider().maximum() / 100))
+        self.assertAlmostEqual(w.range().upper() - w.range().lower(), 10, 6)
+
+        # limits which no longer fit the range move it instead of shrinking it
+        w.setRange(QgsDoubleRange(20, 30))
+        w.setRangeLimits(QgsDoubleRange(0, 25))
+        self.assertAlmostEqual(w.range().lower(), 15, 6)
+        self.assertAlmostEqual(w.range().upper(), 25, 6)
+
     def test_project_interaction(self):
         """
         Test interaction of widget with project

--- a/tests/src/python/test_qgsmathutils.py
+++ b/tests/src/python/test_qgsmathutils.py
@@ -8,7 +8,7 @@ the Free Software Foundation; either version 2 of the License, or
 
 import unittest
 
-from qgis.core import QgsMathUtils
+from qgis.core import QgsDoubleRange, QgsMathUtils
 from qgis.testing import QgisTestCase
 
 
@@ -57,6 +57,56 @@ class TestQgsMathUtils(QgisTestCase):
 
         self.assertEqual(QgsMathUtils.doubleToRational(3.1415926535), (103993, 33102))
         self.assertEqual(QgsMathUtils.doubleToRational(1.6180339887), (28657, 17711))
+
+    def test_rounding_interval(self):
+        self.assertEqual(QgsMathUtils.roundingInterval(2222), 100)
+        self.assertEqual(QgsMathUtils.roundingInterval(1000), 100)
+        self.assertEqual(QgsMathUtils.roundingInterval(999), 10)
+        self.assertAlmostEqual(QgsMathUtils.roundingInterval(5.55), 0.1, 10)
+        self.assertAlmostEqual(QgsMathUtils.roundingInterval(0.086), 0.001, 10)
+        # a finer grain can be asked for
+        self.assertEqual(QgsMathUtils.roundingInterval(2222, 100), 10)
+        self.assertEqual(QgsMathUtils.roundingInterval(2222, 1000), 1)
+        self.assertEqual(QgsMathUtils.roundingInterval(2222, 1), 1000)
+        self.assertAlmostEqual(QgsMathUtils.roundingInterval(5.55, 100), 0.01, 10)
+
+        # degenerate spans have no interval
+        self.assertEqual(QgsMathUtils.roundingInterval(0), 0)
+        self.assertEqual(QgsMathUtils.roundingInterval(-5), 0)
+        self.assertEqual(QgsMathUtils.roundingInterval(2222, 0), 0)
+
+    def test_rounded_range(self):
+        self.assertEqual(
+            QgsMathUtils.roundedRange(QgsDoubleRange(1234.5, 3456.7)),
+            QgsDoubleRange(1200, 3500),
+        )
+        self.assertEqual(
+            QgsMathUtils.roundedRange(QgsDoubleRange(0, 8848.86)),
+            QgsDoubleRange(0, 8900),
+        )
+        self.assertEqual(
+            QgsMathUtils.roundedRange(QgsDoubleRange(-15.2, 102.7)),
+            QgsDoubleRange(-20, 110),
+        )
+        # fractional ranges should not pick up floating point noise
+        self.assertEqual(
+            QgsMathUtils.roundedRange(QgsDoubleRange(12.34, 17.89)),
+            QgsDoubleRange(12.3, 17.9),
+        )
+        self.assertEqual(
+            QgsMathUtils.roundedRange(QgsDoubleRange(0.0123, 0.0987)),
+            QgsDoubleRange(0.012, 0.099),
+        )
+        # already round values should be left alone
+        self.assertEqual(
+            QgsMathUtils.roundedRange(QgsDoubleRange(100, 500)),
+            QgsDoubleRange(100, 500),
+        )
+        # degenerate ranges are returned unchanged
+        self.assertEqual(
+            QgsMathUtils.roundedRange(QgsDoubleRange(50, 50)), QgsDoubleRange(50, 50)
+        )
+        self.assertTrue(QgsMathUtils.roundedRange(QgsDoubleRange()).isInfinite())
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsrasterlayerelevationproperties.py
+++ b/tests/src/python/test_qgsrasterlayerelevationproperties.py
@@ -403,6 +403,37 @@ class TestQgsRasterLayerElevationProperties(QgisTestCase):
             "@band*2 + 1",
         )
 
+    def test_calculate_z_range_elevation_surface(self):
+        """
+        The elevation range of a surface comes from the statistics of its band
+        """
+        layer = QgsRasterLayer(
+            os.path.join(unitTestDataPath(), "raster/dem.tif"), "dem"
+        )
+        self.assertTrue(layer.isValid())
+
+        props = QgsRasterLayerElevationProperties(layer)
+        self.assertEqual(
+            props.mode(), Qgis.RasterElevationMode.RepresentsElevationSurface
+        )
+        props.setEnabled(True)
+        self.assertEqual(props.calculateZRange(layer), QgsDoubleRange(85, 243))
+
+        # the scale and the offset apply to the statistics
+        props.setZScale(2)
+        props.setZOffset(10)
+        self.assertEqual(props.calculateZRange(layer), QgsDoubleRange(180, 496))
+
+        # a band which the layer does not have gives no range
+        props.setZScale(1)
+        props.setZOffset(0)
+        props.setBandNumber(3)
+        self.assertTrue(props.calculateZRange(layer).isInfinite())
+
+        # and neither does a layer which is not a raster
+        props.setBandNumber(1)
+        self.assertTrue(props.calculateZRange(None).isInfinite())
+
     def test_looks_like_dem(self):
         layer = QgsRasterLayer(
             os.path.join(unitTestDataPath(), "landsat.tif"), "i am not a dem"


### PR DESCRIPTION
# Elevation controller improvements

This makes the elevation filter widget usable without opening the project properties:
the elevation range can be set directly in the widget, it is filled from the layers when
the project does not define one, and the values it shows are round numbers.

<img width="926" height="665" alt="image" src="https://github.com/user-attachments/assets/f0bddbe5-8574-45b1-a803-b0df8d989e1f" />

## Settings menu

<img width="695" height="112" alt="image" src="https://github.com/user-attachments/assets/8a75ee0a-6a30-4060-87c7-b14f78a10727" />

The settings menu of the elevation controller is now a single panel, similar to the
temporal controller:

- **Limits**: like for the temporal controller a button allows to define the limits from
  all project layers or from the current layer.
- **Range**: the value is now displayed even if not locked, a lock button is now used (or pressing enter)
- **Invert direction**.

The entry *Disable Elevation Filter* stays.

## Round values

- Limits calculated from layers are rounded: `1234.5 - 3456.7`  becomes `1200 - 3500`.
- The slider snaps to round values while dragging, so a 0 - 1000 slider moves in steps
  of 10.
- The slider also snaps to the elevations which are significant for the layers of the map
  when one of them is closer than the round value, so a handle can still be placed exactly
  on a layer surface.

## Starting values

When the project has no elevation range of its own, the controller starts with the range
calculated from the layers of the canvas, instead of the arbitrary 0 - 100 default.

The elevation range of a raster layer is now calculated from the band statistics of its
elevation surface, so raster layers contribute a real range instead of nothing.

## Fixes

- Some weird values in the slider when the limits are set after a range is locked.
- Canvas layers without elevation properties are ignored, this removes warnings in the message bar

## API

- `QgsMathUtils::roundingInterval()` returns a round interval which splits a value span into
a given number of parts
-  `QgsMathUtils::roundedRange()` expands a range to round values.
- `QgsElevationUtils::calculateZRangeForLayers()` calculates the elevation range of a list
  of layers
- `QgsElevationControllerWidget::setMapCanvas()` gives the widget the canvas it belongs to.
  It provides the layer for the "Current Layer" entry, and its layers give the initial
  limits when the project defines no elevation range.
- `QgsElevationControllerSettingsAction` is now SIP_SKIP (but it was within @cond PRIVATE)

## Demo

https://github.com/user-attachments/assets/e8a2bfe6-fa44-4cb5-b173-839c85b9ff57


## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
