### PR TITLE
Remove QgsProject::instance() references from QgsRelationContext (QEP 423)

### DIFF
--- a/python/PyQt6/core/auto_generated/qgspolymorphicrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspolymorphicrelation.sip.in
@@ -63,7 +63,6 @@ projects.
 
 :param node: The dom node containing the relation information
 :param context: to pass project translator
-:param relationContext: a relation context
 
 :return: A relation
 

--- a/python/PyQt6/core/auto_generated/qgspolymorphicrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspolymorphicrelation.sip.in
@@ -56,7 +56,7 @@ shared and only duplicated when the copy is changed.
 %End
 
 
-    static QgsPolymorphicRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext = QgsRelationContext() );
+ static QgsPolymorphicRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context ) /Deprecated="Since 4.4. Use createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext ) instead."/;
 %Docstring
 Creates a relation from an XML structure. Used for reading .qgs
 projects.
@@ -66,6 +66,24 @@ projects.
 :param relationContext: a relation context
 
 :return: A relation
+
+.. deprecated:: 4.4
+
+   Use createFromXml( const QDomNode &node, :py:class:`QgsReadWriteContext` &context, const :py:class:`QgsRelationContext` &relationContext ) instead.
+%End
+
+    static QgsPolymorphicRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext );
+%Docstring
+Creates a relation from an XML structure. Used for reading .qgs
+projects.
+
+:param node: The dom node containing the relation information
+:param context: to pass project translator
+:param relationContext: a relation context
+
+:return: A relation
+
+.. versionadded:: 4.4
 %End
 
     void writeXml( QDomNode &node, QDomDocument &doc ) const;

--- a/python/PyQt6/core/auto_generated/qgspolymorphicrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspolymorphicrelation.sip.in
@@ -81,8 +81,6 @@ projects.
 :param relationContext: a relation context
 
 :return: A relation
-
-.. versionadded:: 4.4
 %End
 
     void writeXml( QDomNode &node, QDomDocument &doc ) const;

--- a/python/PyQt6/core/auto_generated/qgsrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrelation.sip.in
@@ -42,7 +42,7 @@ shared and only duplicated when the copy is changed.
 %End
 
 
-    static QgsRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext = QgsRelationContext() );
+ static QgsRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context ) /Deprecated="Since 4.4. Use createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext ) instead."/;
 %Docstring
 Creates a relation from an XML structure. Used for reading .qgs
 projects.
@@ -52,6 +52,24 @@ projects.
 :param relationContext: a relation context
 
 :return: A relation
+
+.. deprecated:: 4.4
+
+   Use createFromXml( const QDomNode &node, :py:class:`QgsReadWriteContext` &context, const :py:class:`QgsRelationContext` &relationContext ) instead.
+%End
+
+    static QgsRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext );
+%Docstring
+Creates a relation from an XML structure. Used for reading .qgs
+projects.
+
+:param node: The dom node containing the relation information
+:param context: to pass project translator
+:param relationContext: a relation context
+
+:return: A relation
+
+.. versionadded:: 4.4
 %End
 
     void writeXml( QDomNode &node, QDomDocument &doc ) const;

--- a/python/PyQt6/core/auto_generated/qgsrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrelation.sip.in
@@ -67,8 +67,6 @@ projects.
 :param relationContext: a relation context
 
 :return: A relation
-
-.. versionadded:: 4.4
 %End
 
     void writeXml( QDomNode &node, QDomDocument &doc ) const;

--- a/python/PyQt6/core/auto_generated/qgsrelation.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrelation.sip.in
@@ -49,7 +49,6 @@ projects.
 
 :param node: The dom node containing the relation information
 :param context: to pass project translator
-:param relationContext: a relation context
 
 :return: A relation
 

--- a/python/PyQt6/core/auto_generated/qgsrelationcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrelationcontext.sip.in
@@ -24,13 +24,13 @@ Used to resolve layers from projects.
 #include "qgsrelationcontext.h"
 %End
   public:
- QgsRelationContext() /Deprecated="Since 4.4. Use QgsRelationContext( QgsProject *project ) instead."/;
+    QgsRelationContext() /Deprecated/;
 %Docstring
 Constructor for QgsRelationContext.
 
-.. deprecated:: 4.4
+.. note::
 
-   Use QgsRelationContext( :py:class:`QgsProject` *project ) instead.
+   Will be removed in QGIS 5.0. Use QgsRelationContext( :py:class:`QgsProject` *project ) with explicit project instead.
 %End
 
     QgsRelationContext( QgsProject *project );

--- a/python/PyQt6/core/auto_generated/qgsrelationcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsrelationcontext.sip.in
@@ -24,7 +24,16 @@ Used to resolve layers from projects.
 #include "qgsrelationcontext.h"
 %End
   public:
-    QgsRelationContext( QgsProject *project = 0 );
+ QgsRelationContext() /Deprecated="Since 4.4. Use QgsRelationContext( QgsProject *project ) instead."/;
+%Docstring
+Constructor for QgsRelationContext.
+
+.. deprecated:: 4.4
+
+   Use QgsRelationContext( :py:class:`QgsProject` *project ) instead.
+%End
+
+    QgsRelationContext( QgsProject *project );
 %Docstring
 Constructor for QgsRelationContext.
 %End

--- a/src/core/qgspolymorphicrelation.cpp
+++ b/src/core/qgspolymorphicrelation.cpp
@@ -68,6 +68,12 @@ QgsPolymorphicRelation &QgsPolymorphicRelation::operator=( QgsPolymorphicRelatio
   return *this;
 }
 
+// TODO QGIS 5.0 -- Remove the deprecated createFromXml method without the relationContext parameter
+QgsPolymorphicRelation QgsPolymorphicRelation::createFromXml( const QDomNode &node, QgsReadWriteContext &context )
+{
+  return createFromXml( node, context, QgsRelationContext( QgsProject::instance() ) ); // skip-keyword-check
+}
+
 QgsPolymorphicRelation QgsPolymorphicRelation::createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext )
 {
   Q_UNUSED( context );

--- a/src/core/qgspolymorphicrelation.cpp
+++ b/src/core/qgspolymorphicrelation.cpp
@@ -29,6 +29,7 @@ using namespace Qt::StringLiterals;
 
 QgsPolymorphicRelation::QgsPolymorphicRelation()
   : d( new QgsPolymorphicRelationPrivate() )
+  , mContext( nullptr )
 {}
 
 QgsPolymorphicRelation::QgsPolymorphicRelation( const QgsRelationContext &context )

--- a/src/core/qgspolymorphicrelation.h
+++ b/src/core/qgspolymorphicrelation.h
@@ -93,7 +93,6 @@ class CORE_EXPORT QgsPolymorphicRelation
      *
      * \param node The dom node containing the relation information
      * \param context to pass project translator
-     * \param relationContext a relation context
      *
      * \returns A relation
      * \deprecated QGIS 4.4. Use createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext ) instead.

--- a/src/core/qgspolymorphicrelation.h
+++ b/src/core/qgspolymorphicrelation.h
@@ -87,6 +87,7 @@ class CORE_EXPORT QgsPolymorphicRelation
     QgsPolymorphicRelation &operator=( const QgsPolymorphicRelation &other );
     QgsPolymorphicRelation &operator=( QgsPolymorphicRelation &&other );
 
+    // TODO QGIS 5.0 -- Remove the deprecated createFromXml method without the relationContext parameter
     /**
      * Creates a relation from an XML structure. Used for reading .qgs projects.
      *
@@ -95,8 +96,21 @@ class CORE_EXPORT QgsPolymorphicRelation
      * \param relationContext a relation context
      *
      * \returns A relation
+     * \deprecated QGIS 4.4. Use createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext ) instead.
      */
-    static QgsPolymorphicRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext = QgsRelationContext() );
+    Q_DECL_DEPRECATED static QgsPolymorphicRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context ) SIP_DEPRECATED;
+
+    /**
+     * Creates a relation from an XML structure. Used for reading .qgs projects.
+     *
+     * \param node The dom node containing the relation information
+     * \param context to pass project translator
+     * \param relationContext a relation context
+     *
+     * \returns A relation
+     * \since QGIS 4.4
+     */
+    static QgsPolymorphicRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext );
 
     /**
      * Writes a relation to an XML structure. Used for saving .qgs projects

--- a/src/core/qgspolymorphicrelation.h
+++ b/src/core/qgspolymorphicrelation.h
@@ -107,7 +107,6 @@ class CORE_EXPORT QgsPolymorphicRelation
      * \param relationContext a relation context
      *
      * \returns A relation
-     * \since QGIS 4.4
      */
     static QgsPolymorphicRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext );
 

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -32,6 +32,7 @@ using namespace Qt::StringLiterals;
 
 QgsRelation::QgsRelation()
   : d( new QgsRelationPrivate() )
+  , mContext( nullptr )
 {}
 
 QgsRelation::QgsRelation( const QgsRelationContext &context )

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -71,6 +71,12 @@ QgsRelation &QgsRelation::operator=( QgsRelation &&other )
   return *this;
 }
 
+// TODO QGIS 5.0 -- Remove the deprecated createFromXml method without the relationContext parameter
+QgsRelation QgsRelation::createFromXml( const QDomNode &node, QgsReadWriteContext &context )
+{
+  return createFromXml( node, context, QgsRelationContext( QgsProject::instance() ) ); // skip-keyword-check
+}
+
 QgsRelation QgsRelation::createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext )
 {
   QDomElement elem = node.toElement();

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -114,6 +114,7 @@ class CORE_EXPORT QgsRelation
     QgsRelation &operator=( const QgsRelation &other );
     QgsRelation &operator=( QgsRelation &&other );
 
+    // TODO QGIS 5.0 -- Remove the deprecated createFromXml method without the relationContext parameter
     /**
      * Creates a relation from an XML structure. Used for reading .qgs projects.
      *
@@ -122,8 +123,21 @@ class CORE_EXPORT QgsRelation
      * \param relationContext a relation context
      *
      * \returns A relation
+     * \deprecated QGIS 4.4. Use createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext ) instead.
      */
-    static QgsRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext = QgsRelationContext() );
+    Q_DECL_DEPRECATED static QgsRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context ) SIP_DEPRECATED;
+
+    /**
+     * Creates a relation from an XML structure. Used for reading .qgs projects.
+     *
+     * \param node The dom node containing the relation information
+     * \param context to pass project translator
+     * \param relationContext a relation context
+     *
+     * \returns A relation
+     * \since QGIS 4.4
+     */
+    static QgsRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext );
 
     /**
      * Writes a relation to an XML structure. Used for saving .qgs projects

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -120,7 +120,6 @@ class CORE_EXPORT QgsRelation
      *
      * \param node The dom node containing the relation information
      * \param context to pass project translator
-     * \param relationContext a relation context
      *
      * \returns A relation
      * \deprecated QGIS 4.4. Use createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext ) instead.

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -134,7 +134,6 @@ class CORE_EXPORT QgsRelation
      * \param relationContext a relation context
      *
      * \returns A relation
-     * \since QGIS 4.4
      */
     static QgsRelation createFromXml( const QDomNode &node, QgsReadWriteContext &context, const QgsRelationContext &relationContext );
 

--- a/src/core/qgsrelationcontext.cpp
+++ b/src/core/qgsrelationcontext.cpp
@@ -14,7 +14,13 @@
  ***************************************************************************/
 #include "qgsrelationcontext.h"
 
+#include "qgsmessagelog.h"
 #include "qgsproject.h"
+
+QgsRelationContext::QgsRelationContext()
+{
+  QgsMessageLog::logMessage( "QgsRelationContext constructed without specified project. This will be removed in QGIS 5.0.", "QgsRelationContext", Qgis::Warning );
+}
 
 QgsRelationContext::QgsRelationContext( QgsProject *project )
   : mProject( project )
@@ -30,6 +36,7 @@ const QgsProject *QgsRelationContext::project() const
     return mProject;
   }
 
+  // TODO QGIS 5.0 -- Remove the fallback to the QgsProject instance
   // Fallback to qgis instance
   return QgsProject::instance(); // skip-keyword-check
 }

--- a/src/core/qgsrelationcontext.h
+++ b/src/core/qgsrelationcontext.h
@@ -33,10 +33,18 @@ class QgsProject;
 class CORE_EXPORT QgsRelationContext
 {
   public:
+    // TODO QGIS 5.0 -- Remove the deprecated constructor
+    /**
+     * Constructor for QgsRelationContext.
+     *
+     * \deprecated QGIS 4.4. Use QgsRelationContext( QgsProject *project ) instead.
+     */
+    Q_DECL_DEPRECATED QgsRelationContext() SIP_DEPRECATED;
+
     /**
      * Constructor for QgsRelationContext.
      */
-    QgsRelationContext( QgsProject *project = nullptr );
+    QgsRelationContext( QgsProject *project );
 
     /**
      * Gets the associated project

--- a/src/core/qgsrelationcontext.h
+++ b/src/core/qgsrelationcontext.h
@@ -37,9 +37,9 @@ class CORE_EXPORT QgsRelationContext
     /**
      * Constructor for QgsRelationContext.
      *
-     * \deprecated QGIS 4.4. Use QgsRelationContext( QgsProject *project ) instead.
+     * \note Will be removed in QGIS 5.0. Use QgsRelationContext( QgsProject *project ) with explicit project instead.
      */
-    Q_DECL_DEPRECATED QgsRelationContext() SIP_DEPRECATED;
+    QgsRelationContext() SIP_DEPRECATED;
 
     /**
      * Constructor for QgsRelationContext.


### PR DESCRIPTION
## Description

Mark `QgsRelationContext` to drop `QgsProject::instance()` in QGIS 5.0. Fix constructor so that the constructor with project  specified is preferred. 

Also update functions that had `QgsRelationContext()`  as default parameter value. Update those so that such versions are deprecated and new version of functions where  `QgsRelationContext` need to be specified exist. 

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 


