### PR TITLE
[sfcgal] fix some geometry vs primitive return types

### DIFF
--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -355,7 +355,7 @@ sfcgal::shared_geom QgsSfcgalEngine::fromWkt( const QString &wkt, QString *error
   sfcgal::geometry *out = sfcgal_io_read_wkt( wkt.toStdString().c_str(), wkt.length() );
   CHECK_SUCCESS( errorMsg, nullptr );
 
-  return sfcgal::unique_geom( out );
+  return sfcgal::make_shared_geom( out );
 }
 
 QByteArray QgsSfcgalEngine::toWkb( const sfcgal::geometry *geom, QString *errorMsg )

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -1423,7 +1423,7 @@ sfcgal::shared_prim QgsSfcgalEngine::primitiveTranslate( const sfcgal::primitive
   return sfcgal::make_shared_prim( result );
 }
 
-sfcgal::shared_geom QgsSfcgalEngine::primitiveRotate( const sfcgal::primitive *prim, double angle, const QgsVector3D &axisVector, const QgsPoint &center, QString *errorMsg )
+sfcgal::shared_prim QgsSfcgalEngine::primitiveRotate( const sfcgal::primitive *prim, double angle, const QgsVector3D &axisVector, const QgsPoint &center, QString *errorMsg )
 {
   const QgsPoint rotationCenter = center.isEmpty() ? QgsPoint( 0, 0, 0 ) : center;
 
@@ -1433,7 +1433,7 @@ sfcgal::shared_geom QgsSfcgalEngine::primitiveRotate( const sfcgal::primitive *p
   return sfcgal::make_shared_prim( result );
 }
 
-sfcgal::shared_geom QgsSfcgalEngine::primitiveScale( const sfcgal::primitive *prim, const QgsVector3D &scaleFactor, const QgsPoint &center, QString *errorMsg )
+sfcgal::shared_prim QgsSfcgalEngine::primitiveScale( const sfcgal::primitive *prim, const QgsVector3D &scaleFactor, const QgsPoint &center, QString *errorMsg )
 {
   const QgsPoint scaleCenter = center.isEmpty() ? QgsPoint( 0, 0, 0 ) : center;
 

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -936,7 +936,7 @@ class CORE_EXPORT QgsSfcgalEngine
      *
      * \since QGIS 4.2
      */
-    static sfcgal::shared_geom primitiveRotate( const sfcgal::primitive *prim, double angle, const QgsVector3D &axisVector, const QgsPoint &center = QgsPoint(), QString *errorMsg = nullptr );
+    static sfcgal::shared_prim primitiveRotate( const sfcgal::primitive *prim, double angle, const QgsVector3D &axisVector, const QgsPoint &center = QgsPoint(), QString *errorMsg = nullptr );
 
     /**
      * Scale the primitive \a prim by vector \a scaleFactor.
@@ -948,7 +948,7 @@ class CORE_EXPORT QgsSfcgalEngine
      *
      * \since QGIS 4.2
      */
-    static sfcgal::shared_geom primitiveScale( const sfcgal::primitive *prim, const QgsVector3D &scaleFactor, const QgsPoint &center = QgsPoint(), QString *errorMsg = nullptr );
+    static sfcgal::shared_prim primitiveScale( const sfcgal::primitive *prim, const QgsVector3D &scaleFactor, const QgsPoint &center = QgsPoint(), QString *errorMsg = nullptr );
 #endif
 };
 

--- a/src/core/geometry/qgssfcgalgeometry.cpp
+++ b/src/core/geometry/qgssfcgalgeometry.cpp
@@ -1067,7 +1067,7 @@ std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::primitiveAsPolyhedralSurfa
 
   QString errorMsg;
   sfcgal::errorHandler()->clearText( &errorMsg );
-  sfcgal::shared_prim result = QgsSfcgalEngine::primitiveAsPolyhedral( mSfcgalPrim.get(), &errorMsg );
+  sfcgal::shared_geom result = QgsSfcgalEngine::primitiveAsPolyhedral( mSfcgalPrim.get(), &errorMsg );
   THROW_ON_ERROR( &errorMsg );
 
   std::unique_ptr<QgsSfcgalGeometry> resultGeom = QgsSfcgalEngine::toSfcgalGeometry( result, &errorMsg );


### PR DESCRIPTION
## Description

`sfcgal::shared_geom` and `sfcgal::shared_prim` represent the same type under the hood (a shared pointer to `void *`) but it is still useful to distinguish geometry from primitive usage.

## AI tool usage

No AI Tool used
