### PR TITLE
[SIP_FACTORY] Avoid SIP_FACTORY when unique_ptr is returned

### DIFF
--- a/python/PyQt6/core/auto_generated/elevation/qgsprofilerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgsprofilerenderer.sip.in
@@ -164,7 +164,7 @@ If ``sourceId`` is empty then all sources will be rendered, otherwise
 only the matching source will be rendered.
 %End
 
-    static std::unique_ptr<QgsLineSymbol> defaultSubSectionsSymbol() /Factory/;
+    static std::unique_ptr<QgsLineSymbol> defaultSubSectionsSymbol();
 %Docstring
 Returns the default line symbol to use for subsections lines.
 

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenetexturerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenetexturerenderer.sip.in
@@ -50,7 +50,7 @@ Constructor for QgsTiledSceneTextureRenderer.
 Creates a textured renderer from an XML ``element``.
 %End
 
-    static std::unique_ptr< QgsFillSymbol > createDefaultFillSymbol() /Factory/;
+    static std::unique_ptr< QgsFillSymbol > createDefaultFillSymbol();
 %Docstring
 Returns a copy of the default fill symbol used to render triangles
 without textures.

--- a/scripts/sipify.py
+++ b/scripts/sipify.py
@@ -1618,6 +1618,11 @@ def fix_annotations(line):
     if py_name_match:
         CONTEXT.method_py_name = py_name_match.group(1)
 
+    if "std.unique_ptr" in CONTEXT.return_type and "SIP_FACTORY" in line:
+        exit_with_error(
+            "Don't specify SIP_FACTORY if the return type is std::unique_ptr"
+        )
+
     # Printed annotations
     replacements = {
         r"//\s*SIP_ABSTRACT\b": "/Abstract/",

--- a/src/core/elevation/qgsprofilerenderer.h
+++ b/src/core/elevation/qgsprofilerenderer.h
@@ -186,7 +186,7 @@ class CORE_EXPORT QgsProfilePlotRenderer : public QObject
      * \see setSubsectionsSymbol()
      * \since QGIS 3.44
      */
-    static std::unique_ptr<QgsLineSymbol> defaultSubSectionsSymbol() SIP_FACTORY;
+    static std::unique_ptr<QgsLineSymbol> defaultSubSectionsSymbol();
 
     /**
      * Returns the line symbol used to draw the subsections.

--- a/src/core/tiledscene/qgstiledscenetexturerenderer.h
+++ b/src/core/tiledscene/qgstiledscenetexturerenderer.h
@@ -58,7 +58,7 @@ class CORE_EXPORT QgsTiledSceneTextureRenderer : public QgsTiledSceneRenderer
      *
      * \see setFillSymbol()
      */
-    static std::unique_ptr< QgsFillSymbol > createDefaultFillSymbol() SIP_FACTORY;
+    static std::unique_ptr< QgsFillSymbol > createDefaultFillSymbol();
 
     /**
      * Returns the fill symbol used to render triangles without textures.


### PR DESCRIPTION
## Description

This PR is part of QEP [#417](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-417-remove-sip-factory.md)

SIP_FACTORY is redundant for methods which returns unique_ptr as the unique_ptr mapped type in conversions.sip already transfers the object ownership to python.

## AI tool usage

None

**Funded by the QGIS Grant programme 2026**