### PR TITLE
[3d] material widgets: fix horizontal alignement for phong and metal rough widgets

### DIFF
--- a/src/app/3d/qgsmetalroughmaterialwidget.cpp
+++ b/src/app/3d/qgsmetalroughmaterialwidget.cpp
@@ -32,6 +32,9 @@ QgsMetalRoughMaterialWidget::QgsMetalRoughMaterialWidget( QWidget *parent, bool 
   mPreviewWidget->hide();
   mPreviewWidget->setMaterialType( u"metalrough"_s );
 
+  // Ensure the widgets expand without widening the label column.
+  mGridLayout->setColumnStretch( 2, 1 );
+
   QgsMetalRoughMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );
 

--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -32,6 +32,9 @@ QgsPhongMaterialWidget::QgsPhongMaterialWidget( QWidget *parent, bool hasOpacity
   mPreviewWidget->hide();
   mPreviewWidget->setMaterialType( u"phong"_s );
 
+  // Ensure the widgets expand without widening the label column.
+  mGridLayout->setColumnStretch( 2, 1 );
+
   mOpacityWidget->setVisible( mHasOpacity );
   mLblOpacity->setVisible( mHasOpacity );
   spinShininess->setClearValue( 0, tr( "None" ) );

--- a/src/ui/3d/metalroughmaterialwidget.ui
+++ b/src/ui/3d/metalroughmaterialwidget.ui
@@ -13,12 +13,53 @@
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="mGridLayout">
    <item row="0" column="1">
     <widget class="QLabel" name="lblSpecular">
      <property name="text">
       <string>Base color</string>
      </property>
+    </widget>
+   </item>
+   <item row="0" column="2" colspan="2">
+    <widget class="QWidget" name="mBaseColorContainer">
+     <layout class="QHBoxLayout" name="mBaseColorLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QgsColorButton" name="mButtonBaseColor">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsPropertyOverrideButton" name="mBaseColorDataDefinedButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="9" column="2" colspan="2">
@@ -64,13 +105,6 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="3">
-    <widget class="QgsPropertyOverrideButton" name="mEmissionColorDataDefinedButton">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="2" colspan="2">
     <widget class="QgsPercentageWidget" name="mReflectanceWidget" native="true">
      <property name="focusPolicy">
@@ -85,33 +119,10 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="2">
-    <widget class="QgsColorButton" name="mButtonEmissionColor">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
    <item row="5" column="1">
     <widget class="QLabel" name="lblRoughness_5">
      <property name="text">
       <string>Anisotropy direction</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QgsPropertyOverrideButton" name="mBaseColorDataDefinedButton">
-     <property name="text">
-      <string>...</string>
      </property>
     </widget>
    </item>
@@ -153,6 +164,47 @@
      </property>
     </widget>
    </item>
+   <item row="8" column="2" colspan="2">
+    <widget class="QWidget" name="mEmissionColorContainer">
+     <layout class="QHBoxLayout" name="mEmissionColorLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QgsColorButton" name="mButtonEmissionColor">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsPropertyOverrideButton" name="mEmissionColorDataDefinedButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="7" column="1">
     <widget class="QLabel" name="lblSpecular_7">
      <property name="text">
@@ -188,22 +240,6 @@
      </property>
      <property name="orientation">
       <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QgsColorButton" name="mButtonBaseColor">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
      </property>
     </widget>
    </item>

--- a/src/ui/3d/phongmaterialwidget.ui
+++ b/src/ui/3d/phongmaterialwidget.ui
@@ -13,27 +13,11 @@
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="2">
+  <layout class="QGridLayout" name="mGridLayout">
+   <item row="5" column="2" colspan="2">
     <widget class="QgsPercentageWidget" name="mSpecularCoefficientWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::FocusPolicy::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QgsColorButton" name="btnSpecular">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
      </property>
     </widget>
    </item>
@@ -47,6 +31,50 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="2" colspan="2">
+    <widget class="QWidget" name="mDiffuseColorContainer">
+     <layout class="QHBoxLayout" name="mDiffuseColorLayout">
+      <property name="spacing">
+       <number>3</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QgsColorButton" name="btnDiffuse">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="6" column="1">
     <widget class="QLabel" name="lblShininess">
      <property name="toolTip">
@@ -54,20 +82,6 @@
      </property>
      <property name="text">
       <string>Shininess</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3">
-    <widget class="QgsPropertyOverrideButton" name="mAmbientDataDefinedButton">
-     <property name="text">
-      <string>...</string>
      </property>
     </widget>
    </item>
@@ -81,26 +95,54 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="2" colspan="2">
+    <widget class="QWidget" name="mSpecularColorContainer">
+     <layout class="QHBoxLayout" name="mSpecularColorLayout">
+      <property name="spacing">
+       <number>3</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QgsColorButton" name="btnSpecular">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsPropertyOverrideButton" name="mSpecularDataDefinedButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="6" column="2" colspan="2">
     <widget class="QgsDoubleSpinBox" name="spinShininess">
      <property name="maximum">
       <double>1000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QgsColorButton" name="btnAmbient">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
      </property>
     </widget>
    </item>
@@ -111,7 +153,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="2" colspan="2">
     <widget class="QgsPercentageWidget" name="mDiffuseCoefficientWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::FocusPolicy::StrongFocus</enum>
@@ -125,17 +167,10 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="3" column="2" colspan="2">
     <widget class="QgsPercentageWidget" name="mAmbientCoefficientWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::FocusPolicy::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QgsPropertyOverrideButton" name="mSpecularDataDefinedButton">
-     <property name="text">
-      <string>...</string>
      </property>
     </widget>
    </item>
@@ -149,20 +184,48 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QgsColorButton" name="btnDiffuse">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
+   <item row="2" column="2" colspan="2">
+    <widget class="QWidget" name="mAmbientColorContainer">
+     <layout class="QHBoxLayout" name="mAmbientColorLayout">
+      <property name="spacing">
+       <number>3</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QgsColorButton" name="btnAmbient">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsPropertyOverrideButton" name="mAmbientDataDefinedButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="8" column="2">


### PR DESCRIPTION
## Description

This comes from a discussion of https://github.com/qgis/QGIS/pull/66981

On "Physically based" and "phong" widgets, When some data-defined buttons are not visible, some color picker widgets are not properly aligned with the other widgets.This PR fixes this issue.

Regarding phong widget, the percentage widgets are reworked to be aligned with the color picker widget and to prevent them from being aligned with the "data-defined" buttons

## AI tool usage

No AI tool used

## Screenshots

### Physically based - without data-defined button

#### Current master

<img width="639" height="371" alt="master_physic_without" src="https://github.com/user-attachments/assets/c533a5cf-434b-48d2-98f1-de983344d9d6" />

#### This PR

<img width="639" height="367" alt="new_physic_without" src="https://github.com/user-attachments/assets/129a32b8-4bdd-462a-8c17-5fe0bd034195" />

### Physically based - with data-defined button

#### Current master

<img width="639" height="371" alt="master_physic_with" src="https://github.com/user-attachments/assets/51561ba3-969f-4a84-a0a0-da991349b93c" />

#### This PR

<img width="639" height="367" alt="new_physic_with" src="https://github.com/user-attachments/assets/c21cae01-9065-4168-9b4b-9a40408f9a8f" />


### Phong - without data-defined button

#### Current master

<img width="639" height="310" alt="master_phong_without" src="https://github.com/user-attachments/assets/f6a7763e-728a-42fe-a8ec-a9eea6693be8" />

#### This PR

<img width="616" height="307" alt="phong_without_after" src="https://github.com/user-attachments/assets/5045c04f-bb0a-4389-ac61-dae20f611aab" />


### Phong - with data-defined button

#### Current master

<img width="639" height="310" alt="master_phong_with" src="https://github.com/user-attachments/assets/0a3026ff-5c76-4c4c-b912-90e89471e0c2" />

#### This PR

<img width="616" height="307" alt="phong_with_after" src="https://github.com/user-attachments/assets/1d93bcf5-e244-434f-8195-c7ab1ade78fd" />

