### PR TITLE
Fix dead Transifex link in CONTRIBUTING 🤖🤖🤖

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ For large-scale changes, you can open a [QEP (QGIS Enhancement Proposal)](https:
 
 Please help translate QGIS to your language. At this moment about forty languages are already available in the Desktop user interface and about eighty languages are available in transifex ready to be translated.
 
-The [translation](https://docs.qgis.org/latest/en/docs/documentation_guidelines/do_translations.html) process is managed by the [Translation Team](https://qgis.org/community/organisation/#translation) and all the activities are done under the [Transifex](https://www.transifex.com/qgis/) platform.
+The [translation](https://docs.qgis.org/latest/en/docs/documentation_guidelines/do_translations.html) process is managed by the [Translation Team](https://qgis.org/community/organisation/#translation) and all the activities are done under the [Transifex](https://explore.transifex.com/qgis/) platform.
 
 ## Other ways to contribute
 


### PR DESCRIPTION
`CONTRIBUTING.md` line 33 links the Transifex platform as `https://www.transifex.com/qgis/`, which returns 404. Transifex moved public project pages to `explore.transifex.com`, and `https://explore.transifex.com/qgis/` returns 200.

That is the link a would-be translator follows from the Translations section, so it currently dead-ends.

I requested every URL in `README.md`, `INSTALL.md`, `CONTRIBUTING.md`, `doc/index.dox` and `doc/api_break.dox` — 153 unique — and this is the only real breakage. Two things that look broken but are not, so nobody re-checks them: the `nightly.link` SDK download in `INSTALL.md` 404s on a HEAD request but serves correctly on GET (the `qgis-sdk-x64-windows` artifact is present on the latest successful `windows-qt6` master run), and the Zenodo DOI badge, `doi.org` and `gis.stackexchange.com` links return 403 to scripted requests while working in a browser.

Title carries `🤖🤖🤖` per the note in CONTRIBUTING.md. Disclosure: written with AI assistance (Claude, via Claude Code); I verified both URLs by request rather than inferring them.