### PR TITLE
Only create advanced group when required

### DIFF
--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -304,17 +304,21 @@ class ModelerParametersPanelWidget(QgsPanelWidget):
                 self.algorithmItem.setConfiguration(self.configuration)
             self.verticalLayout.addWidget(self.algorithmItem)
 
-        self.grpAdvanced = QgsCollapsibleGroupBox(self.tr("Advanced Parameters"))
-        self.grpAdvancedVLayout = QVBoxLayout()
-        self.grpAdvanced.setLayout(self.grpAdvancedVLayout)
-        self.grpAdvanced.hide()
+        self.grpAdvanced = None
+        self.grpAdvancedVLayout = None
 
-        self.verticalLayout.addWidget(self.grpAdvanced)
-
+        has_advanced_params = False
         for param in self._alg.parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.Flag.FlagAdvanced:
-                self.grpAdvanced.show()
+                has_advanced_params = True
                 break
+
+        if has_advanced_params:
+            self.grpAdvanced = QgsCollapsibleGroupBox(self.tr("Advanced Parameters"))
+            self.grpAdvancedVLayout = QVBoxLayout()
+            self.grpAdvanced.setLayout(self.grpAdvancedVLayout)
+            self.verticalLayout.addWidget(self.grpAdvanced)
+
         for param in self._alg.parameterDefinitions():
             if (
                 param.isDestination()
@@ -340,7 +344,9 @@ class ModelerParametersPanelWidget(QgsPanelWidget):
                     widget.setToolTip(tooltip)
                     label = wrapper.label
 
-                if param.flags() & QgsProcessingParameterDefinition.Flag.FlagAdvanced:
+                if self.grpAdvancedVLayout is not None and (
+                    param.flags() & QgsProcessingParameterDefinition.Flag.FlagAdvanced
+                ):
                     self.grpAdvancedVLayout.addWidget(label)
                     self.grpAdvancedVLayout.addWidget(widget)
                 else:


### PR DESCRIPTION
## Description

Selected backport from https://github.com/qgis/QGIS/pull/67154

Avoids window temporarily flashing up on screen for a fraction of a second when selecting a child algorithm in modeler that has advanced parameters.

The call to advancedGroup->show() during the widget ui construction would cause the advancedGroup widget to be shown as a standalone window, then immediately this window gets closed when the widget ui layout is finalised and the group is moved to the parent widget. 

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
