### PR TITLE
Update connections-default.xml for the norwegian geoportal

### DIFF
--- a/python/plugins/MetaSearch/resources/connections-default.xml
+++ b/python/plugins/MetaSearch/resources/connections-default.xml
@@ -9,7 +9,7 @@
     <csw type="OGC CSW 2.0.2" name="Italy: Istituto Nazionale di Geofisica e Vulcanologia (INGV)" url="https://ogc.ingv.it/csw/"/>
     <csw type="OGC CSW 2.0.2" name="New Zealand: LINZ Data Service" url="https://data.linz.govt.nz/services/csw/"/>
     <csw type="OGC CSW 2.0.2" name="Netherlands: National CSW (Nationaal Georegister)" url="http://www.nationaalgeoregister.nl/geonetwork/srv/dut/csw"/>
-    <csw type="OGC CSW 2.0.2" name="Norway: National CSW (Geonorge)" url="http://www.geonorge.no/geonetwork/srv/no/csw"/>
+    <csw type="OGC CSW 2.0.2" name="Norway: National CSW (Geonorge)" url="https://www.geonorge.no/geonetwork/srv/nor/csw"/>
     <csw type="OGC CSW 2.0.2" name="Sweden: National CSW" url="https://www.geodata.se/geodataportalen/srv/eng/csw-inspire"/>
     <csw type="OGC CSW 2.0.2" name="UK Location Catalogue Publishing Service" url="https://data.gov.uk/csw"/>
     <csw type="OGC CSW 2.0.2" name="UNEP GRID-Geneva Metadata Catalog" url="https://datacore-gn.unepgrid.ch/geonetwork/srv/eng/csw"/>


### PR DESCRIPTION
## Description

### Corrected URL for the norwegian geoportal in default connections in MetaSearch plugin

We at the product team responsible for maintaining the metadata portal in the Norwegian Mapping Authority discovered a short while ago that the default connection URL for Norway in the MetaSearch plugin did not work as expected, returning HTTP 404 not found:

<img width="780" height="437" alt="image" src="https://github.com/user-attachments/assets/65751cf0-11cc-4318-b614-245d71042b1a" />  

After correcting the URL (protocol: http -> https and language: no -> nor): 

<img width="911" height="478" alt="image" src="https://github.com/user-attachments/assets/2bcd169d-dac9-488b-bd3f-b6b917a234f1" />  


## AI tool usage

Not relevant