### PR TITLE
Remove QgsProject::instance() references from QgsProjectColorScheme (QEP 423)

### DIFF
--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -2500,6 +2500,21 @@ uncommitted edits.
 .. versionadded:: 3.26
 %End
 
+    QgsColorSchemeRegistry *colorSchemeRegistry() /Factory/;
+%Docstring
+Creates a new color scheme registry associated with this project,
+populated with the default color schemes.
+
+Unlike the default-constructed :py:class:`QgsColorSchemeRegistry`, the
+returned registry includes this project's colors (see
+:py:class:`QgsProjectColorScheme`) in addition to the standard schemes.
+
+Ownership of the returned registry is transferred to the caller.
+
+.. versionadded:: 4.4
+%End
+
+
 };
 
 class QgsProjectDirtyBlocker

--- a/python/PyQt6/core/auto_generated/qgscolorscheme.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorscheme.sip.in
@@ -288,7 +288,23 @@ project properties dialog.
 #include "qgscolorscheme.h"
 %End
   public:
-    QgsProjectColorScheme();
+ QgsProjectColorScheme() /Deprecated/;
+%Docstring
+Constructor for a project color scheme bound to the current
+:py:class:`QgsProject` :py:func:`~QgsProjectColorScheme.instance`.
+
+.. note::
+
+   Will be removed in QGIS 5.0. Use the constructor which requires an explicit project instead.
+%End
+
+    QgsProjectColorScheme( QgsProject *project );
+%Docstring
+Constructor for a project color scheme bound to the specified
+``project``.
+
+.. versionadded:: 4.4
+%End
 
     virtual QString schemeName() const;
 
@@ -303,6 +319,7 @@ project properties dialog.
 
 
     virtual QgsProjectColorScheme *clone() const /Factory/;
+
 
 };
 

--- a/python/PyQt6/core/auto_generated/qgscolorschemeregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorschemeregistry.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsColorSchemeRegistry
 {
 %Docstring(signature="appended")
@@ -180,6 +181,18 @@ This method is thread safe.
 
 .. versionadded:: 3.2
 %End
+
+    void setProject( QgsProject *project );
+%Docstring
+Sets the ``project`` associated with the registry, used to provide the
+"Project colors" scheme.
+
+If ``project`` is ``None``, the project colors scheme is removed from
+the registry.
+
+.. versionadded:: 4.4
+%End
+
 
 };
 

--- a/python/PyQt6/core/auto_generated/qgscolorschemeregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorschemeregistry.sip.in
@@ -28,6 +28,13 @@ be created directly, or accessed via a
     QgsColorSchemeRegistry();
 %Docstring
 Constructor for an empty color scheme registry
+
+.. note::
+
+   Since QGIS 4.4 the default construction of QgsColorSchemeRegistry
+   no longer includes project colors by default. QgsColorSchemeRegistry
+   with project colors included can be obtained using :py:func:`QgsProject.colorSchemeRegistry()`
+   or by specifically set project using :py:func:`QgsColorSchemeRegistry.setProject()`.
 %End
 
     virtual ~QgsColorSchemeRegistry();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -266,6 +266,7 @@ using namespace Qt::StringLiterals;
 #include "qgsbookmarkeditordialog.h"
 #include "qgsbrowserdockwidget.h"
 #include "qgsclipboard.h"
+#include "qgscolorschemeregistry.h"
 #include "qgsconfigureshortcutsdialog.h"
 #include "qgscoordinatetransform.h"
 #include "qgscoordinateutils.h"
@@ -1145,6 +1146,10 @@ QgisApp::QgisApp(
   // set project linked to main canvas
   mMapCanvas->setProject( QgsProject::instance() );
   endProfile();
+
+  QgsApplication::colorSchemeRegistry()->setProject( QgsProject::instance() );
+  connect( this, &QgisApp::newProject, this, [] { QgsApplication::colorSchemeRegistry()->setProject( QgsProject::instance() ); } );
+  connect( this, &QgisApp::projectRead, this, [] { QgsApplication::colorSchemeRegistry()->setProject( QgsProject::instance() ); } );
 
   // what type of project to auto-open
   mProjOpen = settingsProjOpenAtLaunch->value();

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -27,6 +27,7 @@
 #include "qgsattributeeditorcontainer.h"
 #include "qgsauxiliarystorage.h"
 #include "qgsbookmarkmanager.h"
+#include "qgscolorschemeregistry.h"
 #include "qgscolorutils.h"
 #include "qgscombinedstylemodel.h"
 #include "qgsdatasourceuri.h"
@@ -5538,6 +5539,14 @@ void QgsProject::cleanFunctionsFromProject()
   {
     QgsPythonRunner::run( "qgis.utils.clean_project_expression_functions()" );
   }
+}
+
+QgsColorSchemeRegistry *QgsProject::colorSchemeRegistry()
+{
+  QgsColorSchemeRegistry *registry = new QgsColorSchemeRegistry();
+  registry->setProject( this );
+  registry->addDefaultSchemes();
+  return registry;
 }
 
 /// @cond PRIVATE

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -69,6 +69,7 @@ class QgsLayerTreeGroup;
 class QgsLayerTreeRegistryBridge;
 class QgsMapLayer;
 class QgsPathResolver;
+class QgsColorSchemeRegistry;
 class QgsProjectBadLayerHandler;
 class QgsProjectStorage;
 class QgsTolerance;
@@ -2421,6 +2422,21 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \since QGIS 3.26
      */
     bool rollBack( QStringList &rollbackErrors SIP_OUT, bool stopEditing = true, QgsVectorLayer *vectorLayer = nullptr );
+
+    /**
+     * Creates a new color scheme registry associated with this project,
+     * populated with the default color schemes.
+     *
+     * Unlike the default-constructed QgsColorSchemeRegistry, the returned
+     * registry includes this project's colors (see QgsProjectColorScheme) in
+     * addition to the standard schemes.
+     *
+     * Ownership of the returned registry is transferred to the caller.
+     *
+     * \since QGIS 4.4
+     */
+    QgsColorSchemeRegistry *colorSchemeRegistry() SIP_FACTORY;
+
 
   private slots:
     void onMapLayersAdded( const QList<QgsMapLayer *> &layers );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -2514,6 +2514,7 @@ QgsColorSchemeRegistry *QgsApplication::colorSchemeRegistry()
   QgsColorSchemeRegistry *registry = members()->mColorSchemeRegistry.get();
   // TODO QGIS 5.0 - remove the default inclusion of the project instance
   registry->setProject( QgsProject::instance() ); // skip-keyword-check
+  registry->addDefaultSchemes();
   return registry;
 }
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -2511,7 +2511,10 @@ QgsSettingsRegistryCore *QgsApplication::settingsRegistryCore()
 
 QgsColorSchemeRegistry *QgsApplication::colorSchemeRegistry()
 {
-  return members()->mColorSchemeRegistry.get();
+  QgsColorSchemeRegistry *registry = members()->mColorSchemeRegistry.get();
+  // TODO QGIS 5.0 - remove the default inclusion of the project instance
+  registry->setProject( QgsProject::instance() ); // skip-keyword-check
+  return registry;
 }
 
 QgsPaintEffectRegistry *QgsApplication::paintEffectRegistry()

--- a/src/core/qgscolorscheme.cpp
+++ b/src/core/qgscolorscheme.cpp
@@ -199,6 +199,14 @@ QgsCustomColorScheme *QgsCustomColorScheme::clone() const
 }
 
 
+QgsProjectColorScheme::QgsProjectColorScheme()
+  : QgsProjectColorScheme( QgsProject::instance() ) // skip-keyword-check
+{}
+
+QgsProjectColorScheme::QgsProjectColorScheme( QgsProject *project )
+  : mProject( project )
+{}
+
 QgsNamedColorList QgsProjectColorScheme::fetchColors( const QString &context, const QColor &baseColor )
 {
   Q_UNUSED( context )
@@ -206,8 +214,11 @@ QgsNamedColorList QgsProjectColorScheme::fetchColors( const QString &context, co
 
   QgsNamedColorList colorList;
 
-  QStringList colorStrings = QgsProject::instance()->readListEntry( u"Palette"_s, u"/Colors"_s );      // skip-keyword-check
-  const QStringList colorLabels = QgsProject::instance()->readListEntry( u"Palette"_s, u"/Labels"_s ); // skip-keyword-check
+  if ( !mProject )
+    return colorList;
+
+  QStringList colorStrings = mProject->readListEntry( u"Palette"_s, u"/Colors"_s );
+  const QStringList colorLabels = mProject->readListEntry( u"Palette"_s, u"/Labels"_s );
 
   //generate list from custom colors
   int colorIndex = 0;
@@ -231,13 +242,17 @@ bool QgsProjectColorScheme::setColors( const QgsNamedColorList &colors, const QS
 {
   Q_UNUSED( context )
   Q_UNUSED( baseColor )
-  QgsProject::instance()->setProjectColors( colors ); // skip-keyword-check
+
+  if ( !mProject )
+    return false;
+
+  mProject->setProjectColors( colors );
   return true;
 }
 
 QgsProjectColorScheme *QgsProjectColorScheme::clone() const
 {
-  return new QgsProjectColorScheme();
+  return new QgsProjectColorScheme( mProject );
 }
 
 

--- a/src/core/qgscolorscheme.h
+++ b/src/core/qgscolorscheme.h
@@ -28,6 +28,7 @@
 
 class QgsSettingsEntryStringList;
 class QgsSettingsEntryVariant;
+class QgsProject;
 
 /**
  * \ingroup core
@@ -280,7 +281,19 @@ class CORE_EXPORT QgsCustomColorScheme : public QgsColorScheme
 class CORE_EXPORT QgsProjectColorScheme : public QgsColorScheme
 {
   public:
-    QgsProjectColorScheme() = default;
+    /**
+     * Constructor for a project color scheme bound to the current QgsProject instance().
+     *
+     * \note Will be removed in QGIS 5.0. Use the constructor which requires an explicit project instead.
+     */
+    Q_DECL_DEPRECATED QgsProjectColorScheme() SIP_DEPRECATED;
+
+    /**
+     * Constructor for a project color scheme bound to the specified \a project.
+     *
+     * \since QGIS 4.4
+     */
+    QgsProjectColorScheme( QgsProject *project );
 
     QString schemeName() const override { return QObject::tr( "Project colors" ); }
 
@@ -293,6 +306,9 @@ class CORE_EXPORT QgsProjectColorScheme : public QgsColorScheme
     bool setColors( const QgsNamedColorList &colors, const QString &context = QString(), const QColor &baseColor = QColor() ) override;
 
     QgsProjectColorScheme *clone() const override SIP_FACTORY;
+
+  private:
+    QgsProject *mProject = nullptr;
 };
 
 #endif

--- a/src/core/qgscolorschemeregistry.cpp
+++ b/src/core/qgscolorschemeregistry.cpp
@@ -21,6 +21,7 @@
 
 #include "qgsapplication.h"
 #include "qgscolorscheme.h"
+#include "qgsproject.h"
 
 #include <QDir>
 #include <QFileInfoList>
@@ -53,7 +54,8 @@ void QgsColorSchemeRegistry::addDefaultSchemes()
   //default color schemes
   addColorScheme( new QgsRecentColorScheme() );
   addColorScheme( new QgsCustomColorScheme() );
-  addColorScheme( new QgsProjectColorScheme() );
+  if ( mProject )
+    addColorScheme( new QgsProjectColorScheme( mProject ) );
   addUserSchemes();
 }
 
@@ -170,6 +172,25 @@ QColor QgsColorSchemeRegistry::fetchRandomStyleColor() const
       mNextRandomStyleColorIndex = 0;
     return res;
   }
+}
+
+void QgsColorSchemeRegistry::setProject( QgsProject *project )
+{
+  if ( project == mProject )
+    return;
+
+  mProject = project;
+
+  QList< QgsProjectColorScheme * > existingSchemes;
+  schemes( existingSchemes );
+  for ( QgsProjectColorScheme *scheme : existingSchemes )
+  {
+    removeColorScheme( scheme );
+    delete scheme;
+  }
+
+  if ( mProject )
+    addColorScheme( new QgsProjectColorScheme( mProject ) );
 }
 
 bool QgsColorSchemeRegistry::removeColorScheme( QgsColorScheme *scheme )

--- a/src/core/qgscolorschemeregistry.h
+++ b/src/core/qgscolorschemeregistry.h
@@ -23,6 +23,8 @@
 
 #include <QList>
 
+class QgsProject;
+
 /**
  * \ingroup core
  * \class QgsColorSchemeRegistry
@@ -176,11 +178,23 @@ class CORE_EXPORT QgsColorSchemeRegistry
      */
     QColor fetchRandomStyleColor() const;
 
+    /**
+     * Sets the \a project associated with the registry, used to provide the "Project colors" scheme.
+     *
+     * If \a project is NULLPTR, the project colors scheme is removed from the registry.
+     *
+     * \since QGIS 4.4
+     */
+    void setProject( QgsProject *project );
+
+
   private:
     QList< QgsColorScheme * > mColorSchemeList;
 
     QgsColorScheme *mRandomStyleColorScheme = nullptr;
     QgsNamedColorList mRandomStyleColors;
+
+    QgsProject *mProject = nullptr;
 
     mutable int mNextRandomStyleColorIndex = 0;
 

--- a/src/core/qgscolorschemeregistry.h
+++ b/src/core/qgscolorschemeregistry.h
@@ -22,6 +22,7 @@
 #include "qgscolorscheme.h"
 
 #include <QList>
+#include <QPointer>
 
 class QgsProject;
 

--- a/src/core/qgscolorschemeregistry.h
+++ b/src/core/qgscolorschemeregistry.h
@@ -194,7 +194,7 @@ class CORE_EXPORT QgsColorSchemeRegistry
     QgsColorScheme *mRandomStyleColorScheme = nullptr;
     QgsNamedColorList mRandomStyleColors;
 
-    QgsProject *mProject = nullptr;
+    QPointer< QgsProject > mProject;
 
     mutable int mNextRandomStyleColorIndex = 0;
 

--- a/src/core/qgscolorschemeregistry.h
+++ b/src/core/qgscolorschemeregistry.h
@@ -38,6 +38,11 @@ class CORE_EXPORT QgsColorSchemeRegistry
   public:
     /**
      * Constructor for an empty color scheme registry
+     *
+     * \note Since QGIS 4.4 the default construction of QgsColorSchemeRegistry
+     * no longer includes project colors by default. QgsColorSchemeRegistry
+     * with project colors included can be obtained using QgsProject::colorSchemeRegistry()
+     * or by specifically set project using QgsColorSchemeRegistry::setProject().
      */
     QgsColorSchemeRegistry() = default;
 

--- a/tests/src/python/test_qgscolorschemeregistry.py
+++ b/tests/src/python/test_qgscolorschemeregistry.py
@@ -17,8 +17,11 @@ from qgis.core import (
     QgsApplication,
     QgsColorScheme,
     QgsColorSchemeRegistry,
+    QgsProject,
+    QgsProjectColorScheme,
     QgsRecentColorScheme,
 )
+from qgis.PyQt.QtGui import QColor
 from qgis.testing import QgisTestCase, start_app
 
 start_app()
@@ -104,6 +107,44 @@ class TestQgsColorSchemeRegistry(QgisTestCase):
         reg = QgsApplication.instance().colorSchemeRegistry()
 
         self.assertIn("TestScheme", [scheme.schemeName() for scheme in reg.schemes()])
+
+    def testSetProject(self):
+        """Test that the project colors scheme follows setProject()"""
+        registry = QgsApplication.colorSchemeRegistry()
+        # other tests rely on the registry being bound to QgsProject.instance(), so restore that after
+        self.addCleanup(registry.setProject, QgsProject.instance())
+
+        project1 = QgsProject()
+        project1.setProjectColors([[QColor(255, 0, 0), "red"]])
+        project2 = QgsProject()
+        project2.setProjectColors([[QColor(0, 255, 0), "green"]])
+
+        registry.setProject(project1)
+        schemes = [
+            s for s in registry.schemes() if isinstance(s, QgsProjectColorScheme)
+        ]
+        self.assertEqual(len(schemes), 1)
+        self.assertEqual(
+            [[c[0], c[1]] for c in schemes[0].fetchColors()],
+            [[QColor(255, 0, 0), "red"]],
+        )
+
+        # switching to a second project should swap the scheme's colors, not add a second scheme
+        registry.setProject(project2)
+        schemes = [
+            s for s in registry.schemes() if isinstance(s, QgsProjectColorScheme)
+        ]
+        self.assertEqual(len(schemes), 1)
+        self.assertEqual(
+            [[c[0], c[1]] for c in schemes[0].fetchColors()],
+            [[QColor(0, 255, 0), "green"]],
+        )
+
+        # clearing the project should remove the project colors scheme entirely
+        registry.setProject(None)
+        self.assertFalse(
+            [s for s in registry.schemes() if isinstance(s, QgsProjectColorScheme)]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -25,6 +25,7 @@ from osgeo import ogr
 from qgis.core import (
     Qgis,
     QgsApplication,
+    QgsColorSchemeRegistry,
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransformContext,
     QgsDataProvider,
@@ -1894,6 +1895,34 @@ class TestQgsProject(QgisTestCase):
                 [QColor(255, 0, 0), "red"],
                 [QColor(0, 255, 0), "green"],
                 [QColor.fromCmykF(1, 0.9, 0.8, 0.7), "TestCmyk"],
+            ],
+        )
+
+    def testColorSchemeRegistry(self):
+        """Test QgsProject.colorSchemeRegistry()"""
+
+        project = QgsProject()
+        project.setProjectColors(
+            [
+                [QColor(255, 0, 0), "red"],
+                [QColor(0, 255, 0), "green"],
+            ]
+        )
+
+        registry = project.colorSchemeRegistry()
+        self.assertIsInstance(registry, QgsColorSchemeRegistry)
+
+        # should include the default schemes plus a project color scheme bound
+        # to this project
+        project_schemes = [
+            s for s in registry.schemes() if isinstance(s, QgsProjectColorScheme)
+        ]
+        self.assertEqual(len(project_schemes), 1)
+        self.assertEqual(
+            [[c[0], c[1]] for c in project_schemes[0].fetchColors()],
+            [
+                [QColor(255, 0, 0), "red"],
+                [QColor(0, 255, 0), "green"],
             ],
         )
 


### PR DESCRIPTION
## Description

Remove calls to QgsProject::instance() in QgsProjectColorScheme.

Reworks `QgsColorSchemeRegistry` so that if it is created directly, it does not contain reference to `QgsProject` and will not provide colors stored in project, unless  the project is specifically assigned to `QgsColorSchemeRegistry`. When registry is obtained using `QgsApplication::colorSchemeRegistry()` the project is assigned to the registry to not break current behavior. 

User can get`QgsColorSchemeRegistry` with project setup using new function `QgsProject::colorSchemeRegistry()`. 

This is build from #67013 which I somehow manage to screw up with bad rebase.

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR.
