### PR TITLE
Fix \param names that do not match the declaration

### DIFF
--- a/src/app/labeling/qgsmaptoollabel.h
+++ b/src/app/labeling/qgsmaptoollabel.h
@@ -231,7 +231,7 @@ class APP_EXPORT QgsMapToolLabel : public QgsMapToolAdvancedDigitizing
 
     /**
      * Change the data defined line anchor percent of current label
-     * \param anchorPercent data defined line anchor percent
+     * \param lineAnchorPercent data defined line anchor percent
      * \returns TRUE if data defined curved offset could be changed
      */
     bool changeCurrentLabelDataDefinedLineAnchorPercent( const QVariant &lineAnchorPercent );

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -44,7 +44,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
   public:
     /**
      * Constructor.
-     * \param qgis Pointer to the QgisApp object
+     * \param qgisapp Pointer to the QgisApp object
      */
     QgisAppInterface( QgisApp *qgisapp );
 

--- a/src/app/vertextool/qgslockedfeature.h
+++ b/src/app/vertextool/qgslockedfeature.h
@@ -39,7 +39,7 @@ class APP_EXPORT QgsLockedFeature : public QObject
   public:
     /**
      * Creates a locked feature
-     * \param featureId id of feature which was selected
+     * \param id id of feature which was selected
      * \param layer vector layer in which feature is selected
      * \param canvas mapCanvas on which we are working
      */

--- a/src/core/mesh/qgsmeshcalcnode.h
+++ b/src/core/mesh/qgsmeshcalcnode.h
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsMeshCalcNode
 
     /**
      * Constructs a Type::tDatasetGroupRef node with values from dataset group
-     * \param datasetName dataset group to fetch data and populate node data
+     * \param datasetGroupName dataset group to fetch data and populate node data
      */
     QgsMeshCalcNode( const QString &datasetGroupName );
 

--- a/src/providers/delimitedtext/qgsdelimitedtextfile.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.h
@@ -173,7 +173,7 @@ class QgsDelimitedTextFile : public QObject
 
     /**
      * Set reading field names from the first record
-     * \param useheaders Field names will be read if true
+     * \param useheader Field names will be read if true
      */
     void setUseHeader( bool useheader = true );
 

--- a/src/providers/grass/qgsgrassprovider.h
+++ b/src/providers/grass/qgsgrassprovider.h
@@ -458,7 +458,7 @@ class GRASS_LIB_EXPORT QgsGrassProvider : public QgsVectorDataProvider
     /**
      * Gets attribute by category(key) and attribute number.
      *  \param layerId
-     *  \param category (key)
+     *  \param cat (key)
      *  \param column column number ( < nColumns )
      *  \returns pointer to string representation of the value or NULL, this value must not be changed
      */


### PR DESCRIPTION
## Description

Ran doxygen over src and six `\param` names came back with nothing matching them in the declaration below. Most are an argument that got renamed while the comment stayed put, and `useheaders` against `useheader` plus `category` against `cat` are off by a letter or two. Doxygen drops a name it cannot match without saying anything, so the argument quietly ends up undocumented on the API page while the build stays green. I left out the hits where the argument list carries `SIP_OUT` or `SIP_TRANSFER`, my reader mangles those, and the ones where the documented parameter is gone from the signature altogether, since removing a line there is someone else's call.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

Claude Code (claude-opus-5) found the mismatches and drafted this text. Every one of the six was checked by hand against the declaration under it.
