### PR TITLE
Require interaction before submitting plugin votes

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -169,6 +169,7 @@ QgsPluginManager::QgsPluginManager( QWidget *parent, bool pluginsAreEnabled, Qt:
   voteLabel->hide();
   voteSlider->hide();
   voteSubmit->hide();
+  connect( voteSlider, &QSlider::actionTriggered, voteSubmit, [this] { voteSubmit->setEnabled( true ); } );
   connect( voteSubmit, &QPushButton::clicked, this, &QgsPluginManager::submitVote );
 
   // Init the message bar instance
@@ -686,6 +687,8 @@ void QgsPluginManager::pluginItemChanged( QStandardItem *item )
 
 void QgsPluginManager::showPluginDetails( QStandardItem *item )
 {
+  voteSubmit->setEnabled( false );
+
   const QMap<QString, QString> *metadata = pluginMetadata( item->data( PLUGIN_BASE_NAME_ROLE ).toString() );
 
   if ( !metadata )
@@ -747,8 +750,6 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
     voteLabel->show();
     voteSlider->show();
     voteSubmit->show();
-    QgsDebugMsgLevel( u"vote slider:%1"_s.arg( std::round( metadata->value( "average_vote" ).toFloat() ) ), 2 );
-    voteSlider->setValue( std::round( metadata->value( "average_vote" ).toFloat() ) );
     mCurrentPluginId = metadata->value( "plugin_id" ).toInt();
   }
   else

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "qgis.h"
+#include "qgis_app.h"
 #include "qgsguiutils.h"
 #include "qgsoptionsdialogbase.h"
 #include "qgssettingstree.h"
@@ -44,7 +45,7 @@ class QgsSettingsEntryStringList;
 /**
  * \brief Plugin manager for browsing, (un)installing and (un)loading plugins
 */
-class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManagerBase
+class APP_EXPORT QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManagerBase
 {
     Q_OBJECT
   public:

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -435,6 +435,9 @@
                  </item>
                  <item row="1" column="2">
                   <widget class="QPushButton" name="voteSubmit">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::ClickFocus</enum>
                    </property>

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TESTS
   testqgsmaptoolreverseline.cpp
   testqgsmaptooltrimextendfeature.cpp
   testqgsprojectproperties.cpp
+  testqgspluginmanagervote.cpp
   testqgsapplayoutvaliditychecks.cpp
   testqgsmeshcalculatordialog.cpp
   testqgsgpsintegration.cpp

--- a/tests/src/app/testqgspluginmanagervote.cpp
+++ b/tests/src/app/testqgspluginmanagervote.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+    testqgspluginmanagervote.cpp
+    ---------------------------
+    Date                 : August 2026
+    Copyright            : (C) 2026 by Kevin Lo
+    Email                : veeman961 at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "pluginmanager/qgspluginmanager.h"
+#include "pluginmanager/qgspluginsortfilterproxymodel.h"
+#include "qgsapplication.h"
+#include "qgstest.h"
+
+#include <QPushButton>
+#include <QSlider>
+#include <QStandardItem>
+
+using namespace Qt::StringLiterals;
+
+class TestQgsPluginManagerVote : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void voteRequiresUserInteraction();
+};
+
+void TestQgsPluginManagerVote::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsPluginManagerVote::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsPluginManagerVote::voteRequiresUserInteraction()
+{
+  QgsPluginManager manager;
+  manager.addPluginMetadata( u"test_plugin"_s, {
+                                                     { u"plugin_id"_s, u"123"_s },
+                                                     { u"average_vote"_s, u"4.5"_s },
+                                                   } );
+
+  QStandardItem item;
+  item.setData( u"test_plugin"_s, PLUGIN_BASE_NAME_ROLE );
+  manager.showPluginDetails( &item );
+
+  QSlider *slider = manager.findChild<QSlider *>( u"voteSlider"_s );
+  QPushButton *submit = manager.findChild<QPushButton *>( u"voteSubmit"_s );
+  QVERIFY( slider );
+  QVERIFY( submit );
+  QCOMPARE_NE( slider->value(), 4 );
+  QCOMPARE_NE( slider->value(), 5 );
+  QVERIFY( !submit->isEnabled() );
+
+  slider->setFocus();
+  QTest::keyClick( slider, Qt::Key_Right );
+  QVERIFY( submit->isEnabled() );
+
+  manager.showPluginDetails( &item );
+  QVERIFY( !submit->isEnabled() );
+}
+
+QGSTEST_MAIN( TestQgsPluginManagerVote )
+#include "testqgspluginmanagervote.moc"


### PR DESCRIPTION
## Description

The plugin manager currently initializes the vote slider from a plugin's average rating. A user can consequently submit that existing average as their own vote without ever choosing a rating.

This change leaves the slider at its default value and disables **Vote!** until the user operates the slider. Selecting plugin details resets the button to disabled. A focused app test covers the initial state, keyboard interaction, and selection reset.

Fixes #67047

Backport: recommended for maintained release branches because this prevents unintended plugin votes and does not change plugin metadata or network APIs.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
