### PR TITLE
Fix for unbounded layer names

### DIFF
--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -73,8 +73,11 @@ QString QgsStringUtils::unaccent( const QString &input )
 QString QgsStringUtils::createUniqueId( const QString &base )
 {
   // A random UUID guarantees uniqueness; the base is a human-readable prefix.
+  constexpr int MAX_BASE_LENGTH = 36; // set to the length of a UUID string
   const QString uuid = QUuid::createUuid().toString( QUuid::StringFormat::WithoutBraces );
-  QString id = base.isEmpty() ? uuid : base + '_' + uuid;
+  // Cap length of base to avoid unchecked large name
+  const QString prefix = base.left( MAX_BASE_LENGTH );
+  QString id = prefix.isEmpty() ? uuid : prefix + '_' + uuid;
   // Tidy the id up to avoid characters that may cause problems elsewhere (e.g.
   // in some parts of XML). Replaces every non-word character (word characters
   // are the alphabet, numbers and underscore) with an underscore.

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -73,11 +73,8 @@ QString QgsStringUtils::unaccent( const QString &input )
 QString QgsStringUtils::createUniqueId( const QString &base )
 {
   // A random UUID guarantees uniqueness; the base is a human-readable prefix.
-  constexpr int MAX_BASE_LENGTH = 36; // set to the length of a UUID string
   const QString uuid = QUuid::createUuid().toString( QUuid::StringFormat::WithoutBraces );
-  // Cap length of base to avoid unchecked large name
-  const QString prefix = base.left( MAX_BASE_LENGTH );
-  QString id = prefix.isEmpty() ? uuid : prefix + '_' + uuid;
+  QString id = base.isEmpty() ? uuid : base + '_' + uuid;
   // Tidy the id up to avoid characters that may cause problems elsewhere (e.g.
   // in some parts of XML). Replaces every non-word character (word characters
   // are the alphabet, numbers and underscore) with an underscore.

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -656,10 +656,31 @@ void QgsWMSSourceSelect::addButtonClicked()
     uri.setParam( u"layers"_s, layers );
     uri.setParam( u"styles"_s, styles );
 
+    // name the layer after the node the user actually selected, so a selected group is named after the group's title
+    QStringList selectedTitles;
+    const QList<QTreeWidgetItem *> selectedItems = lstLayers->selectedItems();
+    selectedTitles.reserve( selectedItems.size() );
+    for ( QTreeWidgetItem *item : selectedItems )
+    {
+      QString itemTitle = item->data( 0, Qt::UserRole + 3 ).toString();
+      if ( itemTitle.isEmpty() )
+        itemTitle = item->text( 2 );
+      if ( !itemTitle.isEmpty() )
+        selectedTitles << itemTitle;
+    }
+
+    // default to the collected sublayer titles when there is no tree selection
+    // and handle WMTS tilesets
+    QString title = selectedTitles.isEmpty() ? titles.join( '/'_L1 ) : selectedTitles.join( '/'_L1 );
+
+    // bound generated name in case it still exceeds max length
+    constexpr int MAX_WMS_LAYER_NAME_LENGTH = 255;
+    title = title.left( MAX_WMS_LAYER_NAME_LENGTH );
+
     Q_NOWARN_DEPRECATED_PUSH
-    emit addRasterLayer( uri.encodedUri(), titles.join( '/'_L1 ), u"wms"_s );
+    emit addRasterLayer( uri.encodedUri(), title, u"wms"_s );
     Q_NOWARN_DEPRECATED_POP
-    emit addLayer( Qgis::LayerType::Raster, uri.encodedUri(), titles.join( '/'_L1 ), u"wms"_s );
+    emit addLayer( Qgis::LayerType::Raster, uri.encodedUri(), title, u"wms"_s );
   }
 }
 


### PR DESCRIPTION
## Description

WMS layers added from a WMS Server dialog can end up with names and IDs that are kilobytes long. This PR bounds those names and also tries to rename the layer to the parent where possible instead of traversing down children nodes.

Fix in 2 files
- `src/providers/wms/qgswmssourceselect.cpp`: names layer after the node the user actually selected in the tree (for example the parent), instead of  the concatenation of all descendants. Selecting a group now yields the group's own title. The generated name is then bounded to 255 characters.
- `src/core/qgsstringutils.cpp`:  `createUniqueId()` now caps the name prefix at 36 characters (the length of a UUID string, but kind of arbitrary) before concatenating the ID. This guarantees a bounded ID for every layer type regardless of how the name was produced, not just this WMS path.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
Used Gemini to consult about options for fixing renaming.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
