### PR TITLE
[PostgreSQL] Don't propagate session_role parameter to PQConnect

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -331,7 +331,10 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
         mUri.setPassword( password );
 
       QgsDebugMsgLevel( "Connecting to " + QgsPostgresConn::connectionInfo( mUri, false ), 2 );
-      QString connectString = QgsPostgresConn::connectionInfo( mUri );
+
+      // We don't use QgsPostgresConn::connectionInfo() here because it would add session_role parameter
+      // which is not a valid parameter to PQConnectdb()
+      QString connectString = mUri.connectionInfo();
       addDefaultTimeoutAndClientEncoding( connectString );
       // use conninfo for log, connectString - can contain clear text username & password
       logWrapper = std::make_unique<QgsDatabaseQueryLogWrapper>( u"libpq::PQconnectdb()"_s, conninfo, u"postgres"_s, u"QgsPostgresConn"_s, QGS_QUERY_LOG_ORIGIN_PG_CON );


### PR DESCRIPTION
## Description

Fixes #67178

the issue happen when you fail the first connection because you have bad credentials and then, even if the user set the correct credentials, it fails printing the `Invalid connection option: "session role"` message.


The regression was introduced in #61386 [here](https://github.com/qgis/QGIS/pull/61386/changes#diff-0f5c2a816f858de7d3f811e413c73d264a5bfd97492e9d6d34fd97bae4701e9bL415)

## AI tool usage

None

**Funded by Oslandia**