### PR TITLE
[GetCapabilities] Do not expose Style for group

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1256,13 +1256,6 @@ namespace QgsWms
 
           writeServerProperties( doc, layerElem, project, treeGroupChild->serverProperties(), name, version );
 
-          // There is no style assicated with layer tree group so just use a default one
-          const QString styleName = u"default"_s;
-          QDomElement styleElem = createStyleElement( doc, styleName );
-          writeLegendUrl( doc, styleElem, treeGroupChild->serverProperties()->legendUrl(), treeGroupChild->serverProperties()->legendUrlFormat(), name, styleName, project, request, serverIface->serverSettings() );
-
-          layerElem.appendChild( styleElem );
-
           // Layer tree name
           if ( projectSettings )
           {

--- a/tests/testdata/qgis_server/getcapabilities-map.txt
+++ b/tests/testdata/qgis_server/getcapabilities-map.txt
@@ -330,14 +330,6 @@ Content-Type: text/xml; charset=utf-8
      <Format>text/xml</Format>
      <OnlineResource xlink:type="simple" xlink:href="http://groupmetadata1.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
     </MetadataURL>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/jpeg</Format>
-      <OnlineResource xlink:type="simple" xlink:href="http://mylegendurl.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -376,14 +368,6 @@ Content-Type: text/xml; charset=utf-8
     </EX_GeographicBoundingBox>
     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -330,14 +330,6 @@ Content-Type: text/xml; charset=utf-8
      <Format>text/xml</Format>
      <OnlineResource xlink:type="simple" xlink:href="http://groupmetadata1.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
     </MetadataURL>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/jpeg</Format>
-      <OnlineResource xlink:type="simple" xlink:href="http://mylegendurl.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -376,14 +368,6 @@ Content-Type: text/xml; charset=utf-8
     </EX_GeographicBoundingBox>
     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project.qgs&amp;SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=testlayer2&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -388,14 +388,6 @@ Content-Type: text/xml; charset=utf-8
      <Format>text/xml</Format>
      <OnlineResource xlink:type="simple" xlink:href="http://groupmetadata1.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
     </MetadataURL>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/jpeg</Format>
-      <OnlineResource xlink:type="simple" xlink:href="http://mylegendurl.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <TreeName>groupwithshortname</TreeName>
     <Layer geometryType="Point" queryable="1" displayField="id" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer2</Name>
@@ -441,14 +433,6 @@ Content-Type: text/xml; charset=utf-8
     </EX_GeographicBoundingBox>
     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <TreeName>groupwithoutshortname</TreeName>
     <Layer geometryType="Point" queryable="0" displayField="name" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer3</Name>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -300,14 +300,6 @@ Content-Type: text/xml; charset=utf-8
     </EX_GeographicBoundingBox>
     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <TreeName>groupwithshortname</TreeName>
     <Layer geometryType="Point" queryable="1" displayField="id" visible="1" visibilityChecked="1" opacity="1" expanded="1">
      <Name>testlayer2</Name>
@@ -353,14 +345,6 @@ Content-Type: text/xml; charset=utf-8
     </EX_GeographicBoundingBox>
     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?*****" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <TreeName>groupwithoutshortname</TreeName>
     <Layer geometryType="Point" queryable="0" displayField="name" visible="1" visibilityChecked="1" opacity="0.8" expanded="1">
      <Name>testlayer3</Name>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
@@ -276,14 +276,6 @@ Content-Type: text/xml; charset=utf-8
      <Format>text/xml</Format>
      <OnlineResource xlink:type="simple" xlink:href="http://groupmetadata1.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
     </MetadataURL>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/jpeg</Format>
-      <OnlineResource xlink:type="simple" xlink:href="http://mylegendurl.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -310,14 +302,6 @@ Content-Type: text/xml; charset=utf-8
     <LatLonBoundingBox maxy="44.901483" maxx="8.203547" miny="44.901394" minx="8.203459"/>
     <BoundingBox maxy="5606025.238" SRS="EPSG:3857" maxx="913214.675" miny="5606011.456" minx="913204.912"/>
     <BoundingBox maxy="44.901483" SRS="EPSG:4326" maxx="8.203547" miny="44.901394" minx="8.203459"/>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project.qgs&amp;SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=testlayer2&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -330,14 +330,6 @@ Content-Type: text/xml; charset=utf-8
      <Format>text/xml</Format>
      <OnlineResource xlink:type="simple" xlink:href="http://groupmetadata1.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
     </MetadataURL>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/jpeg</Format>
-      <OnlineResource xlink:type="simple" xlink:href="http://mylegendurl.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -376,14 +368,6 @@ Content-Type: text/xml; charset=utf-8
     </EX_GeographicBoundingBox>
     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/png</Format>
-      <OnlineResource xlink:type="simple" xlink:href="https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project.qgs&amp;SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=testlayer2&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>

--- a/tests/testdata/qgis_server/wms_getcapabilities_rewriting.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_rewriting.txt
@@ -1,4 +1,4 @@
-Content-Length: 18351
+Content-Length: 17647
 Content-Type: text/xml; charset=utf-8
 
 <?xml version="1.0" encoding="utf-8"?>
@@ -330,14 +330,6 @@ Content-Type: text/xml; charset=utf-8
      <Format>text/xml</Format>
      <OnlineResource xlink:type="simple" xlink:href="http://groupmetadata1.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
     </MetadataURL>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/jpeg</Format>
-      <OnlineResource xlink:type="simple" xlink:href="http://mylegendurl.com" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="1">
      <Name>testlayer2</Name>
      <Title>testlayer2</Title>
@@ -376,14 +368,6 @@ Content-Type: text/xml; charset=utf-8
     </EX_GeographicBoundingBox>
     <BoundingBox maxy="5606025.238" maxx="913214.675" miny="5606011.456" CRS="EPSG:3857" minx="913204.912"/>
     <BoundingBox maxy="8.203547" maxx="44.901483" miny="8.203459" CRS="EPSG:4326" minx="44.901394"/>
-    <Style>
-     <Name>default</Name>
-     <Title>default</Title>
-     <LegendURL>
-      <Format>image/png</Format>
-       <OnlineResource xlink:type="simple" xlink:href="http://localhost/wms/test_project?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=groupwithoutshortname&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0" xmlns:xlink="http://www.w3.org/1999/xlink"/>
-     </LegendURL>
-    </Style>
     <Layer queryable="0">
      <Name>testlayer3</Name>
      <Title>testlayer3</Title>


### PR DESCRIPTION
## Description

They don't have actually style that could be activated then with STYLE parameter. It was a regression introduced in #61195 3.44 while a refactoring. OGC WMS specification allows to have zero style.

> 7.2.4.6.5 Style
> Zero or more Styles may be advertised for a Layer or collection of layers using <Style> elements

## AI tool usage

None

**Funded by Ressources Naturelles Canada**