### PR TITLE
Fix build: Remove Q_FLAG on private member

### DIFF
--- a/src/3d/symbols/qgsbillboardgeometry.h
+++ b/src/3d/symbols/qgsbillboardgeometry.h
@@ -113,7 +113,6 @@ class _3D_EXPORT QgsBillboardGeometry : public Qt3DCore::QGeometry
       PixelOffsets = 1 << 3,
     };
     Q_DECLARE_FLAGS( Attributes, Attribute )
-    Q_FLAG( Attributes )
 
     void setAttributes( Attributes attributes );
     Attributes mAttributes;


### PR DESCRIPTION
## Description

Since #67135, I get the following error message 

> In file included from /home/julien/work/QGIS/.worktrees/rncan_fix_style/src/3d/symbols/qgsbillboardgeometry.cpp:23:
> /home/julien/work/QGIS/.worktrees/rncan_fix_style/build/src/3d/qgis_3d_autogen/include/moc_qgsbillboardgeometry.cpp:81:38: error: 'Attribute' is a private member of 'QgsBillboardGeometry'
>    81 |        6, uint(QgsBillboardGeometry::Attribute::Position),
>       |                                      ^
> /home/julien/work/QGIS/.worktrees/rncan_fix_style/src/3d/symbols/qgsbillboardgeometry.h:108:16: note: declared private here
>   108 |     enum class Attribute
> 

I'm on Debian 13 (trixie) with Qt 6.8.2

## AI tool usage

None