### PR TITLE
Revert "[Customization] fix position check"

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -188,7 +188,7 @@ unsigned int QgsCustomization::QgsItem::childrenCount() const
 
 void QgsCustomization::QgsItem::insertChild( int position, std::unique_ptr<QgsItem> item )
 {
-  if ( position < 0 || position >= static_cast<int>( mChildItemList.size() ) )
+  if ( position < 0 || position > static_cast<int>( mChildItemList.size() ) )
   {
     QgsDebugError( u"Insert item impossible, invalid position"_s );
     return;

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -188,6 +188,7 @@ unsigned int QgsCustomization::QgsItem::childrenCount() const
 
 void QgsCustomization::QgsItem::insertChild( int position, std::unique_ptr<QgsItem> item )
 {
+  // NOTE: strict inequality is not appropriate here -- it must be possible to have position equal to the current size to allow inserting items at the end of the list
   if ( position < 0 || position > static_cast<int>( mChildItemList.size() ) )
   {
     QgsDebugError( u"Insert item impossible, invalid position"_s );


### PR DESCRIPTION
Reverts qgis/QGIS#67090

We can insert at size position when we want to insert after the last element (or 0 when the size is empty).

And I misinterpreted test failure and thought it was unrelated. Sorry for the inconvenience. 