### PR TITLE
Drop default raster file test tolerance

### DIFF
--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -564,8 +564,8 @@ class AlgorithmsTest:
             elif expected_result["type"] == "rasterfile":
                 result_filepath = results[id]
                 expected_filepath = self.filepath_from_param(expected_result)
-                abs_tol = expected_result.get("abs_tol", 1e-5)
-                rel_tol = expected_result.get("rel_tol", 1e-5)
+                abs_tol = expected_result.get("abs_tol", 1e-15)
+                rel_tol = expected_result.get("rel_tol", 1e-15)
                 self.check_raster_equality(
                     expected_filepath, result_filepath, abs_tol=abs_tol, rel_tol=rel_tol
                 )
@@ -598,7 +598,7 @@ class AlgorithmsTest:
                     self.assertRegex(data, rule)
 
     def check_raster_equality(
-        self, expected_filepath, result_filepath, abs_tol=1e-5, rel_tol=1e-5
+        self, expected_filepath, result_filepath, abs_tol=1e-15, rel_tol=1e-15
     ):
         """
         Checks that two raster files are pixel-wise equal with detailed mismatch reporting


### PR DESCRIPTION
The previous default was possibly a bit too generous, better to make individual tests expand these values

## Description

[Replace this with some text explaining the rationale and details about this pull request]

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
