### PR TITLE
Fix race condition in spell check pre-commit hook

### DIFF
--- a/scripts/pre_commit/spell_check/check_spelling.sh
+++ b/scripts/pre_commit/spell_check/check_spelling.sh
@@ -90,7 +90,13 @@ SPELLOKRX='(#\s*spellok|<!--\s*#\s*spellok\s*-->)'
 # split into several files to avoid too long regexes
 SPLIT=8
 
-${GP}split --number=l/$SPLIT --numeric-suffixes --suffix-length=2 --additional-suffix=~ ${DIR}/spelling.dat spelling
+# use a private temp dir so concurrent invocations of this script (e.g. pre-commit
+# running this hook on several file batches in parallel) don't clobber each other's
+# split files, which were previously written under fixed names in the working directory
+TMPDIR_SPELLCHECK=$(mktemp -d)
+trap '${GP}rm -rf "$TMPDIR_SPELLCHECK"' EXIT
+
+${GP}split --number=l/$SPLIT --numeric-suffixes --suffix-length=2 --additional-suffix=~ ${DIR}/spelling.dat ${TMPDIR_SPELLCHECK}/spelling
 
 # global replace variables (dictionary)
 declare -A GLOBREP_ALLFILES=()
@@ -101,7 +107,7 @@ ERRORFOUND=NO
 
 for I in $(seq -f '%02g' 0  $((SPLIT-1)) ) ; do
   { [[ "$INTERACTIVE" =~ YES ]] || [[ "$TRAVIS" =~ true ]]; } && printf "Progress: %d/%d\r" $(( I + 1 )) $SPLIT
-  SPELLFILE=spelling$I~
+  SPELLFILE=${TMPDIR_SPELLCHECK}/spelling$I~
   ${GP}sed -i '/^#/d' $SPELLFILE
 
   # if correction contains an uppercase letter and is the same as the error character wise, this means that the error is searched as a full word and case sensitive (not incorporated in a bigger one)

--- a/scripts/pre_commit/spell_check/check_spelling.sh
+++ b/scripts/pre_commit/spell_check/check_spelling.sh
@@ -94,7 +94,7 @@ SPLIT=8
 # running this hook on several file batches in parallel) don't clobber each other's
 # split files, which were previously written under fixed names in the working directory
 TMPDIR_SPELLCHECK=$(mktemp -d)
-trap '${GP}rm -rf "$TMPDIR_SPELLCHECK"' EXIT
+trap 'rm -rf "$TMPDIR_SPELLCHECK"' EXIT
 
 ${GP}split --number=l/$SPLIT --numeric-suffixes --suffix-length=2 --additional-suffix=~ ${DIR}/spelling.dat ${TMPDIR_SPELLCHECK}/spelling
 


### PR DESCRIPTION
## Description

`check_spelling.sh` splits its dictionary into fixed-name temp files (`spelling00~..spelling07~`) in the repo's working directory. Since the spell_check hook isn't `require_serial`, pre-commit runs it concurrently on larger PRs (probably linked to large files as well), and parallel invocations clobber each other's temp files — causing spurious CI failures unrelated to actual spelling - error `(could not find correction for #if, sed: can't read spelling04~)`.  This is not quite deterministic, it may not happen every time, making it even more problematic.

The specific run that shows this error is for example [here](https://github.com/qgis/QGIS/actions/runs/33048329140/job/98437495490?pr=67160)

The solution is to use a private `mktemp -d` temp directory per invocation which is then cleaned up via `trap ... EXIT`, so concurrent runs no longer share files.

## AI tool usage

 - [X] AI tool(s)  Claude supported my development of this PR.
