### PR TITLE
[python] Fix sys.executable pointing at the QGIS binary instead of a Python interpreter

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -796,6 +796,83 @@ def pluginDirectory(packageName: str) -> str:
     return os.path.dirname(sys.modules[packageName].__file__)
 
 
+def python_executable() -> str:
+    """
+    Returns the path of an executable which runs the Python environment
+    QGIS runs on.
+
+    When Python is embedded, the interpreter reports the host application
+    as ``sys.executable``: ``qgis-bin.exe`` on Windows and the ``QGIS``
+    binary inside the application bundle on macOS. Spawning it, for
+    instance to run a script in a separate process, starts a second QGIS
+    instead. QGIS calls this function at startup to point
+    ``sys.executable`` at an interpreter, so that ``subprocess``,
+    ``multiprocessing``, ``venv`` and other tools which read it behave as
+    documented.
+
+    :returns: path of the executable, or an empty string if none could be
+              found
+
+    .. versionadded:: 4.4
+    """
+    try:
+        return _find_python_executable()
+    except (OSError, ValueError):
+        return ""
+
+
+def _find_python_executable() -> str:
+    def looks_like_python(path: str) -> bool:
+        name = os.path.basename(path).lower()
+        return (
+            name.startswith("python")
+            and os.path.isfile(path)
+            and os.access(path, os.X_OK)
+        )
+
+    prefixes = []
+    for prefix in (sys.prefix, sys.base_prefix, sys.exec_prefix):
+        if prefix and prefix not in prefixes:
+            prefixes.append(prefix)
+
+    if sys.executable and looks_like_python(sys.executable):
+        directory = os.path.dirname(sys.executable)
+        if sys.platform == "darwin" and directory.endswith(
+            os.path.join("Contents", "MacOS")
+        ):
+            # The application bundle ships a "python" wrapper next to the QGIS
+            # binary which sets PYTHONHOME before running the bundled
+            # interpreter. The versioned binary next to it lives outside its
+            # prefix and cannot locate the standard library on its own, so
+            # prefer the wrapper.
+            wrapper = os.path.join(directory, "python")
+            if looks_like_python(wrapper):
+                return wrapper
+        return sys.executable
+
+    candidates = []
+    if sys.platform == "win32":
+        # OSGeo4W, the standalone installer and conda all ship python.exe in
+        # PYTHONHOME, which is sys.prefix
+        for prefix in prefixes:
+            candidates.append(os.path.join(prefix, "python.exe"))
+    else:
+        version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+        for prefix in prefixes:
+            candidates.append(os.path.join(prefix, "bin", version))
+        # the macOS bundle, see above
+        if sys.executable:
+            candidates.append(os.path.join(os.path.dirname(sys.executable), "python"))
+        for prefix in prefixes:
+            candidates.append(os.path.join(prefix, "bin", "python3"))
+
+    for candidate in candidates:
+        if looks_like_python(candidate):
+            return os.path.normpath(candidate)
+
+    return ""
+
+
 def reloadProjectMacros():
     # unload old macros
     unloadProjectMacros()

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -191,6 +191,11 @@ _ssr = StartupScriptRunner()
     return false;
   }
 
+  // when Python is embedded, sys.executable is the host application (qgis-bin.exe on
+  // Windows, the QGIS binary inside the macOS bundle) rather than a Python interpreter,
+  // so anything spawning it starts a second QGIS. Point it at an interpreter instead.
+  runString( u"sys.executable = qgis.utils.python_executable() or sys.executable"_s );
+
   // tell the utils script where to look for the plugins
   runString( u"qgis.utils.plugin_paths = [%1]"_s.arg( pluginpaths.join( ',' ) ) );
   runString( u"qgis.utils.sys_plugin_path = \"%1\""_s.arg( pluginsPath() ) );

--- a/tests/src/python/test_python_utils.py
+++ b/tests/src/python/test_python_utils.py
@@ -13,7 +13,11 @@ __date__ = "31.8.2021"
 __copyright__ = "Copyright 2021, The QGIS Project"
 
 import os
+import subprocess
+import sys
+import tempfile
 import unittest
+from unittest import mock
 
 from qgis import utils
 from qgis.testing import QgisTestCase, start_app
@@ -25,6 +29,96 @@ class TestPythonUtils(QgisTestCase):
     def setUpClass(cls):
         super().setUpClass()
         start_app()
+
+    def test_python_executable(self):
+        exe = utils.python_executable()
+        self.assertTrue(exe)
+        self.assertTrue(os.path.isfile(exe))
+        self.assertTrue(os.path.basename(exe).lower().startswith("python"))
+
+        # the interpreter must run, and be the very one QGIS embeds
+        version = subprocess.check_output(
+            [exe, "-c", "import sys; print(sys.version_info[0], sys.version_info[1])"],
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            version.split(), [str(sys.version_info[0]), str(sys.version_info[1])]
+        )
+
+    def test_python_executable_embedded_layouts(self):
+        """sys.executable is the host application when QGIS embeds Python"""
+
+        def touch(*parts):
+            path = os.path.join(*parts)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w"):
+                pass
+            os.chmod(path, 0o755)
+            return path
+
+        with tempfile.TemporaryDirectory() as root:
+            # macOS application bundle
+            host = touch(root, "QGIS.app", "Contents", "MacOS", "QGIS")
+            touch(root, "QGIS.app", "Contents", "MacOS", "python3.12")
+            wrapper = touch(root, "QGIS.app", "Contents", "MacOS", "python")
+            prefix = os.path.join(root, "QGIS.app", "Contents", "Frameworks")
+            with mock.patch.multiple(
+                sys,
+                platform="darwin",
+                executable=host,
+                prefix=prefix,
+                base_prefix=prefix,
+                exec_prefix=prefix,
+            ):
+                self.assertEqual(utils.python_executable(), wrapper)
+
+            # the bundled interpreter run through the wrapper, e.g. by ctest
+            with mock.patch.multiple(
+                sys,
+                platform="darwin",
+                executable=os.path.join(
+                    root, "QGIS.app", "Contents", "MacOS", "python3.12"
+                ),
+                prefix=prefix,
+                base_prefix=prefix,
+                exec_prefix=prefix,
+            ):
+                self.assertEqual(utils.python_executable(), wrapper)
+
+            # an interpreter outside the bundle is left alone, whatever sits
+            # next to it
+            python = touch(root, "opt", "python", "bin", "python3.12")
+            touch(root, "opt", "python", "bin", "python")
+            prefix = os.path.join(root, "opt", "python")
+            with mock.patch.multiple(
+                sys,
+                platform="darwin",
+                executable=python,
+                prefix=prefix,
+                base_prefix=prefix,
+                exec_prefix=prefix,
+            ):
+                self.assertEqual(utils.python_executable(), python)
+
+            # OSGeo4W and the Windows standalone installer
+            host = touch(root, "OSGeo4W", "bin", "qgis-bin.exe")
+            python = touch(root, "OSGeo4W", "apps", "Python312", "python.exe")
+            prefix = os.path.dirname(python)
+            with mock.patch.multiple(
+                sys,
+                platform="win32",
+                executable=host,
+                prefix=prefix,
+                base_prefix=prefix,
+                exec_prefix=prefix,
+            ):
+                self.assertEqual(utils.python_executable(), python)
+
+            # nothing to repair when sys.executable already is an interpreter
+            python = touch(root, "usr", "bin", "python3")
+            with mock.patch.multiple(sys, platform="linux", executable=python):
+                self.assertEqual(utils.python_executable(), python)
 
     def test_update_available_plugins(self):
         utils.plugin_paths = [os.path.join(unitTestDataPath(), "test_plugin_path")]


### PR DESCRIPTION
## Description

When QGIS embeds Python, `sys.executable` is the host application: `qgis-bin.exe` on Windows and the `QGIS` binary inside the bundle on macOS. Anything that spawns it starts a second QGIS. Debuggers, `venv`, `multiprocessing` and plain `subprocess` calls all read it and all get the wrong answer.

We hit this while building our QGIS plugins at TerraLab. Our first version spawned `sys.executable` to run a helper script and a second QGIS window opened on the user's screen. We ended up with a per-platform lookup of the interpreter, and so did everyone else who needed one: QPIP ([plugin.py](https://github.com/opengisch/QPIP/blob/c5d1117948eae24629a91d6dc168cb3972a81fcf/a00_qpip/plugin.py#L437-L475), which links this very issue), Deepness ([packages_installer_dialog.py](https://github.com/PUTvision/qgis-plugin-deepness/blob/71d01437097dd6eba6f610a02077ed99261ae574/src/deepness/dialogs/packages_installer/packages_installer_dialog.py#L77-L93)), Oslandia's plugin templater ([MR !36](https://gitlab.com/Oslandia/qgis/qgis-plugin-templater-gui/-/merge_requests/36), where cookiecutter hooks kept opening new QGIS instances) and nicogodet's [qgis-venv-creator](https://github.com/nicogodet/qgis-venv-creator/blob/main/src/qgis_venv_creator/create_qgis_venv.py). This PR is that lookup, so the next plugin does not have to rediscover it.

It adds `qgis.utils.python_executable()`, which looks for the interpreter next to `sys.prefix`, `sys.base_prefix` and `sys.exec_prefix`, and points `sys.executable` at it once `qgis.utils` is imported. Any failure in the lookup leaves `sys.executable` untouched. On macOS the result is the `python` wrapper next to the QGIS binary, which sets `PYTHONHOME` before running the bundled interpreter; the versioned binary next to it lives outside its prefix and cannot find the standard library on its own, so it is never picked. Linux already reports `/usr/bin/python3` and is left as is.

#51923 tried the same fix in C++ and stalled on @rouault's question about the conda-forge layout, where @SrNetoChan said `python.exe` sits next to `qgis.exe` rather than `python3.exe`. Resolving through `sys.prefix` covers both: conda's prefix is the environment root where `python.exe` lives, OSGeo4W's is `apps\PythonXXX` and the vcpkg build's is `tools\python3`. I kept the lookup in Python rather than presetting `PyConfig.executable` as suggested in #45646, because that field is an output of the path configuration and presetting it also short-circuits `base_executable` and the prefix derivation. Keeping it in Python also makes the layouts unit-testable. Happy to move the assignment into `Py_InitializeFromConfig` if you prefer it there, @lbartoletti; the lookup itself would stay in `qgis.utils` either way.

Tested on the macOS bundles of 3.44.7 and 4.0.0, inside the running application (`--code`): `sys.executable` goes from `Contents/MacOS/QGIS` to `Contents/MacOS/python`, and spawning it runs Python. The tests pass with both bundled interpreters. The Windows branch is checked against the OSGeo4W, standalone installer and conda layouts, but I have not built this on Windows. A check from someone with a Windows build would be welcome.

Fixes #45646

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
