### PR TITLE
qgsalgorithmapproximatemedialaxis: Prevent crash when geometry creation fails

### DIFF
--- a/src/analysis/processing/qgsalgorithmapproximatemedialaxis.cpp
+++ b/src/analysis/processing/qgsalgorithmapproximatemedialaxis.cpp
@@ -143,6 +143,7 @@ QgsFeatureList QgsApproximateMedialAxisAlgorithm::processFeature( const QgsFeatu
   {
     QgsGeometry outputGeometry;
     QgsSfcgalGeometry inputSfcgalGeometry;
+    bool constructorSuccess = true;
     try
     {
       inputSfcgalGeometry = QgsSfcgalGeometry( modifiedFeature.geometry() );
@@ -151,9 +152,10 @@ QgsFeatureList QgsApproximateMedialAxisAlgorithm::processFeature( const QgsFeatu
     {
       feedback->reportError( QObject::tr( "Cannot calculate approximate medial axis for feature %1: %2" ).arg( feature.id() ).arg( exception.what() ) );
       modifiedFeature.clearGeometry();
+      constructorSuccess = false;
     }
 
-    if ( !inputSfcgalGeometry.isEmpty() )
+    if ( constructorSuccess && !inputSfcgalGeometry.isEmpty() )
     {
       try
       {


### PR DESCRIPTION
## Description

If SFCGAL geometry creation fails, an exception is thrown. However, `isEmpty` method is still called. This also throws an exception because the geometry has not been properly created. This results in a crash because this exception is not caught.

Fix the issue by checking that the geometry has been properly created.

Closes: https://github.com/qgis/QGIS/issues/67275

## AI tool usage

No AI tool used
