### PR TITLE
Add toggleable outlines for histogram

### DIFF
--- a/src/gui/qgshistogramwidget.cpp
+++ b/src/gui/qgshistogramwidget.cpp
@@ -34,6 +34,7 @@ using namespace Qt::StringLiterals;
 
 const QgsSettingsEntryBool *QgsHistogramWidget::settingsHistogramShowMean = new QgsSettingsEntryBool( u"histogram-show-mean"_s, QgsSettingsTree::sTreeHistogram, false );
 const QgsSettingsEntryBool *QgsHistogramWidget::settingsHistogramShowStdev = new QgsSettingsEntryBool( u"histogram-show-stdev"_s, QgsSettingsTree::sTreeHistogram, false );
+const QgsSettingsEntryBool *QgsHistogramWidget::settingsHistogramShowBinOutlines = new QgsSettingsEntryBool( u"histogram-show-bin-outlines"_s, QgsSettingsTree::sTreeHistogram, true );
 
 // QWT Charting widget
 #include <qwt_global.h>
@@ -46,6 +47,7 @@ const QgsSettingsEntryBool *QgsHistogramWidget::settingsHistogramShowStdev = new
 #include <qwt_picker_machine.h>
 #include <qwt_plot_layout.h>
 #include <qwt_plot_renderer.h>
+#include <qwt_scale_widget.h>
 #include <qwt_plot_histogram.h>
 #include <qwt_text.h>
 
@@ -68,10 +70,12 @@ QgsHistogramWidget::QgsHistogramWidget( QWidget *parent, QgsVectorLayer *layer, 
 
   mMeanCheckBox->setChecked( settingsHistogramShowMean->value() );
   mStdevCheckBox->setChecked( settingsHistogramShowStdev->value() );
+  mShowBinOutlinesCheckBox->setChecked( settingsHistogramShowBinOutlines->value() );
 
   connect( mBinsSpinBox, static_cast<void ( QSpinBox::* )( int )>( &QSpinBox::valueChanged ), this, &QgsHistogramWidget::refresh );
   connect( mMeanCheckBox, &QAbstractButton::toggled, this, &QgsHistogramWidget::refresh );
   connect( mStdevCheckBox, &QAbstractButton::toggled, this, &QgsHistogramWidget::refresh );
+  connect( mShowBinOutlinesCheckBox, &QAbstractButton::toggled, this, &QgsHistogramWidget::refresh );
   connect( mLoadValuesButton, &QAbstractButton::clicked, this, &QgsHistogramWidget::refreshValues );
 
   mGridPen = QPen( QColor( 0, 0, 0, 40 ) );
@@ -90,6 +94,7 @@ QgsHistogramWidget::~QgsHistogramWidget()
 {
   settingsHistogramShowMean->setValue( mMeanCheckBox->isChecked() );
   settingsHistogramShowStdev->setValue( mStdevCheckBox->isChecked() );
+  settingsHistogramShowBinOutlines->setValue( mShowBinOutlinesCheckBox->isChecked() );
 }
 
 static bool _rangesByLower( const QgsRendererRange &a, const QgsRendererRange &b )
@@ -134,6 +139,7 @@ void QgsHistogramWidget::refreshValues()
   mpPlot->setEnabled( true );
   mMeanCheckBox->setEnabled( true );
   mStdevCheckBox->setEnabled( true );
+  mShowBinOutlinesCheckBox->setEnabled( true );
   mBinsSpinBox->setEnabled( true );
 
   QApplication::restoreOverrideCursor();
@@ -165,6 +171,7 @@ void QgsHistogramWidget::clearHistogram()
   mpPlot->setEnabled( false );
   mMeanCheckBox->setEnabled( false );
   mStdevCheckBox->setEnabled( false );
+  mShowBinOutlinesCheckBox->setEnabled( false );
   mBinsSpinBox->setEnabled( false );
 }
 
@@ -215,9 +222,21 @@ void QgsHistogramWidget::drawHistogram()
     mHistoColors << ( range.symbol() ? range.symbol()->color() : Qt::black );
   }
 
+  // set appropriate pen
+  if ( mShowBinOutlinesCheckBox->isChecked() )
+  {
+    mPen = QPen( mpPlot->axisWidget( QwtPlot::xBottom )->palette().color( QPalette::WindowText ) );
+    mPen.setWidth( 0 );
+    mPen.setCosmetic( true );
+  }
+  else
+  {
+    mPen = QPen( Qt::NoPen );
+  }
+
   //draw histogram
   QwtPlotHistogram *plotHistogram = nullptr;
-  plotHistogram = createPlotHistogram( !mRanges.isEmpty() ? mRanges.at( 0 ).label() : QString(), !mRanges.isEmpty() ? QBrush( mHistoColors.at( 0 ) ) : mBrush, !mRanges.isEmpty() ? Qt::NoPen : mPen );
+  plotHistogram = createPlotHistogram( !mRanges.isEmpty() ? mRanges.at( 0 ).label() : QString(), !mRanges.isEmpty() ? QBrush( mHistoColors.at( 0 ) ) : mBrush, mPen );
   QVector<QwtIntervalSample> dataHisto;
 
   int bins = mBinsSpinBox->value();
@@ -238,7 +257,7 @@ void QgsHistogramWidget::drawHistogram()
       rangeIndex++;
       plotHistogram->setSamples( dataHisto );
       plotHistogram->attach( mpPlot );
-      plotHistogram = createPlotHistogram( mRanges.at( rangeIndex ).label(), mHistoColors.at( rangeIndex ) );
+      plotHistogram = createPlotHistogram( mRanges.at( rangeIndex ).label(), mHistoColors.at( rangeIndex ), mPen );
       dataHisto.clear();
       dataHisto << QwtIntervalSample( lastValue, mRanges.at( rangeIndex - 1 ).upperValue(), edges.at( bin ) );
     }
@@ -308,21 +327,6 @@ QwtPlotHistogram *QgsHistogramWidget::createPlotHistogram( const QString &title,
 {
   QwtPlotHistogram *histogram = new QwtPlotHistogram( title );
   histogram->setBrush( brush );
-  if ( pen != Qt::NoPen )
-  {
-    histogram->setPen( pen );
-  }
-  else if ( brush.color().lightness() > 200 )
-  {
-    QPen p;
-    p.setColor( brush.color().darker( 150 ) );
-    p.setWidth( 0 );
-    p.setCosmetic( true );
-    histogram->setPen( p );
-  }
-  else
-  {
-    histogram->setPen( QPen( Qt::NoPen ) );
-  }
+  histogram->setPen( pen );
   return histogram;
 }

--- a/src/gui/qgshistogramwidget.h
+++ b/src/gui/qgshistogramwidget.h
@@ -65,6 +65,7 @@ class GUI_EXPORT QgsHistogramWidget : public QWidget, private Ui::QgsHistogramWi
 
     static const QgsSettingsEntryBool *settingsHistogramShowMean SIP_SKIP;
     static const QgsSettingsEntryBool *settingsHistogramShowStdev SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsHistogramShowBinOutlines SIP_SKIP;
 
     /**
      * Returns the layer currently associated with the widget.

--- a/src/ui/qgshistogramwidgetbase.ui
+++ b/src/ui/qgshistogramwidgetbase.ui
@@ -76,6 +76,13 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="2">
+    <widget class="QCheckBox" name="mShowBinOutlinesCheckBox">
+     <property name="text">
+      <string>Show bin outlines</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
This adds outlines around the bins in vector layer symbology histograms. Outlines are shown by default and users can toggle them with a checkbox. The checked state is stored in the user's settings. The color of the outlines is taken from the plot's axes to make them compatible with any UI theme, even dark ones.

## Description
This adds outlines around the bins in vector layer symbology histograms. Users can toggle them with a checkbox.

| Before | After | After with outlines disabled |
|-|-|-|
| <img width="518" height="774" alt="Image" src="https://github.com/user-attachments/assets/ab2ff3e0-b82d-40f3-af5b-9253d4e0a003" /> | <img width="518" height="774" alt="Image" src="https://github.com/user-attachments/assets/4928a446-aa3f-46b9-b5d6-b652c2a7cf23" /> | <img width="518" height="774" alt="Image" src="https://github.com/user-attachments/assets/2baeae0e-ca25-4c06-82ba-e04cc2b7ab85" /> |
| <img width="518" height="774" alt="Image" src="https://github.com/user-attachments/assets/27b69085-59ac-4365-9bbe-21b9f538da2c" /> | <img width="518" height="774" alt="Image" src="https://github.com/user-attachments/assets/f0e30002-7b93-4828-8e7d-5cc4bf93bfe4" /> | <img width="518" height="774" alt="Image" src="https://github.com/user-attachments/assets/d2d3e166-b6f9-4646-a515-d56e1be8f134" /> |

### Outlines are shown by default
By default, histogram bins will be rendered _with_ outlines. Even though it might look less appealing sometimes, I decided for this because it makes every bin immediately recognisable, regardless of the difference in bin height to its neighbors. Without outlines, neighboring bins of the same height appear as one wide blob. The histogram display is an information tool rather than a "nice graphics" product, so clarity seems more important than visual appeal to me.

Also this makes them visible if the user uses the histogram without any symbology classes:

<img width="370" height="201" alt="Image" src="https://github.com/user-attachments/assets/dc6f4a22-8076-4a62-b492-2e14c84d3007" />

### Outline color
The outlines use the same color as the axes ticks. This should make them have appropriate contrast to the background in dark UI themes too. :partying_face: 

<img width="428" height="219" alt="Image" src="https://github.com/user-attachments/assets/eadc976e-35ae-4ac2-8f19-2b0e50b61d65" />

### Implementation
A new checkbox below the existing checkboxes for the mean and stdev lines that toggles the outlines.

The pen is of width `0` and set as "cosmetic" which makes Qt draw it as a 1 pixel wide line, regardless of any transformation of the canvas. Theoretically it would be enough to just set the width to `0` according to https://doc.qt.io/qt-6/qpen.html but it was written this explicit before and I preferred that myself too

The checked state is written to the `QGIS4.ini` as:
```
[histogram]
histogram-show-bar-outlines=true
...
```

### Questions/Uncertainties
- [ ] I am not 100% sure if `QPalette.WindowText` is the formally correct color role I want, it might be `QPalette.Text`. And I am not sure if I shouldn't just pick the color directly from the _application_'s palette instead?
- [ ] Does this need tests? If so, I would highly appreciate some pointers and suggestions how to create them. :)
- [ ] Is this a new "feature" according to https://github.com/qgis/QGIS/blob/master/CONTRIBUTING.md#new-features-and-enhancements?

### What I did _not_ do
- I did not add an entry like `QgsHistogramWidget::settingsHistogramShowBinOutlines->copyValueFromKey( u"HistogramWidget/showBinOutlines"_s, true );` in `qgssettingsregistrygui.cpp` because I understand that those are migrations from older key syntax.
- I looked at `QgsGraduatedHistogramWidget` (inherits from `QgsHistogramWidget`) and it does not look like I would have to update that.
- I decided not to also update the histogram in `QgsCurveEditorWidget` because it has more issues in dark UI themes and I would probably make everything worse.
- Raster layers have a histogram feature too but that is quite different and since it usually shows many many bins with tiny widths, definitely should not get outlines.
- `qgshistogramwidget.h` contains some methods that appear unused to me? If they really are, maybe they should be dropped from the API? I decided to not use them.
    - `void setPen( const QPen &pen ) `
    - `QPen pen()`
    - `void setBrush( const QBrush &brush )`
    - `QBrush brush()`


## AI tool usage
 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR.

I did use GitHub Copilot for the initial identification of code to change. I did review, rework, extend and test this thoroughly and feel like I understand most of its context. See the description for remaining confusion.

-----

This was motivated by and fixes https://github.com/qgis/QGIS/issues/21651