### PR TITLE
[expressions] Narrow the columns the overlay functions depend on

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -9919,6 +9919,37 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     zFunc->setIsStatic( false );
     functions << zFunc;
 
+    const auto overlayReferencedColumns = []( const QgsExpressionNodeFunction *node ) {
+      if ( !node )
+        return QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES;
+
+      if ( !node->args() )
+        return QSet<QString>();
+
+      QSet<QString> referencedColumns;
+      QSet<QString> referencedVariables;
+
+      // Expression and filter are evaluated against the target layer, so only their variables matter
+      if ( node->args()->count() > 1 )
+        referencedVariables.unite( node->args()->at( 1 )->referencedVariables() );
+      if ( node->args()->count() > 2 )
+        referencedVariables.unite( node->args()->at( 2 )->referencedVariables() );
+
+      // Limit is evaluated against the source feature, so keep its columns
+      if ( node->args()->count() > 3 )
+      {
+        QgsExpressionNode *limitNode = node->args()->at( 3 );
+        referencedColumns.unite( limitNode->referencedColumns() );
+        referencedVariables.unite( limitNode->referencedVariables() );
+      }
+
+      // @parent reads the source feature, and an empty name is only known once evaluated
+      if ( referencedVariables.contains( u"parent"_s ) || referencedVariables.contains( QString() ) )
+        return QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES;
+
+      return referencedColumns;
+    };
+
     QMap< QString, QgsExpressionFunction::FcnEval > geometry_overlay_definitions {
       { u"overlay_intersects"_s, fcnGeomOverlayIntersects },
       { u"overlay_contains"_s, fcnGeomOverlayContains },
@@ -9953,8 +9984,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         i.value(),
         u"GeometryGroup"_s,
         QString(),
-        true,
-        QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES,
+        []( const QgsExpressionNodeFunction * ) { return true; },
+        overlayReferencedColumns,
         true
       );
 
@@ -9975,8 +10006,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
       fcnGeomOverlayNearest,
       u"GeometryGroup"_s,
       QString(),
-      true,
-      QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES,
+      []( const QgsExpressionNodeFunction * ) { return true; },
+      overlayReferencedColumns,
       true
     );
     // The current feature is accessed for the geometry, so this should not be cached

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -66,6 +66,9 @@ class TestQgsOverlayExpression : public QObject
     void testOverlayMeasure();
     void testOverlayMeasure_data();
 
+    void testReferencedColumns();
+    void testReferencedColumns_data();
+
     void testOverlayIntersectsDetails();
 };
 
@@ -687,6 +690,49 @@ void TestQgsOverlayExpression::testOverlayExpression_data()
   QTest::newRow( "intersects get ids limit 2 #39068 [cached]" ) << "overlay_intersects('rectangles', id, limit:=2,cache:=true)" << "LINESTRING(-178 52, -133 33, -132 42, -64 46)" << QVariantList { 1, 3 };
 }
 
+
+void TestQgsOverlayExpression::testReferencedColumns()
+{
+  QFETCH( QString, expression );
+  QFETCH( QStringList, expectedColumns );
+
+  QgsExpression exp( expression );
+  QVERIFY2( !exp.hasParserError(), exp.parserErrorString().toUtf8().constData() );
+
+  QSet<QString> expected;
+  for ( const QString &column : expectedColumns )
+    expected.insert( column );
+
+  QCOMPARE( exp.referencedColumns(), expected );
+
+  // Narrowing the dependencies must not drop the geometry requirement
+  QVERIFY( exp.needsGeometry() );
+}
+
+void TestQgsOverlayExpression::testReferencedColumns_data()
+{
+  QTest::addColumn<QString>( "expression" );
+  QTest::addColumn<QStringList>( "expectedColumns" );
+
+  QTest::newRow( "no subexpression" ) << u"overlay_intersects('rectangles')"_s << QStringList();
+  QTest::newRow( "target expression field" ) << u"overlay_intersects('rectangles', id)"_s << QStringList();
+  QTest::newRow( "target filter field" ) << u"overlay_intersects('rectangles', id, id > 1)"_s << QStringList();
+  QTest::newRow( "source layer field" ) << u"overlay_intersects(\"source_layer\")"_s << QStringList { u"source_layer"_s };
+  QTest::newRow( "source limit field" ) << u"overlay_intersects('rectangles', limit:=\"source_limit\")"_s << QStringList { u"source_limit"_s };
+  QTest::newRow( "source cache field" ) << u"overlay_intersects('rectangles', cache:=\"source_cache\")"_s << QStringList { u"source_cache"_s };
+  QTest::newRow( "parent in expression" ) << u"overlay_intersects('rectangles', attribute(@parent, 'source_field'))"_s << QStringList { QgsFeatureRequest::ALL_ATTRIBUTES };
+  QTest::newRow( "parent in filter" ) << u"overlay_intersects('rectangles', id, attribute(@parent, 'source_field') > 1)"_s << QStringList { QgsFeatureRequest::ALL_ATTRIBUTES };
+  QTest::newRow( "dynamic variable in expression" ) << u"overlay_intersects('rectangles', var(\"variable_name\"))"_s << QStringList { QgsFeatureRequest::ALL_ATTRIBUTES };
+  QTest::newRow( "parent in limit" ) << u"overlay_intersects('rectangles', limit:=attribute(@parent, 'source_field'))"_s << QStringList { QgsFeatureRequest::ALL_ATTRIBUTES };
+  QTest::newRow( "parent variable in limit" ) << u"overlay_intersects('rectangles', limit:=@parent)"_s << QStringList { QgsFeatureRequest::ALL_ATTRIBUTES };
+  QTest::newRow( "named arguments" ) << u"overlay_intersects(layer:='rectangles', expression:=id, min_inscribed_circle_radius:=1, sort_by_intersection_size:='desc')"_s << QStringList();
+  QTest::newRow( "source min_overlap field" ) << u"overlay_intersects('rectangles', min_overlap:=\"source_overlap\")"_s << QStringList { u"source_overlap"_s };
+
+  QTest::newRow( "nearest target expression field" ) << u"overlay_nearest('rectangles', id)"_s << QStringList();
+  QTest::newRow( "nearest source limit field" ) << u"overlay_nearest('rectangles', limit:=\"source_limit\")"_s << QStringList { u"source_limit"_s };
+  QTest::newRow( "nearest source max_distance field" ) << u"overlay_nearest('rectangles', max_distance:=\"source_distance\")"_s << QStringList { u"source_distance"_s };
+  QTest::newRow( "nearest parent in expression" ) << u"overlay_nearest('rectangles', attribute(@parent, 'source_field'))"_s << QStringList { QgsFeatureRequest::ALL_ATTRIBUTES };
+}
 
 void TestQgsOverlayExpression::testOverlaySelf()
 {


### PR DESCRIPTION
## Description

The overlay functions asked for all attributes, so a field using one as a default value with "apply default value on update" was recomputed on every change in the form.

Expression and filter are evaluated against the target layer, so they say nothing about the current feature. The limit is evaluated in the current context, so I kept its columns. Still falls back to all attributes when @parent or a variable name that is only known at evaluation time is involved, like the aggregate functions here already do.

needsGeometry is unchanged, so a default value that is meant to follow the geometry still updates.

Left relation_aggregate alone for now. If this looks good I think it's worth backporting.

Fixes #56383

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

Level 5 on the visidata scale. ChatGPT wrote the first version, then I used Claude Code to fix the constructor overload and add the test rows. I decided the behaviour, reviewed it and ran the tests.
