### PR TITLE
allow setting creation options and output nodata value in the TIN and IDW interpolation algorithms

### DIFF
--- a/src/analysis/processing/qgsalgorithmidwinterpolation.cpp
+++ b/src/analysis/processing/qgsalgorithmidwinterpolation.cpp
@@ -103,6 +103,17 @@ void QgsIdwInterpolationAlgorithm::initAlgorithm( const QVariantMap & )
   rowsParam->setFlags( rowsParam->flags() | Qgis::ProcessingParameterFlag::Hidden );
   addParameter( rowsParam.release() );
 
+  auto outputNodataParam = std::make_unique<QgsProcessingParameterNumber>( u"NODATA"_s, QObject::tr( "Output NoData value" ), Qgis::ProcessingNumberParameterType::Double, -9999.0 );
+  outputNodataParam->setHelp( QObject::tr( "The NODATA value to use in the output raster." ) );
+  outputNodataParam->setFlags( outputNodataParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
+  addParameter( outputNodataParam.release() );
+
+  auto creationOptsParam = std::make_unique<QgsProcessingParameterString>( u"CREATION_OPTIONS"_s, QObject::tr( "Creation options" ), QVariant(), false, true );
+  creationOptsParam->setHelp( QObject::tr( "The raster creation options for the output raster. These options control things like colorimetry, compression, etc." ) );
+  creationOptsParam->setMetadata( QVariantMap( { { u"widget_wrapper"_s, QVariantMap( { { u"widget_type"_s, u"rasteroptions"_s } } ) } } ) );
+  creationOptsParam->setFlags( creationOptsParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
+  addParameter( creationOptsParam.release() );
+
   auto outputParam = std::make_unique<QgsProcessingParameterRasterDestination>( u"OUTPUT"_s, QObject::tr( "Interpolated" ) );
   addParameter( outputParam.release() );
 }
@@ -114,6 +125,8 @@ QVariantMap QgsIdwInterpolationAlgorithm::processAlgorithm( const QVariantMap &p
   const double coefficient = parameterAsDouble( parameters, u"DISTANCE_COEFFICIENT"_s, context );
   const QgsRectangle boundingBox = parameterAsExtent( parameters, u"EXTENT"_s, context );
   const double pixelSize = parameterAsDouble( parameters, u"PIXEL_SIZE"_s, context );
+  const QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
+  const double outputNodata = parameterAsDouble( parameters, u"NODATA"_s, context );
   const QString output = parameterAsOutputLayer( parameters, u"OUTPUT"_s, context );
 
   int columns = parameterAsInt( parameters, u"COLUMNS"_s, context );
@@ -190,6 +203,12 @@ QVariantMap QgsIdwInterpolationAlgorithm::processAlgorithm( const QVariantMap &p
   interpolator.setDistanceCoefficient( coefficient );
 
   QgsGridFileWriter writer( &interpolator, output, boundingBox, columns, rows );
+  if ( !creationOptions.isEmpty() )
+  {
+    writer.setCreationOptions( creationOptions.split( '|' ) );
+  }
+  writer.setNoDataValue( outputNodata );
+
   writer.writeFile( feedback );
 
   QVariantMap outputs;

--- a/src/analysis/processing/qgsalgorithmtininterpolation.cpp
+++ b/src/analysis/processing/qgsalgorithmtininterpolation.cpp
@@ -106,6 +106,17 @@ void QgsTinInterpolationAlgorithm::initAlgorithm( const QVariantMap & )
   rowsParam->setFlags( rowsParam->flags() | Qgis::ProcessingParameterFlag::Hidden );
   addParameter( rowsParam.release() );
 
+  auto outputNodataParam = std::make_unique<QgsProcessingParameterNumber>( u"NODATA"_s, QObject::tr( "Output NoData value" ), Qgis::ProcessingNumberParameterType::Double, -9999.0 );
+  outputNodataParam->setHelp( QObject::tr( "The NODATA value to use in the output raster." ) );
+  outputNodataParam->setFlags( outputNodataParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
+  addParameter( outputNodataParam.release() );
+
+  auto creationOptsParam = std::make_unique<QgsProcessingParameterString>( u"CREATION_OPTIONS"_s, QObject::tr( "Creation options" ), QVariant(), false, true );
+  creationOptsParam->setHelp( QObject::tr( "The raster creation options for the output raster. These options control things like colorimetry, compression, etc." ) );
+  creationOptsParam->setMetadata( QVariantMap( { { u"widget_wrapper"_s, QVariantMap( { { u"widget_type"_s, u"rasteroptions"_s } } ) } } ) );
+  creationOptsParam->setFlags( creationOptsParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
+  addParameter( creationOptsParam.release() );
+
   auto outputParam = std::make_unique<QgsProcessingParameterRasterDestination>( u"OUTPUT"_s, QObject::tr( "Interpolated" ) );
   addParameter( outputParam.release() );
 
@@ -121,6 +132,8 @@ QVariantMap QgsTinInterpolationAlgorithm::processAlgorithm( const QVariantMap &p
   const int method = parameterAsEnum( parameters, u"METHOD"_s, context );
   const QgsRectangle boundingBox = parameterAsExtent( parameters, u"EXTENT"_s, context );
   const double pixelSize = parameterAsDouble( parameters, u"PIXEL_SIZE"_s, context );
+  const QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
+  const double outputNodata = parameterAsDouble( parameters, u"NODATA"_s, context );
   const QString output = parameterAsOutputLayer( parameters, u"OUTPUT"_s, context );
 
   int columns = parameterAsInt( parameters, u"COLUMNS"_s, context );
@@ -213,6 +226,11 @@ QVariantMap QgsTinInterpolationAlgorithm::processAlgorithm( const QVariantMap &p
   }
 
   QgsGridFileWriter writer( &interpolator, output, boundingBox, columns, rows );
+  if ( !creationOptions.isEmpty() )
+  {
+    writer.setCreationOptions( creationOptions.split( '|' ) );
+  }
+  writer.setNoDataValue( outputNodata );
   writer.writeFile( feedback );
 
   if ( triangulationSink )


### PR DESCRIPTION
## Description

Expose creation options and nodata value in the TIN and IDW interpolation algorithms. This allow users create compressed raster outputs and let them to define nodata value which better fits their data instead of using hardcoded value -9999.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.