### PR TITLE
Improve undo/redo button handling for 3d map canvas

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -137,6 +137,17 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   mActionUndo->setObjectName( u"m3DActionUndo"_s );
   mActionRedo->setObjectName( u"m3DActionRedo"_s );
 
+  connect( mActionUndo, &QAction::triggered, this, [] {
+    QgsMapLayer *layer = QgisApp::instance()->activeLayer();
+    if ( layer && layer->isEditable() )
+      layer->undoStack()->undo();
+  } );
+  connect( mActionRedo, &QAction::triggered, this, [] {
+    QgsMapLayer *layer = QgisApp::instance()->activeLayer();
+    if ( layer && layer->isEditable() )
+      layer->undoStack()->redo();
+  } );
+
   mEditingToolBar->addAction( mActionToggleEditing );
   mEditingToolBar->addAction( mActionUndo );
   mEditingToolBar->addAction( mActionRedo );
@@ -713,9 +724,6 @@ void Qgs3DMapCanvasWidget::setCanvasName( const QString &name )
 
 void Qgs3DMapCanvasWidget::updateLayerRelatedActions( QgsMapLayer *layer )
 {
-  mActionUndo->disconnect();
-  mActionRedo->disconnect();
-
   if ( !layer || layer->type() != Qgis::LayerType::PointCloud )
   {
     mPointCloudEditingToolbar->setEnabled( false );
@@ -751,16 +759,17 @@ void Qgs3DMapCanvasWidget::updateLayerRelatedActions( QgsMapLayer *layer )
 
   mActionToggleEditing->setEnabled( pcLayer->supportsEditing() );
   mActionToggleEditing->setChecked( pcLayer->isEditable() );
-  connect( mActionUndo, &QAction::triggered, pcLayer->undoStack(), &QUndoStack::undo );
-  connect( mActionRedo, &QAction::triggered, pcLayer->undoStack(), &QUndoStack::redo );
-  mActionUndo->setEnabled( pcLayer->undoStack()->canUndo() );
-  mActionRedo->setEnabled( pcLayer->undoStack()->canRedo() );
-  connect( pcLayer->undoStack(), &QUndoStack::canUndoChanged, mActionUndo, &QAction::setEnabled );
-  connect( pcLayer->undoStack(), &QUndoStack::canRedoChanged, mActionRedo, &QAction::setEnabled );
+  updateUndoRedoActions( pcLayer->undoStack()->canUndo(), pcLayer->undoStack()->canRedo() );
   mPointCloudEditingToolbar->setEnabled( pcLayer->isEditable() );
   mEditingToolsAction->setEnabled( pcLayer->isEditable() );
   // Reparse the class values when the renderer changes - renderer3DChanged() is not fired when only the renderer symbol is changed
   connect( pcLayer, &QgsMapLayer::request3DUpdate, this, &Qgs3DMapCanvasWidget::onPointCloudChangeAttributeSettingsChanged );
+}
+
+void Qgs3DMapCanvasWidget::updateUndoRedoActions( bool canUndo, bool canRedo )
+{
+  mActionUndo->setEnabled( canUndo );
+  mActionRedo->setEnabled( canRedo );
 }
 
 bool Qgs3DMapCanvasWidget::eventFilter( QObject *watched, QEvent *event )

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -101,6 +101,8 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     void setCanvasName( const QString &name );
     QString canvasName() const { return mCanvasName; }
 
+    void updateUndoRedoActions( bool canUndo, bool canRedo );
+
     void showAnimationWidget() { mActionAnim->trigger(); }
 
     void updateLayerRelatedActions( QgsMapLayer *layer );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -16601,6 +16601,11 @@ void QgisApp::updateUndoActions()
   }
   mActionUndo->setEnabled( canUndo );
   mActionRedo->setEnabled( canRedo );
+
+#ifdef HAVE_3D
+  for ( Qgs3DMapCanvasWidget *w : mOpen3DMapViews )
+    w->updateUndoRedoActions( canUndo, canRedo );
+#endif
 }
 
 


### PR DESCRIPTION
The disconnect() of undo/redo button from all signals is a bit ugly, and if there's anything else connected, this can trigger Qt warning which may cause a deadlock when QGIS tries to push that warning to the message bar.

Also fixes an issue with undo/redo buttons not being correctly enabled/disabled because canUndoChanged()/canRedoChanged() signals were not getting disconnected

With this change, we are using the approach like in QGIS main window, where the undo/redo buttons are not directly linked to a map layer's undo stack.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
