### PR TITLE
Fix regression introduced with CompoundCurve::deleteVertices when deleting a shared vertex (surviving points)

### DIFF
--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -968,15 +968,42 @@ bool QgsCompoundCurve::deleteVertices( const QSet<QgsVertexId> &positions )
     }
   }
 
+  QVector< QgsPoint > survivingPoints;
+
+  auto appendSurvivingPoints = [&survivingPoints, this]( const QgsPoint &point, const int curveId ) {
+    QgsPointSequence pts;
+    pts.reserve( 1 + survivingPoints.size() );
+    pts << point;
+
+    for ( size_t i = survivingPoints.size(); i-- > 0; )
+      pts << survivingPoints[i];
+
+    auto newLineString = std::make_unique<QgsLineString>();
+    newLineString->setPoints( pts );
+    mCurves.insert( curveId, newLineString.release() );
+
+    survivingPoints.clear();
+  };
+
   // loop through the curves in reverse order and delete vertices
   QMapIterator<int, QList<QgsVertexId >> curveVerticesIt( curveVertices );
   curveVerticesIt.toBack();
+  int previousCurveId = -1;
   while ( curveVerticesIt.hasPrevious() )
   {
     curveVerticesIt.previous();
     const int curveId = curveVerticesIt.key();
+
+    // append surviving points at the end of a curve that has no vertices scheduled for deletion
+    if ( previousCurveId - 1 > curveId && !survivingPoints.isEmpty() )
+    {
+      QgsCurve *curve = mCurves.at( previousCurveId - 1 );
+      appendSurvivingPoints( curve->endPoint(), previousCurveId );
+    }
+
     QgsCurve *curve = mCurves.at( curveId );
     QList<QgsVertexId> vertices = curveVerticesIt.value();
+    std::sort( vertices.begin(), vertices.end(), []( const QgsVertexId &a, const QgsVertexId &b ) { return a.vertex < b.vertex; } );
 
     const QgsCircularString *circularString = qgsgeometry_cast<const QgsCircularString *>( curve );
     // If the vertex to delete is the middle vertex of a circularstring arc, we transform
@@ -985,11 +1012,8 @@ bool QgsCompoundCurve::deleteVertices( const QSet<QgsVertexId> &positions )
     {
       // we loop through the vertices to see if we need to handle special case
       // of a middle vertex (see deleteVertex)
-      std::sort( vertices.begin(), vertices.end(), []( const QgsVertexId &a, const QgsVertexId &b ) { return a.vertex < b.vertex; } );
       QList<QgsVertexId> circularVerticesToDelete;
       circularVerticesToDelete.reserve( vertices.size() );
-
-      QListIterator<QgsVertexId> curveVerticesIt( vertices );
 
       // search for odd vertices (middle vertices of an arc)
       for ( size_t i = vertices.size(); i-- > 0; )
@@ -1066,13 +1090,61 @@ bool QgsCompoundCurve::deleteVertices( const QSet<QgsVertexId> &positions )
       // remove any remaining circular vertices to delete
       if ( !circularVerticesToDelete.isEmpty() )
       {
+        // check if we are deleting a shared vertex and save the end point IF it is not being deleted
+        // we don't want to make assumtions how circularstring deletes its vertices
+        // so we save it, delete the vertices, and if the curve gets deleted as a result
+        // only then we actually append the survivingPoint to the list
+        QgsPoint survivingPoint;
+        if ( curveId > 0 && circularVerticesToDelete.last().vertex == 0 && circularVerticesToDelete.first().vertex != curve->numPoints() - 1 )
+        {
+          survivingPoint = curve->endPoint();
+        }
+        else if ( curveId == 0 && circularVerticesToDelete.first().vertex == curve->numPoints() - 1 && circularVerticesToDelete.last().vertex != 0 )
+        {
+          survivingPoint = curve->startPoint();
+        }
         if ( !curve->deleteVertices( QSet<QgsVertexId>( circularVerticesToDelete.begin(), circularVerticesToDelete.end() ) ) )
         {
           Q_ASSERT( false );
           return false;
         }
+
+        if ( curve->numPoints() == 0 )
+        {
+          removeCurve( curveId );
+          // end point wasn't marked for deletion and the curve was deleted
+          // append it to survivingPoints
+          if ( !survivingPoint.isEmpty() )
+          {
+            survivingPoints.emplace_back( survivingPoint );
+          }
+        }
+        else if ( survivingPoints.size() != 0 )
+        {
+          appendSurvivingPoints( curve->endPoint(), curveId + 1 );
+        }
       }
+      previousCurveId = curveId;
       continue; // circularstring handled, continue to next curve
+    }
+
+    // linestring
+    // check if we are deleting a shared vertex and all but 1 point would be deleted
+    // if that's the case, we add that point to survivingPoints, delete the curve and continue
+    if ( ( curveId > 0 && curve->numPoints() - vertices.size() == 1 && vertices.first().vertex == 0 )
+         || ( curveId == 0 && curve->numPoints() - vertices.size() == 1 && vertices.last().vertex == curve->numPoints() - 1 ) )
+    {
+      int remainingIdx = 0;
+      for ( const QgsVertexId &v : vertices )
+      {
+        if ( v.vertex != remainingIdx )
+          break;
+        remainingIdx++;
+      }
+      survivingPoints.emplace_back( curve->vertexAt( QgsVertexId( 0, 0, remainingIdx ) ) );
+      removeCurve( curveId );
+      previousCurveId = curveId;
+      continue; // curve removed, continue to next one
     }
 
     if ( !curve->deleteVertices( QSet<QgsVertexId>( vertices.begin(), vertices.end() ) ) )
@@ -1080,15 +1152,57 @@ bool QgsCompoundCurve::deleteVertices( const QSet<QgsVertexId> &positions )
       Q_ASSERT( false );
       return false;
     }
-  }
 
-  // remove any empty curves
-  for ( int i = mCurves.size() - 1; i >= 0; i-- )
-  {
-    QgsCurve *curve = mCurves.at( i );
     if ( curve->numPoints() == 0 )
     {
-      removeCurve( i );
+      removeCurve( curveId );
+    }
+    else if ( survivingPoints.size() != 0 )
+    {
+      appendSurvivingPoints( curve->endPoint(), curveId + 1 );
+    }
+
+    previousCurveId = curveId;
+    // linestring handled, this is the end of the loop
+  }
+
+  if ( survivingPoints.size() != 0 )
+  {
+    if ( previousCurveId > 0 )
+    {
+      // (note: we went through the list in reverse order)
+      // we are not at the start of curve list, there are curves further down
+      // so we add those points at the start of the previous curve
+      const QgsCurve *curve = mCurves.at( previousCurveId - 1 );
+      appendSurvivingPoints( curve->endPoint(), previousCurveId );
+    }
+    else
+    {
+      // we reached the end of list, which means we are at the start of the geometry
+      // so we append those points at the start of the first curve in the list
+      // if there are no curves left, but the number of surviving points is 2 or greater
+      // we make a linestring out of them and add it as the only curve
+      QgsPoint startPoint;
+      if ( mCurves.size() != 0 )
+      {
+        const QgsCurve *curve = mCurves.at( 0 );
+        startPoint = curve->startPoint();
+      }
+
+      QgsPointSequence pts;
+      for ( int i = survivingPoints.size() - 1; i >= 0; --i )
+        pts << survivingPoints[i];
+
+      if ( !startPoint.isEmpty() )
+        pts << startPoint;
+
+      if ( pts.size() > 1 )
+      {
+        auto newLineString = std::make_unique<QgsLineString>();
+        newLineString->setPoints( pts );
+
+        mCurves.insert( 0, newLineString.release() );
+      }
     }
   }
 

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -3264,7 +3264,7 @@ class TestQgsGeometry(QgisTestCase):
         # remove one linestring from compoundcurve
         compoundcurve = QgsGeometry.fromWkt(compoundcurvewkt)
         assert compoundcurve.deleteVertices([5, 6]), "Delete vertices [5, 6] failed"
-        expwkt = "CompoundCurve ( (0 1, 1 2, 2 1, 1 0, 0 1) )"
+        expwkt = "CompoundCurve ( (0 1, 1 2, 2 1, 1 0, 0 1 ) )"
         wkt = compoundcurve.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -3289,7 +3289,7 @@ class TestQgsGeometry(QgisTestCase):
         assert compoundcurve.deleteVertices([1, 2, 3, 4, 5]), (
             "Delete vertices [1, 2, 3, 4, 5] failed"
         )
-        expwkt = "CompoundCurve EMPTY"
+        expwkt = "CompoundCurve ( (0 1, 0 3) )"
         wkt = compoundcurve.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -3297,7 +3297,7 @@ class TestQgsGeometry(QgisTestCase):
         assert compoundcurve.deleteVertices([0, 2, 3, 4, 6]), (
             "Delete vertices [0, 2, 3, 4, 6] failed"
         )
-        expwkt = "CompoundCurve EMPTY"
+        expwkt = "CompoundCurve ( (1 2, 0 2) )"
         wkt = compoundcurve.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 


### PR DESCRIPTION
Fixes before deleteVertex could be removed.

`deleteVertices` introduced a regression when it comes to `CompoundCurve` behavior.
Previously, when we were deleting a point belonging to 2 curves (shared vertex), if a point at the either end would “survive” (not be deleted), we would keep it and append it to the “surviving” curve.

Example how it worked before. This is a `CompoundCurve` made out of 2 `CircularStrings` that share the vertex in the middle.

`wkt = "CompoundCurve (CircularString(0 0, 1 1, 2 0), CircularString(2 0, 3 1, 4 0))"`


https://github.com/user-attachments/assets/722ae658-8f7a-4212-8d93-60da21f1a362



.
.
What happens now in master is, both curves are deleted, end points do not end up forming a `linestring`.

As I don’t know of a better term to describe those points that wouldn’t be deleted, I called them “survivingPoints” in code as well.

The logic is simple.
If we are deleting a shared vertex and we are on a `linestring`, we check how many points are scheduled for deletion. If the number of scheduled points for deletion is 1 less than the number of points in that `linestring`, we append the point in the `linestring` that is not scheduled for deletion to the `survivingPoints` list and delete the curve.

`CircularStrings` are more complex, so we only check if its endpoint is not set for deletion.
`CirculrString::deleteVertices` has a special implementation where it removes whole arcs rather than just the points marked for deletion, but there is also points adjacency check. 
To conclude, the alg is not straightforward to make assumptions what would happen with a specific list of vertices passed for deletion. 

So, what we do is, we take the endpoint, call `deleteVertices` on the `CircularString` and only if at the end the curve is gone, we take that endpoint and append it to the `survivingPoints` list.

If there are surviving points, we add them to the end of the previous curve (we always delete vertices and go through curves in reverse order). If we have reached the end of the list and there are surviving points, we add them at the start of the very first curve.
If at the end, all curves are deleted, but there are more than 1 `survivingPoints`, we make a `linestring` out of them and set it as the only curve in the `compoundcurve` geometry.

I've added explanatory comments in code, they can be expanded if necessary.

Here is another demo showing new, fixed behavior:
`wkt = "CompoundCurve ((0 -3, 0 -2, 0 -1, 0 0), CircularString(0 0, 1 1, 2 0), CircularString(2 0, 3 1, 4 0))"`


[Screencast_20260906_194651.webm](https://github.com/user-attachments/assets/9c40f0d5-d0a5-46c9-af4f-7d145bd59178)

More demos on request, I understand this is boring.