### PR TITLE
Add "sample" as tag for native:rastersampling

### DIFF
--- a/src/analysis/processing/qgsalgorithmrastersampling.cpp
+++ b/src/analysis/processing/qgsalgorithmrastersampling.cpp
@@ -37,7 +37,7 @@ QString QgsRasterSamplingAlgorithm::displayName() const
 
 QStringList QgsRasterSamplingAlgorithm::tags() const
 {
-  return QObject::tr( "extract,point,pixel,value" ).split( ',' );
+  return QObject::tr( "extract,point,pixel,sample,value" ).split( ',' );
 }
 
 QString QgsRasterSamplingAlgorithm::group() const


### PR DESCRIPTION
## Description

The tool is called "Sample raster values" in English but other languages might not use the word "sample". The algorithm itself is called `native:rastersampling`. As an advanced user I am used to finding algorithms in localized QGIS by searching for their English terms in the Processing toolbox.

Usually this works well if the tools are internally named similarly to their displayed name. Here there is a discrepancy between "Sampl_e_ raster values" and "rastersampl_ing_". I was lost and confused for a moment in a German QGIS, when I searched for the algorithm by entering "sample" in the Processing toolbox and not seeing it listed.

This PR adds "sample" to the algorithms tags. I think it is a word that people might search the algorithm by.

I did not compile or test this in any way. It looks like a trivial change to me. If not, please just shout and I will compile and test.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.