### PR TITLE
[server][oapif] Fix invalid schema properties

### DIFF
--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -677,7 +677,7 @@ void QgsWfs3AbstractItemsHandler::gatherLayerFieldsInfo( json &data, const QgsVe
 
           fInfo.role = "reference";
           fInfo.collectionId = referencedLayerId.toStdString();
-          if ( !referencedLayerTitle.isEmpty() )
+          if ( !fInfo.title.has_value() && !referencedLayerTitle.isEmpty() )
           {
             fInfo.title = referencedLayerTitle.toStdString();
           }
@@ -688,7 +688,7 @@ void QgsWfs3AbstractItemsHandler::gatherLayerFieldsInfo( json &data, const QgsVe
           const QString referencedLayerId = referencedLayerIdentifier( mapLayer, fieldElement->idx(), context, &referencedLayerTitle );
           fInfo.role = "reference";
           fInfo.collectionId = referencedLayerId.toStdString();
-          if ( !referencedLayerTitle.isEmpty() )
+          if ( !fInfo.title.has_value() && !referencedLayerTitle.isEmpty() )
           {
             fInfo.title = referencedLayerTitle.toStdString();
           }

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -837,8 +837,9 @@ void QgsWfs3AbstractItemsHandler::gatherLayerFieldsInfo( json &data, const QgsVe
     const std::string fieldName = fInfo.identifier;
     fieldsInfo[fieldName] = json::object();
     fieldsInfo[fieldName]["x-ogc-propertySeq"] = fInfo.seq;
-    fieldsInfo[fieldName]["type"] = fInfo.type;
     // Optional info
+    if ( fInfo.type.has_value() )
+      fieldsInfo[fieldName]["type"] = fInfo.type.value();
     if ( fInfo.title.has_value() )
       fieldsInfo[fieldName]["title"] = fInfo.title.value();
     if ( fInfo.readOnly.has_value() )

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -863,27 +863,22 @@ void QgsWfs3AbstractItemsHandler::gatherLayerFieldsInfo( json &data, const QgsVe
       fieldsInfo[fieldName]["pattern"] = fInfo.pattern.value();
     if ( fInfo.codelist.has_value() )
     {
-      json codelistJson = json::object();
+      json codelistJson = json::array();
       const CodelistInline &codelistInfo = fInfo.codelist.value();
-      if ( codelistInfo.title.has_value() )
-        codelistJson["title"] = codelistInfo.title.value();
-      if ( codelistInfo.description.has_value() )
-        codelistJson["description"] = codelistInfo.description.value();
-      codelistJson["oneOf"] = json::array();
       const QVariantMap values = codelistInfo.values.value();
       for ( auto it = values.constBegin(); it != values.constEnd(); ++it )
       {
         if ( it.value().isValid() )
         {
-          codelistJson["oneOf"].push_back( { { "title", it.key().toStdString() }, { "const", QgsJsonUtils::jsonFromVariant( it.value() ) } } );
+          codelistJson.push_back( { { "title", it.key().toStdString() }, { "const", QgsJsonUtils::jsonFromVariant( it.value() ) } } );
         }
         else
         {
-          codelistJson["oneOf"].push_back( { { "title", it.key().toStdString() }, { "const", json() } } );
+          codelistJson.push_back( { { "title", it.key().toStdString() }, { "const", json() } } );
           fieldsInfo[fieldName]["x-ogc-nullValues"] = json::array( { json() } );
         }
       }
-      fieldsInfo[fieldName]["x-ogc-codelist"] = codelistJson;
+      fieldsInfo[fieldName]["oneOf"] = codelistJson;
     }
   }
   data["properties"] = fieldsInfo;

--- a/tests/src/python/test_qgsserver_ogcapi_schema.py
+++ b/tests/src/python/test_qgsserver_ogcapi_schema.py
@@ -281,13 +281,10 @@ class QgsServerOgcApiSchemaTest(QgsServerAPITestBase):
             {"map": {"a": "A", "b": "B"}},
             {
                 "type": "string",
-                "x-ogc-codelist": {
-                    "oneOf": [
-                        {"const": "A", "title": "a"},
-                        {"const": "B", "title": "b"},
-                    ],
-                    "title": "field1",
-                },
+                "oneOf": [
+                    {"const": "A", "title": "a"},
+                    {"const": "B", "title": "b"},
+                ],
                 "x-ogc-propertySeq": 2,
             },
             required=True,


### PR DESCRIPTION
## Description

This PR fixes 3 issues in the document generated for an OGC API - Features (OAPIF) schema response, based on the current draft of the OAPIF Part 5 specification.

If possible, this fix should go into version 4.2

#### Fix invalid structure for `oneOf` properties

Attributes describing a value map currently contain an invalid `x-ogc-codelist` property with a nested `oneOf` property. The `oneOf` property should be defined directly on the property, without the `x-ogc-codelist` wrapper.

Relevant references:

- [OGC API - Features, Chapter 15, Requirement 34 and Example 10](https://docs.ogc.org/DRAFTS/23-058r1.html#rc_profile-codelists)

#### Remove empty `type` property for primary geometry

The primary geometry currently contains a `"type": null` property. The primary geometry is the only attribute that should not contain a `type` property. The empty property is removed.

Reference:

- [OGC API - Features, Chapter 7.1, Requirement 2, entry A](https://docs.ogc.org/DRAFTS/23-058r1.html#schema-representation)

#### Preserve explicitly defined titles for reference properties

Attributes containing a reference currently have their `title` overwritten with the name of the referenced layer. 

This is not a schema violation, but the current behaviour is not transparent from a user perspective. If a user has explicitly defined a title for an attribute, that title should be preserved rather than being overwritten with the name of the referenced layer.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
