### PR TITLE
[processing] methods should return a unique_ptr

### DIFF
--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -598,9 +598,9 @@ must be passed.
 .. seealso:: :py:func:`createExpressionContextScopeForChildAlgorithm`
 %End
 
-    QgsExpressionContextScope *createExpressionContextScopeForChildAlgorithm(
+    std::unique_ptr<QgsExpressionContextScope> createExpressionContextScopeForChildAlgorithm(
       const QString &childId, QgsProcessingContext &context, const QVariantMap &modelParameters = QVariantMap(), const QVariantMap &results = QVariantMap()
-    ) const /Factory/;
+    ) const;
 %Docstring
 Creates a new expression context scope for a child algorithm within the
 model.

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -450,7 +450,9 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       }
 
       QgsExpressionContext expContext = baseContext;
-      expContext << QgsExpressionContextUtils::processingAlgorithmScope( child.algorithm(), parameters, context ) << createExpressionContextScopeForChildAlgorithm( childId, context, parameters, childResults );
+      expContext
+        << QgsExpressionContextUtils::processingAlgorithmScope( child.algorithm(), parameters, context )
+        << createExpressionContextScopeForChildAlgorithm( childId, context, parameters, childResults ).release();
       context.setExpressionContext( expContext );
 
       QString error;
@@ -1427,7 +1429,7 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
   return variables;
 }
 
-QgsExpressionContextScope *QgsProcessingModelAlgorithm::createExpressionContextScopeForChildAlgorithm(
+std::unique_ptr<QgsExpressionContextScope> QgsProcessingModelAlgorithm::createExpressionContextScopeForChildAlgorithm(
   const QString &childId, QgsProcessingContext &context, const QVariantMap &modelParameters, const QVariantMap &results
 ) const
 {
@@ -1438,7 +1440,7 @@ QgsExpressionContextScope *QgsProcessingModelAlgorithm::createExpressionContextS
   {
     scope->addVariable( QgsExpressionContextScope::StaticVariable( varIt.key(), varIt->value, true, false, varIt->description ) );
   }
-  return scope.release();
+  return scope;
 }
 
 QgsProcessingModelChildParameterSources QgsProcessingModelAlgorithm::availableSourcesForChild( const QString &childId, const QgsProcessingParameterDefinition *param ) const

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -523,9 +523,9 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
      * Creates a new expression context scope for a child algorithm within the model.
      * \see variablesForChildAlgorithm()
      */
-    QgsExpressionContextScope *createExpressionContextScopeForChildAlgorithm(
+    std::unique_ptr<QgsExpressionContextScope> createExpressionContextScopeForChildAlgorithm(
       const QString &childId, QgsProcessingContext &context, const QVariantMap &modelParameters = QVariantMap(), const QVariantMap &results = QVariantMap()
-    ) const SIP_FACTORY;
+    ) const;
 
     /**
      * Returns the map of custom expression context variables defined for this model.

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -287,7 +287,7 @@ QgsExpressionContext QgsProcessingModelerParameterWidget::createExpressionContex
     c << algorithmScope;
     QgsExpressionContextScope *modelScope = QgsExpressionContextUtils::processingModelAlgorithmScope( mModel, QVariantMap(), mContext );
     c << modelScope;
-    QgsExpressionContextScope *childScope = mModel->createExpressionContextScopeForChildAlgorithm( mChildId, mContext, QVariantMap(), QVariantMap() );
+    QgsExpressionContextScope *childScope = mModel->createExpressionContextScopeForChildAlgorithm( mChildId, mContext, QVariantMap(), QVariantMap() ).release();
     c << childScope;
 
     QStringList highlightedVariables = childScope->variableNames();

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -383,7 +383,7 @@ QgsExpressionContext QgsProcessingWidgetWrapperUtils::createExpressionContext(
 
     QgsExpressionContextScope *algorithmScope = QgsExpressionContextUtils::processingAlgorithmScope( alg ? alg : algorithm, QVariantMap(), *context );
     c << algorithmScope;
-    QgsExpressionContextScope *childScope = lModel->createExpressionContextScopeForChildAlgorithm( widgetContext.modelChildAlgorithmId(), *context, QVariantMap(), QVariantMap() );
+    QgsExpressionContextScope *childScope = lModel->createExpressionContextScopeForChildAlgorithm( widgetContext.modelChildAlgorithmId(), *context, QVariantMap(), QVariantMap() ).release();
     c << childScope;
 
     QStringList highlightedVariables = childScope->variableNames();


### PR DESCRIPTION
## Description

This PR is part of QEP [#417](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-417-remove-sip-factory.md)

It concerns only core/processing folder and method with non-QObject return type.

## AI tool usage

None

**Funded by the QGIS Grant programme 2026**