### PR TITLE
Fix incorrectly culled billboard entities in 3d views

### DIFF
--- a/src/3d/symbols/qgsbillboardgeometry.cpp
+++ b/src/3d/symbols/qgsbillboardgeometry.cpp
@@ -84,6 +84,7 @@ void QgsBillboardGeometry::setMode( Mode mode )
   mPositionAttribute->setDivisor( 1 );
   mPositionAttribute->setName( "instancePosition" );
   addAttribute( mPositionAttribute );
+  setBoundingVolumePositionAttribute( mPositionAttribute );
 
   switch ( mode )
   {
@@ -199,6 +200,7 @@ void QgsBillboardGeometry::setPositions( const QVector<QVector3D> &vertices )
 
   mVertexCount = vertices.count();
   mVertexBuffer->setData( vertexBufferData );
+  mPositionAttribute->setCount( mVertexCount );
 
   emit countChanged( mVertexCount );
 }
@@ -269,6 +271,7 @@ void QgsBillboardGeometry::setBillboardData( const QVector<BillboardAtlasData> &
 
   mVertexCount = billboards.count();
   mVertexBuffer->setData( vertexBufferData );
+  mPositionAttribute->setCount( mVertexCount );
 
   emit countChanged( mVertexCount );
 }


### PR DESCRIPTION
Follow up https://github.com/qgis/QGIS/pull/66837

Avoids the console being spammed with the qt warning:

"findBoundingVolumeComputeData: Position attribute not suited for bounding volume computation warnings"

and missing billboard entities in 3d views, due to incorrectly culled entities

## AI tool usage

 - [x] AI tool(s) Gemini was used to interpret the qt 3d warning 


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
