### PR TITLE
Fix EXTERNAL_WMS layers

### DIFF
--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -590,6 +590,10 @@ void QgsWmsRenderContext::searchLayersToRenderSld()
 
 void QgsWmsRenderContext::searchLayersToRenderStyle()
 {
+
+  //
+
+
   // Throw a LayerNotDefined when one of the requested layers or groups is not leading to a result, otherwise return the layers to render
   mAcceptableLayersToRender = acceptableLayers( mParameters.allLayersNickname() );
 
@@ -944,7 +948,7 @@ QHash<const QgsMapLayer *, QStringList> QgsWmsRenderContext::acceptableLayers( c
     auto firstFoundInacceptableLayer = std::find_if( requestedLayerNames.cbegin(), requestedLayerNames.cend(), [&]( const QString &layerName ) {
       //return when the requested layer has not been found as a acceptable layer
       return !std::any_of( acceptableLayersAndRequestNames.cbegin(), acceptableLayersAndRequestNames.cend(), [&]( const QStringList &requestedNames ) {
-        return requestedNames.contains( layerName ) || isExternalLayer( layerName );
+        return requestedNames.contains( layerName ) || layerName.startsWith( "EXTERNAL_WMS:", Qt::CaseInsensitive );
       } );
     } );
     if ( firstFoundInacceptableLayer != requestedLayerNames.cend() )

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -590,10 +590,6 @@ void QgsWmsRenderContext::searchLayersToRenderSld()
 
 void QgsWmsRenderContext::searchLayersToRenderStyle()
 {
-
-  //
-
-
   // Throw a LayerNotDefined when one of the requested layers or groups is not leading to a result, otherwise return the layers to render
   mAcceptableLayersToRender = acceptableLayers( mParameters.allLayersNickname() );
 


### PR DESCRIPTION
In QgsWmsRenderContext::acceptableLayers(), there is a test if a layer is contained in mExternalLayers. The problem is that mExternalLayers is filled after the call to acceptableLayers(). So external layers are never acceptable. It might be better to just do a quick test if the layer starts with 'EXTERNAL_WMS:'
