### PR TITLE
[WmsDimension] Move DefaultDisplay enum in Qgis

### DIFF
--- a/python/PyQt6/core/__init__.py.in
+++ b/python/PyQt6/core/__init__.py.in
@@ -122,6 +122,15 @@ QgsDateTimeRange(QgsDateTimeRange)
 Copy constructor.
 """
 
+# MonkeyPatch old QgsServerWmsDimensionProperties.WmsDimensionInfo.DefaultDisplay enum manually
+# because sipify doesn't know how to deal with inner class unnest
+
+QgsServerWmsDimensionProperties.WmsDimensionInfo.DefaultDisplay = Qgis.WmsDimensionDefaultDisplay
+QgsServerWmsDimensionProperties.WmsDimensionInfo.AllValues = Qgis.WmsDimensionDefaultDisplay.AllValues
+QgsServerWmsDimensionProperties.WmsDimensionInfo.MinValue = Qgis.WmsDimensionDefaultDisplay.MinValue
+QgsServerWmsDimensionProperties.WmsDimensionInfo.MaxValue = Qgis.WmsDimensionDefaultDisplay.MaxValue
+QgsServerWmsDimensionProperties.WmsDimensionInfo.ReferenceValue = Qgis.WmsDimensionDefaultDisplay.ReferenceValue
+
 
 QgsProperty.__bool__ = lambda self: self.propertyType() != Qgis.PropertyType.Invalid
 QgsOptionalExpression.__bool__ = lambda self: self.enabled()

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -13113,6 +13113,27 @@ Qgis.PdfRenderFlags = lambda flags=0: Qgis.PdfRenderFlag(flags)
 Qgis.PdfRenderFlags.baseClass = Qgis
 PdfRenderFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
+Qgis.WmsDimensionDefaultDisplay.AllValues.__doc__ = "Display all values of the dimension"
+Qgis.WmsDimensionDefaultDisplay.MinValue.__doc__ = "Display minimum value of the dimension"
+Qgis.WmsDimensionDefaultDisplay.MaxValue.__doc__ = "Display maximum value of the dimension"
+Qgis.WmsDimensionDefaultDisplay.ReferenceValue.__doc__ = "Display a reference value"
+Qgis.WmsDimensionDefaultDisplay.__doc__ = """QGIS Server WMS Dimension default display types
+
+.. note::
+
+   Prior to QGIS 4.4 this was available as :py:class:`QgsServerWmsDimensionProperties`.WmsDimensionInfo.DefaultDisplay
+
+.. versionadded:: 4.4
+
+* ``AllValues``: Display all values of the dimension
+* ``MinValue``: Display minimum value of the dimension
+* ``MaxValue``: Display maximum value of the dimension
+* ``ReferenceValue``: Display a reference value
+
+"""
+# --
+Qgis.WmsDimensionDefaultDisplay.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.RubberBandIconType.NoIcon.__doc__ = "No icon is used"
 Qgis.RubberBandIconType.CrossPlus.__doc__ = "A cross is used to highlight points (+)"
 Qgis.RubberBandIconType.CrossX.__doc__ = "A cross is used to highlight points (x)"

--- a/python/PyQt6/core/auto_additions/qgsmaplayerserverproperties.py
+++ b/python/PyQt6/core/auto_additions/qgsmaplayerserverproperties.py
@@ -3,10 +3,6 @@ QgsServerWmsDimensionProperties.TIME = QgsServerWmsDimensionProperties.Predefine
 QgsServerWmsDimensionProperties.DATE = QgsServerWmsDimensionProperties.PredefinedWmsDimensionName.DATE
 QgsServerWmsDimensionProperties.ELEVATION = QgsServerWmsDimensionProperties.PredefinedWmsDimensionName.ELEVATION
 QgsServerWmsDimensionProperties.PredefinedWmsDimensionName.baseClass = QgsServerWmsDimensionProperties
-QgsServerWmsDimensionProperties.WmsDimensionInfo.AllValues = QgsServerWmsDimensionProperties.WmsDimensionInfo.DefaultDisplay.AllValues
-QgsServerWmsDimensionProperties.WmsDimensionInfo.MinValue = QgsServerWmsDimensionProperties.WmsDimensionInfo.DefaultDisplay.MinValue
-QgsServerWmsDimensionProperties.WmsDimensionInfo.MaxValue = QgsServerWmsDimensionProperties.WmsDimensionInfo.DefaultDisplay.MaxValue
-QgsServerWmsDimensionProperties.WmsDimensionInfo.ReferenceValue = QgsServerWmsDimensionProperties.WmsDimensionInfo.DefaultDisplay.ReferenceValue
 try:
     QgsServerMetadataUrlProperties.MetadataUrl.__attribute_docs__ = {'url': 'URL of the link', 'type': 'Link type. Suggested to use FGDC or TC211.', 'format': 'Format specification of online resource. It is strongly suggested to either use text/plain or text/xml.'}
     QgsServerMetadataUrlProperties.MetadataUrl.__annotations__ = {'url': str, 'type': str, 'format': str}

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -3920,6 +3920,15 @@ The development version
     typedef QFlags<Qgis::PdfRenderFlag> PdfRenderFlags;
 
 
+
+    enum class WmsDimensionDefaultDisplay /BaseType=IntEnum/
+    {
+      AllValues,
+      MinValue,
+      MaxValue,
+      ReferenceValue,
+    };
+
     enum class RubberBandIconType /BaseType=IntEnum/
     {
       NoIcon,

--- a/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -109,22 +109,6 @@ Manages QGIS Server properties for WMS dimensions.
 
     struct WmsDimensionInfo
     {
- explicit WmsDimensionInfo(
-          const QString &dimName,
-          const QString &dimFieldName,
-          const QString &dimEndFieldName,
-          const QString &dimUnits,
-          const QString &dimUnitSymbol,
-          int dimDefaultDisplayType = static_cast<int>( Qgis::WmsDimensionDefaultDisplay::AllValues ),
-          const QVariant &dimReferenceValue = QVariant()
-        ) /Deprecated="Since 4.4. Use constructor with Qgis.WmsDimensionDefaultDisplay enum instead of int."/;
-%Docstring
-Constructor for WmsDimensionInfo.
-
-.. deprecated:: 4.4
-
-   Use constructor with :py:class:`Qgis`.WmsDimensionDefaultDisplay enum instead of int.
-%End
         explicit WmsDimensionInfo(
           const QString &dimName,
           const QString &dimFieldName,

--- a/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -109,21 +109,29 @@ Manages QGIS Server properties for WMS dimensions.
 
     struct WmsDimensionInfo
     {
-        enum DefaultDisplay /BaseType=IntEnum/
-        {
-          AllValues,
-          MinValue,
-          MaxValue,
-          ReferenceValue,
-        };
+ explicit WmsDimensionInfo(
+          const QString &dimName,
+          const QString &dimFieldName,
+          const QString &dimEndFieldName,
+          const QString &dimUnits,
+          const QString &dimUnitSymbol,
+          int dimDefaultDisplayType = static_cast<int>( Qgis::WmsDimensionDefaultDisplay::AllValues ),
+          const QVariant &dimReferenceValue = QVariant()
+        ) /Deprecated="Since 4.4. Use constructor with Qgis.WmsDimensionDefaultDisplay enum instead of int."/;
+%Docstring
+Constructor for WmsDimensionInfo.
 
+.. deprecated:: 4.4
+
+   Use constructor with :py:class:`Qgis`.WmsDimensionDefaultDisplay enum instead of int.
+%End
         explicit WmsDimensionInfo(
           const QString &dimName,
           const QString &dimFieldName,
           const QString &dimEndFieldName = QString(),
           const QString &dimUnits = QString(),
           const QString &dimUnitSymbol = QString(),
-          const int &dimDefaultDisplayType = QgsServerWmsDimensionProperties::WmsDimensionInfo::AllValues,
+          Qgis::WmsDimensionDefaultDisplay dimDefaultDisplayType = Qgis::WmsDimensionDefaultDisplay::AllValues,
           const QVariant &dimReferenceValue = QVariant()
         );
 %Docstring
@@ -138,7 +146,7 @@ Constructor for WmsDimensionInfo.
         QString endFieldName;
         QString units;
         QString unitSymbol;
-        int defaultDisplayType;
+        Qgis::WmsDimensionDefaultDisplay defaultDisplayType;
         QVariant referenceValue;
     };
 
@@ -154,6 +162,7 @@ Returns WMS Dimension default display labels
 
 .. versionadded:: 3.10
 %End
+
 
     bool addWmsDimension( const QgsServerWmsDimensionProperties::WmsDimensionInfo &wmsDimInfo );
 %Docstring

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -6991,6 +6991,23 @@ int QgisEvent = QEvent::User + 1;
     Q_DECLARE_FLAGS( PdfRenderFlags, PdfRenderFlag )
     Q_FLAG( PdfRenderFlags )
 
+
+    /**
+     * QGIS Server WMS Dimension default display types
+     *
+     * \note Prior to QGIS 4.4 this was available as QgsServerWmsDimensionProperties::WmsDimensionInfo::DefaultDisplay
+     *
+     * \since QGIS 4.4
+     */
+    enum class WmsDimensionDefaultDisplay : int
+    {
+      AllValues = 0,      //!< Display all values of the dimension
+      MinValue = 1,       //!< Display minimum value of the dimension
+      MaxValue = 2,       //!< Display maximum value of the dimension
+      ReferenceValue = 3, //!< Display a reference value
+    };
+    Q_ENUM( WmsDimensionDefaultDisplay )
+
     /**
      * Rubber band icon type.
      *

--- a/src/core/qgsmaplayerserverproperties.cpp
+++ b/src/core/qgsmaplayerserverproperties.cpp
@@ -212,7 +212,7 @@ void QgsServerWmsDimensionProperties::readXml( const QDomNode &layer_node )
       continue;
     }
     QVariant dimRefValue;
-    const Qgis::WmsDimensionDefaultDisplay dimDefaultDisplayType = qgsEnumKeyToValue( dimElem.attribute( u"defaultDisplayType"_s ), Qgis::WmsDimensionDefaultDisplay::AllValues );
+    const Qgis::WmsDimensionDefaultDisplay dimDefaultDisplayType = static_cast<Qgis::WmsDimensionDefaultDisplay>( dimElem.attribute( u"defaultDisplayType"_s ).toInt() );
     if ( dimDefaultDisplayType == Qgis::WmsDimensionDefaultDisplay::AllValues )
     {
       const QString dimRefValueStr = dimElem.attribute( u"referenceValue"_s );
@@ -249,7 +249,7 @@ void QgsServerWmsDimensionProperties::writeXml( QDomNode &layer_node, QDomDocume
       dimElem.setAttribute( u"endFieldName"_s, dim.endFieldName );
       dimElem.setAttribute( u"units"_s, dim.units );
       dimElem.setAttribute( u"unitSymbol"_s, dim.unitSymbol );
-      dimElem.setAttribute( u"defaultDisplayType"_s, qgsEnumValueToKey( dim.defaultDisplayType ) );
+      dimElem.setAttribute( u"defaultDisplayType"_s, static_cast<int>( dim.defaultDisplayType ) );
       dimElem.setAttribute( u"referenceValue"_s, dim.referenceValue.toString() );
       wmsDimsElem.appendChild( dimElem );
     }

--- a/src/core/qgsmaplayerserverproperties.cpp
+++ b/src/core/qgsmaplayerserverproperties.cpp
@@ -145,10 +145,10 @@ QMap<int, QString> QgsServerWmsDimensionProperties::wmsDimensionDefaultDisplayLa
 QMap<Qgis::WmsDimensionDefaultDisplay, QString> QgsServerWmsDimensionProperties::wmsDimensionDefaultDisplayDescriptions()
 {
   QMap<Qgis::WmsDimensionDefaultDisplay, QString> labels;
-  labels[Qgis::WmsDimensionDefaultDisplay::AllValues] = QObject::tr( "All values" );
-  labels[Qgis::WmsDimensionDefaultDisplay::MinValue] = QObject::tr( "Min value" );
-  labels[Qgis::WmsDimensionDefaultDisplay::MaxValue] = QObject::tr( "Max value" );
-  labels[Qgis::WmsDimensionDefaultDisplay::ReferenceValue] = QObject::tr( "Reference value" );
+  labels[Qgis::WmsDimensionDefaultDisplay::AllValues] = QObject::tr( "All Values" );
+  labels[Qgis::WmsDimensionDefaultDisplay::MinValue] = QObject::tr( "Min Value" );
+  labels[Qgis::WmsDimensionDefaultDisplay::MaxValue] = QObject::tr( "Max Value" );
+  labels[Qgis::WmsDimensionDefaultDisplay::ReferenceValue] = QObject::tr( "Reference Value" );
   return labels;
 }
 

--- a/src/core/qgsmaplayerserverproperties.cpp
+++ b/src/core/qgsmaplayerserverproperties.cpp
@@ -146,8 +146,8 @@ QMap<Qgis::WmsDimensionDefaultDisplay, QString> QgsServerWmsDimensionProperties:
 {
   QMap<Qgis::WmsDimensionDefaultDisplay, QString> labels;
   labels[Qgis::WmsDimensionDefaultDisplay::AllValues] = QObject::tr( "All Values" );
-  labels[Qgis::WmsDimensionDefaultDisplay::MinValue] = QObject::tr( "Min Value" );
-  labels[Qgis::WmsDimensionDefaultDisplay::MaxValue] = QObject::tr( "Max Value" );
+  labels[Qgis::WmsDimensionDefaultDisplay::MinValue] = QObject::tr( "Minimum Value" );
+  labels[Qgis::WmsDimensionDefaultDisplay::MaxValue] = QObject::tr( "Maximum Value" );
   labels[Qgis::WmsDimensionDefaultDisplay::ReferenceValue] = QObject::tr( "Reference Value" );
   return labels;
 }

--- a/src/core/qgsmaplayerserverproperties.cpp
+++ b/src/core/qgsmaplayerserverproperties.cpp
@@ -133,10 +133,22 @@ void QgsServerWmsDimensionProperties::setWmsDimensions( const QList<QgsServerWms
 QMap<int, QString> QgsServerWmsDimensionProperties::wmsDimensionDefaultDisplayLabels()
 {
   QMap<int, QString> labels;
-  labels[QgsServerWmsDimensionProperties::WmsDimensionInfo::AllValues] = QObject::tr( "All values" );
-  labels[QgsServerWmsDimensionProperties::WmsDimensionInfo::MinValue] = QObject::tr( "Min value" );
-  labels[QgsServerWmsDimensionProperties::WmsDimensionInfo::MaxValue] = QObject::tr( "Max value" );
-  labels[QgsServerWmsDimensionProperties::WmsDimensionInfo::ReferenceValue] = QObject::tr( "Reference value" );
+  const QMap<Qgis::WmsDimensionDefaultDisplay, QString> descriptions = wmsDimensionDefaultDisplayDescriptions();
+  for ( auto it = descriptions.cbegin(); it != descriptions.cend(); it++ )
+  {
+    labels[static_cast<int>( it.key() )] = descriptions[it.key()];
+  }
+
+  return labels;
+}
+
+QMap<Qgis::WmsDimensionDefaultDisplay, QString> QgsServerWmsDimensionProperties::wmsDimensionDefaultDisplayDescriptions()
+{
+  QMap<Qgis::WmsDimensionDefaultDisplay, QString> labels;
+  labels[Qgis::WmsDimensionDefaultDisplay::AllValues] = QObject::tr( "All values" );
+  labels[Qgis::WmsDimensionDefaultDisplay::MinValue] = QObject::tr( "Min value" );
+  labels[Qgis::WmsDimensionDefaultDisplay::MaxValue] = QObject::tr( "Max value" );
+  labels[Qgis::WmsDimensionDefaultDisplay::ReferenceValue] = QObject::tr( "Reference value" );
   return labels;
 }
 
@@ -200,8 +212,8 @@ void QgsServerWmsDimensionProperties::readXml( const QDomNode &layer_node )
       continue;
     }
     QVariant dimRefValue;
-    const int dimDefaultDisplayType = dimElem.attribute( u"defaultDisplayType"_s ).toInt();
-    if ( dimDefaultDisplayType == QgsServerWmsDimensionProperties::WmsDimensionInfo::AllValues )
+    const Qgis::WmsDimensionDefaultDisplay dimDefaultDisplayType = qgsEnumKeyToValue( dimElem.attribute( u"defaultDisplayType"_s ), Qgis::WmsDimensionDefaultDisplay::AllValues );
+    if ( dimDefaultDisplayType == Qgis::WmsDimensionDefaultDisplay::AllValues )
     {
       const QString dimRefValueStr = dimElem.attribute( u"referenceValue"_s );
       if ( !dimRefValueStr.isEmpty() )
@@ -237,7 +249,7 @@ void QgsServerWmsDimensionProperties::writeXml( QDomNode &layer_node, QDomDocume
       dimElem.setAttribute( u"endFieldName"_s, dim.endFieldName );
       dimElem.setAttribute( u"units"_s, dim.units );
       dimElem.setAttribute( u"unitSymbol"_s, dim.unitSymbol );
-      dimElem.setAttribute( u"defaultDisplayType"_s, dim.defaultDisplayType );
+      dimElem.setAttribute( u"defaultDisplayType"_s, qgsEnumValueToKey( dim.defaultDisplayType ) );
       dimElem.setAttribute( u"referenceValue"_s, dim.referenceValue.toString() );
       wmsDimsElem.appendChild( dimElem );
     }

--- a/src/core/qgsmaplayerserverproperties.h
+++ b/src/core/qgsmaplayerserverproperties.h
@@ -18,6 +18,7 @@
 #ifndef QGSMAPLAYERSERVERPROPERTIES_H
 #define QGSMAPLAYERSERVERPROPERTIES_H
 
+#include "qgis.h"
 #include "qgis_core.h"
 #include "qgis_sip.h"
 
@@ -158,16 +159,25 @@ class CORE_EXPORT QgsServerWmsDimensionProperties
     struct CORE_EXPORT WmsDimensionInfo
     {
         /**
-       * Selection behavior for QGIS Server WMS Dimension default display
-       * \since QGIS 3.10
-       */
-        enum DefaultDisplay
-        {
-          AllValues = 0,      //!< Display all values of the dimension
-          MinValue = 1,       //!< Add selection to current selection
-          MaxValue = 2,       //!< Modify current selection to include only select features which match
-          ReferenceValue = 3, //!< Remove from current selection
-        };
+         * Constructor for WmsDimensionInfo.
+         * \deprecated QGIS 4.4. Use constructor with Qgis::WmsDimensionDefaultDisplay enum instead of int.
+         */
+        Q_DECL_DEPRECATED explicit WmsDimensionInfo(
+          const QString &dimName,
+          const QString &dimFieldName,
+          const QString &dimEndFieldName,
+          const QString &dimUnits,
+          const QString &dimUnitSymbol,
+          int dimDefaultDisplayType = static_cast<int>( Qgis::WmsDimensionDefaultDisplay::AllValues ),
+          const QVariant &dimReferenceValue = QVariant()
+        ) SIP_DEPRECATED : name( dimName ),
+                           fieldName( dimFieldName ),
+                           endFieldName( dimEndFieldName ),
+                           units( dimUnits ),
+                           unitSymbol( dimUnitSymbol ),
+                           defaultDisplayType( Qgis::WmsDimensionDefaultDisplay( dimDefaultDisplayType ) ),
+                           referenceValue( dimReferenceValue )
+        {}
 
         /**
        * Constructor for WmsDimensionInfo.
@@ -178,7 +188,7 @@ class CORE_EXPORT QgsServerWmsDimensionProperties
           const QString &dimEndFieldName = QString(),
           const QString &dimUnits = QString(),
           const QString &dimUnitSymbol = QString(),
-          const int &dimDefaultDisplayType = QgsServerWmsDimensionProperties::WmsDimensionInfo::AllValues,
+          Qgis::WmsDimensionDefaultDisplay dimDefaultDisplayType = Qgis::WmsDimensionDefaultDisplay::AllValues,
           const QVariant &dimReferenceValue = QVariant()
         )
           : name( dimName )
@@ -198,7 +208,7 @@ class CORE_EXPORT QgsServerWmsDimensionProperties
         QString endFieldName;
         QString units;
         QString unitSymbol;
-        int defaultDisplayType;
+        Qgis::WmsDimensionDefaultDisplay defaultDisplayType;
         QVariant referenceValue;
     };
 
@@ -214,6 +224,14 @@ class CORE_EXPORT QgsServerWmsDimensionProperties
      * \since QGIS 3.10
      */
     static QMap<int, QString> wmsDimensionDefaultDisplayLabels();
+
+    /**
+     * Returns WMS Dimension default display descriptions
+     * \note This method returns the same labels as wmsDimensionDefaultDisplayLabels() but keeps keys
+     * as enum instead of int
+     * \since QGIS 4.4
+     */
+    static QMap<Qgis::WmsDimensionDefaultDisplay, QString> wmsDimensionDefaultDisplayDescriptions() SIP_SKIP;
 
     /**
      * Adds a QGIS Server WMS Dimension

--- a/src/core/qgsmaplayerserverproperties.h
+++ b/src/core/qgsmaplayerserverproperties.h
@@ -159,27 +159,6 @@ class CORE_EXPORT QgsServerWmsDimensionProperties
     struct CORE_EXPORT WmsDimensionInfo
     {
         /**
-         * Constructor for WmsDimensionInfo.
-         * \deprecated QGIS 4.4. Use constructor with Qgis::WmsDimensionDefaultDisplay enum instead of int.
-         */
-        Q_DECL_DEPRECATED explicit WmsDimensionInfo(
-          const QString &dimName,
-          const QString &dimFieldName,
-          const QString &dimEndFieldName,
-          const QString &dimUnits,
-          const QString &dimUnitSymbol,
-          int dimDefaultDisplayType = static_cast<int>( Qgis::WmsDimensionDefaultDisplay::AllValues ),
-          const QVariant &dimReferenceValue = QVariant()
-        ) SIP_DEPRECATED : name( dimName ),
-                           fieldName( dimFieldName ),
-                           endFieldName( dimEndFieldName ),
-                           units( dimUnits ),
-                           unitSymbol( dimUnitSymbol ),
-                           defaultDisplayType( Qgis::WmsDimensionDefaultDisplay( dimDefaultDisplayType ) ),
-                           referenceValue( dimReferenceValue )
-        {}
-
-        /**
        * Constructor for WmsDimensionInfo.
        */
         explicit WmsDimensionInfo(

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1501,7 +1501,7 @@ void QgsVectorLayerProperties::addWmsDimensionInfoToTreeWidget( const QgsMapLaye
 
   QTreeWidgetItem *childWmsDimensionDefaultValue = new QTreeWidgetItem();
   childWmsDimensionDefaultValue->setText( 0, tr( "Default display" ) );
-  childWmsDimensionDefaultValue->setText( 1, QgsMapLayerServerProperties::wmsDimensionDefaultDisplayLabels().value( wmsDim.defaultDisplayType ) );
+  childWmsDimensionDefaultValue->setText( 1, QgsMapLayerServerProperties::wmsDimensionDefaultDisplayDescriptions().value( wmsDim.defaultDisplayType ) );
   childWmsDimensionDefaultValue->setFlags( Qt::ItemIsEnabled );
   wmsDimensionItem->addChild( childWmsDimensionDefaultValue );
 

--- a/src/gui/vector/qgswmsdimensiondialog.cpp
+++ b/src/gui/vector/qgswmsdimensiondialog.cpp
@@ -68,13 +68,13 @@ QgsWmsDimensionDialog::QgsWmsDimensionDialog( QgsVectorLayer *layer, QStringList
 
   // Set default display combobox
   mDefaultDisplayComboBox->clear();
-  QMap<int, QString> defaultDisplayLabels = QgsMapLayerServerProperties::wmsDimensionDefaultDisplayLabels();
-  for ( auto it = defaultDisplayLabels.constBegin(); it != defaultDisplayLabels.constEnd(); it++ )
+  QMap<Qgis::WmsDimensionDefaultDisplay, QString> defaultDisplayDescriptions = QgsMapLayerServerProperties::wmsDimensionDefaultDisplayDescriptions();
+  for ( auto it = defaultDisplayDescriptions.constBegin(); it != defaultDisplayDescriptions.constEnd(); it++ )
   {
-    mDefaultDisplayComboBox->addItem( it.value(), QVariant( it.key() ) );
+    mDefaultDisplayComboBox->addItem( it.value(), QVariant( static_cast<int>( it.key() ) ) );
   }
   // Set default display to All values
-  mDefaultDisplayComboBox->setCurrentIndex( mDefaultDisplayComboBox->findData( QVariant( QgsMapLayerServerProperties::WmsDimensionInfo::AllValues ) ) );
+  mDefaultDisplayComboBox->setCurrentIndex( mDefaultDisplayComboBox->findData( QVariant( static_cast<int>( Qgis::WmsDimensionDefaultDisplay::AllValues ) ) ) );
 
   mReferenceValueLabel->setEnabled( false );
   mReferenceValueComboBox->setEnabled( false );
@@ -102,8 +102,8 @@ void QgsWmsDimensionDialog::setInfo( const QgsMapLayerServerProperties::WmsDimen
   mUnitsLineEdit->setText( info.units );
   mUnitSymbolLineEdit->setText( info.unitSymbol );
 
-  mDefaultDisplayComboBox->setCurrentIndex( mDefaultDisplayComboBox->findData( QVariant( info.defaultDisplayType ) ) );
-  if ( info.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::ReferenceValue )
+  mDefaultDisplayComboBox->setCurrentIndex( mDefaultDisplayComboBox->findData( QVariant( static_cast<int>( info.defaultDisplayType ) ) ) );
+  if ( info.defaultDisplayType == Qgis::WmsDimensionDefaultDisplay::ReferenceValue )
   {
     const int referenceValueIndex = mReferenceValueComboBox->findData( info.referenceValue );
     if ( referenceValueIndex == -1 )
@@ -137,8 +137,15 @@ QgsMapLayerServerProperties::WmsDimensionInfo QgsWmsDimensionDialog::info() cons
   {
     refValue = mReferenceValueComboBox->currentData();
   }
-  return QgsMapLayerServerProperties::
-    WmsDimensionInfo( name, mFieldComboBox->currentField(), mEndFieldComboBox->currentField(), mUnitsLineEdit->text(), mUnitSymbolLineEdit->text(), mDefaultDisplayComboBox->currentData().toInt(), refValue );
+  return QgsMapLayerServerProperties::WmsDimensionInfo(
+    name,
+    mFieldComboBox->currentField(),
+    mEndFieldComboBox->currentField(),
+    mUnitsLineEdit->text(),
+    mUnitSymbolLineEdit->text(),
+    static_cast<Qgis::WmsDimensionDefaultDisplay>( mDefaultDisplayComboBox->currentData().toInt() ),
+    refValue
+  );
 }
 
 void QgsWmsDimensionDialog::nameChanged( const QString &name )

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1369,15 +1369,15 @@ namespace QgsWms
               {
                 dimElem.setAttribute( u"unitSymbol"_s, dim.unitSymbol );
               }
-              if ( !values.isEmpty() && dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::MinValue )
+              if ( !values.isEmpty() && dim.defaultDisplayType == Qgis::WmsDimensionDefaultDisplay::MinValue )
               {
                 dimElem.setAttribute( u"default"_s, values.first().toString() );
               }
-              else if ( !values.isEmpty() && dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::MaxValue )
+              else if ( !values.isEmpty() && dim.defaultDisplayType == Qgis::WmsDimensionDefaultDisplay::MaxValue )
               {
                 dimElem.setAttribute( u"default"_s, values.last().toString() );
               }
-              else if ( dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::ReferenceValue )
+              else if ( dim.defaultDisplayType == Qgis::WmsDimensionDefaultDisplay::ReferenceValue )
               {
                 dimElem.setAttribute( u"default"_s, dim.referenceValue.toString() );
               }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3932,11 +3932,11 @@ namespace QgsWms
       {
         // Default value based on type configured by user
         QVariant defValue;
-        if ( dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::AllValues )
+        if ( dim.defaultDisplayType == Qgis::WmsDimensionDefaultDisplay::AllValues )
         {
           continue; // no filter by default for this dimension
         }
-        else if ( dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::ReferenceValue )
+        else if ( dim.defaultDisplayType == Qgis::WmsDimensionDefaultDisplay::ReferenceValue )
         {
           defValue = dim.referenceValue;
         }
@@ -3951,11 +3951,11 @@ namespace QgsWms
           // sort unique values
           QList<QVariant> values = qgis::setToList( uniqueValues );
           std::sort( values.begin(), values.end() );
-          if ( dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::MinValue )
+          if ( dim.defaultDisplayType == Qgis::WmsDimensionDefaultDisplay::MinValue )
           {
             defValue = values.first();
           }
-          else if ( dim.defaultDisplayType == QgsMapLayerServerProperties::WmsDimensionInfo::MaxValue )
+          else if ( dim.defaultDisplayType == Qgis::WmsDimensionDefaultDisplay::MaxValue )
           {
             defValue = values.last();
           }

--- a/tests/src/core/testqgsmaplayer.cpp
+++ b/tests/src/core/testqgsmaplayer.cpp
@@ -575,7 +575,7 @@ void TestQgsMapLayer::cloneServerProperties()
   source->serverProperties()->addMetadataUrl( metadataUrl );
 
   const QgsServerWmsDimensionProperties::WmsDimensionInfo
-    wmsDimension( u"elevation"_s, u"field_name"_s, u"end_field_name"_s, u"foot"_s, u"ft"_s, QgsServerWmsDimensionProperties::WmsDimensionInfo::ReferenceValue, QVariant( u"0"_s ) );
+    wmsDimension( u"elevation"_s, u"field_name"_s, u"end_field_name"_s, u"foot"_s, u"ft"_s, Qgis::WmsDimensionDefaultDisplay::ReferenceValue, QVariant( u"0"_s ) );
   QVERIFY( source->serverProperties()->addWmsDimension( wmsDimension ) );
 
   std::unique_ptr<QgsVectorLayer> clone( source->clone() );


### PR DESCRIPTION
## Description

WmsDimensionInfo::DefaultDisplay enum is used in different places, hence it needs to be moved in qgis.h. 

This PR also:
- fix enum documentation which were not describing at all what the enum was implying. see #67058 
- Use an enum in WmsDimensionInfo instead of int

Fixes #67058 

cc @agiudiceandrea 

## AI tool usage

None

**Funded by Ressources Naturelles Canada**