### PR TITLE
[python] Add qgis.utils.subprocess_environment() for running a Python interpreter from a plugin

### DIFF
--- a/platform/macos/python.in
+++ b/platform/macos/python.in
@@ -3,4 +3,4 @@
 # to make it relocatable.
 BASEDIR="$(cd "$(dirname "$0")" && pwd)"
 export PYTHONHOME="${BASEDIR}/../Frameworks"
-exec ${BASEDIR}/@PYTHON_EXECUTABLE@ "$@"
+exec "${BASEDIR}/@PYTHON_EXECUTABLE@" "$@"

--- a/python/utils.py
+++ b/python/utils.py
@@ -796,6 +796,79 @@ def pluginDirectory(packageName: str) -> str:
     return os.path.dirname(sys.modules[packageName].__file__)
 
 
+def python_executable() -> str:
+    """
+    Returns the path of an executable which runs the Python environment
+    QGIS runs on.
+
+    When Python is embedded, the interpreter reports the host application
+    as ``sys.executable``: ``qgis-bin.exe`` on Windows and the ``QGIS``
+    binary inside the application bundle on macOS. QGIS calls this function
+    at startup to point ``sys.executable`` at something which actually runs
+    Python, so that plugins can spawn it, for instance to install a
+    dependency::
+
+        subprocess.run([sys.executable, "-m", "pip", "install", "shapely"])
+
+    :returns: path of the executable, or an empty string if none could be
+              found
+
+    .. versionadded:: 4.4
+    """
+
+    def looks_like_python(path: str) -> bool:
+        name = os.path.basename(path).lower()
+        return (
+            name.startswith("python")
+            and os.path.isfile(path)
+            and os.access(path, os.X_OK)
+        )
+
+    prefixes = []
+    for prefix in (sys.prefix, sys.base_prefix, sys.exec_prefix):
+        if prefix and prefix not in prefixes:
+            prefixes.append(prefix)
+
+    if sys.executable and looks_like_python(sys.executable):
+        if sys.platform == "darwin":
+            # The macOS bundle ships a "python" wrapper next to the QGIS binary
+            # which sets PYTHONHOME before running the bundled interpreter. The
+            # versioned binary next to it lives outside its prefix and cannot
+            # locate the standard library on its own, so prefer the wrapper.
+            directory = os.path.dirname(sys.executable)
+            wrapper = os.path.join(directory, "python")
+            in_prefix = any(
+                os.path.realpath(directory)
+                == os.path.realpath(os.path.join(prefix, "bin"))
+                for prefix in prefixes
+            )
+            if not in_prefix and looks_like_python(wrapper):
+                return wrapper
+        return sys.executable
+
+    candidates = []
+    if sys.platform == "win32":
+        # OSGeo4W and the standalone installer ship python.exe in PYTHONHOME,
+        # which is sys.prefix
+        for prefix in prefixes:
+            candidates.append(os.path.join(prefix, "python.exe"))
+    else:
+        version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+        for prefix in prefixes:
+            candidates.append(os.path.join(prefix, "bin", version))
+        # the macOS bundle, see above
+        if sys.executable:
+            candidates.append(os.path.join(os.path.dirname(sys.executable), "python"))
+        for prefix in prefixes:
+            candidates.append(os.path.join(prefix, "bin", "python3"))
+
+    for candidate in candidates:
+        if looks_like_python(candidate):
+            return os.path.normpath(candidate)
+
+    return ""
+
+
 def reloadProjectMacros():
     # unload old macros
     unloadProjectMacros()

--- a/python/utils.py
+++ b/python/utils.py
@@ -37,6 +37,7 @@ from typing import Optional
 
 from qgis.core import (
     Qgis,
+    QgsApplication,
     QgsMessageLog,
     QgsMessageOutput,
     QgsSettingsTree,
@@ -867,6 +868,73 @@ def python_executable() -> str:
             return os.path.normpath(candidate)
 
     return ""
+
+
+def subprocess_environment() -> dict:
+    """
+    Returns a copy of the environment suitable for running a Python
+    interpreter as a child process of QGIS.
+
+    The QGIS launchers export variables which tell the embedded interpreter
+    where its standard library and modules are. A child interpreter which
+    inherits them reads the wrong standard library and fails before its
+    first import, typically with "No module named 'encodings'", or, when
+    it is a virtual environment, stops recognising it as one and installs
+    packages next to the base interpreter instead. Those variables are
+    removed here, and the directories of the QGIS installation are taken
+    out of ``PATH`` so that a bare ``python`` resolved by a child process
+    (a package built from source does that) is not the QGIS one.
+
+    Directories shared with the rest of the system, such as ``/usr``, are
+    left in ``PATH``. Use the result as the ``env`` argument of
+    ``subprocess``::
+
+        subprocess.run([sys.executable, "-m", "pip", "install", "shapely"],
+                       env=qgis.utils.subprocess_environment())
+
+    .. versionadded:: 4.4
+    """
+    env = os.environ.copy()
+    for name in (
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "PYTHONEXECUTABLE",
+        "__PYVENV_LAUNCHER__",
+    ):
+        env.pop(name, None)
+
+    shared = {"/", "/usr", "/usr/local", "/opt", "/opt/local", "/opt/homebrew"}
+    roots = []
+    for root in (
+        QgsApplication.prefixPath(),
+        os.environ.get("OSGEO4W_ROOT", ""),
+        sys.prefix,
+    ):
+        if not root:
+            continue
+        root = os.path.normcase(os.path.realpath(root))
+        # a bare drive letter or the filesystem root would match every entry
+        if root.rstrip("\\/") in shared or len(root.rstrip("\\/")) <= 2:
+            continue
+        if root not in roots:
+            roots.append(root)
+
+    def under_qgis(entry: str) -> bool:
+        try:
+            entry = os.path.normcase(os.path.realpath(entry))
+        except (OSError, ValueError):
+            return False
+        return any(entry == root or entry.startswith(root + os.sep) for root in roots)
+
+    path = env.get("PATH", "")
+    if path and roots:
+        kept = [
+            entry for entry in path.split(os.pathsep) if entry and not under_qgis(entry)
+        ]
+        if kept:
+            env["PATH"] = os.pathsep.join(kept)
+
+    return env
 
 
 def reloadProjectMacros():

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -191,6 +191,11 @@ _ssr = StartupScriptRunner()
     return false;
   }
 
+  // when Python is embedded, sys.executable is the host application (qgis-bin.exe on
+  // Windows, the QGIS binary inside the macOS bundle) rather than a Python interpreter.
+  // Point it at something which runs Python so that plugins can spawn it, e.g. to run pip.
+  runString( u"sys.executable = qgis.utils.python_executable() or sys.executable"_s );
+
   // tell the utils script where to look for the plugins
   runString( u"qgis.utils.plugin_paths = [%1]"_s.arg( pluginpaths.join( ',' ) ) );
   runString( u"qgis.utils.sys_plugin_path = \"%1\""_s.arg( pluginsPath() ) );

--- a/tests/src/python/test_python_utils.py
+++ b/tests/src/python/test_python_utils.py
@@ -105,6 +105,42 @@ class TestPythonUtils(QgisTestCase):
             with mock.patch.multiple(sys, platform="linux", executable=python):
                 self.assertEqual(utils.python_executable(), python)
 
+    def test_subprocess_environment(self):
+        from qgis.core import QgsApplication
+
+        prefix = QgsApplication.prefixPath()
+        qgis_bin = os.path.join(prefix, "bin")
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PYTHONHOME": prefix,
+                "PYTHONPATH": os.path.join(prefix, "share", "qgis", "python"),
+                "PYTHONEXECUTABLE": sys.executable,
+                "PATH": os.pathsep.join([qgis_bin, "/usr/bin", "/opt/tools/bin"]),
+                "PROJ_DATA": os.path.join(prefix, "share", "proj"),
+            },
+        ):
+            env = utils.subprocess_environment()
+
+        for name in ("PYTHONHOME", "PYTHONPATH", "PYTHONEXECUTABLE"):
+            self.assertNotIn(name, env)
+        # the rest of the environment is passed on untouched
+        self.assertEqual(env["PROJ_DATA"], os.path.join(prefix, "share", "proj"))
+        path = env["PATH"].split(os.pathsep)
+        self.assertIn("/usr/bin", path)
+        self.assertIn("/opt/tools/bin", path)
+        if prefix.rstrip("/") not in ("/usr", "/usr/local", "/opt", "/"):
+            self.assertNotIn(qgis_bin, path)
+
+        # a child interpreter started with it finds its own standard library
+        out = subprocess.check_output(
+            [sys.executable, "-c", "import encodings; print('ok')"],
+            env=env,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(out.strip(), "ok")
+
     def test_update_available_plugins(self):
         utils.plugin_paths = [os.path.join(unitTestDataPath(), "test_plugin_path")]
         utils.updateAvailablePlugins(True)

--- a/tests/src/python/test_python_utils.py
+++ b/tests/src/python/test_python_utils.py
@@ -13,7 +13,11 @@ __date__ = "31.8.2021"
 __copyright__ = "Copyright 2021, The QGIS Project"
 
 import os
+import subprocess
+import sys
+import tempfile
 import unittest
+from unittest import mock
 
 from qgis import utils
 from qgis.testing import QgisTestCase, start_app
@@ -25,6 +29,81 @@ class TestPythonUtils(QgisTestCase):
     def setUpClass(cls):
         super().setUpClass()
         start_app()
+
+    def test_python_executable(self):
+        exe = utils.python_executable()
+        self.assertTrue(exe)
+        self.assertTrue(os.path.isfile(exe))
+        self.assertTrue(os.path.basename(exe).lower().startswith("python"))
+
+        # the interpreter must run, and be the very one QGIS embeds
+        version = subprocess.check_output(
+            [exe, "-c", "import sys; print(sys.version_info[0], sys.version_info[1])"],
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            version.split(), [str(sys.version_info[0]), str(sys.version_info[1])]
+        )
+
+    def test_python_executable_embedded_layouts(self):
+        """sys.executable is the host application when QGIS embeds Python"""
+
+        def touch(*parts):
+            path = os.path.join(*parts)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w"):
+                pass
+            os.chmod(path, 0o755)
+            return path
+
+        with tempfile.TemporaryDirectory() as root:
+            # macOS application bundle
+            host = touch(root, "QGIS.app", "Contents", "MacOS", "QGIS")
+            touch(root, "QGIS.app", "Contents", "MacOS", "python3.12")
+            wrapper = touch(root, "QGIS.app", "Contents", "MacOS", "python")
+            prefix = os.path.join(root, "QGIS.app", "Contents", "Frameworks")
+            with mock.patch.multiple(
+                sys,
+                platform="darwin",
+                executable=host,
+                prefix=prefix,
+                base_prefix=prefix,
+                exec_prefix=prefix,
+            ):
+                self.assertEqual(utils.python_executable(), wrapper)
+
+            # the bundled interpreter run through the wrapper, e.g. by ctest
+            with mock.patch.multiple(
+                sys,
+                platform="darwin",
+                executable=os.path.join(
+                    root, "QGIS.app", "Contents", "MacOS", "python3.12"
+                ),
+                prefix=prefix,
+                base_prefix=prefix,
+                exec_prefix=prefix,
+            ):
+                self.assertEqual(utils.python_executable(), wrapper)
+
+            # OSGeo4W and the Windows standalone installer
+            host = touch(root, "OSGeo4W", "bin", "qgis-bin.exe")
+            python = touch(root, "OSGeo4W", "apps", "Python312", "python.exe")
+            prefix = os.path.dirname(python)
+            with mock.patch.multiple(
+                sys,
+                platform="win32",
+                executable=host,
+                prefix=prefix,
+                base_prefix=prefix,
+                exec_prefix=prefix,
+            ):
+                self.assertEqual(utils.python_executable(), python)
+
+            # nothing to repair when sys.executable already is an interpreter
+            python = touch(root, "usr", "bin", "python3")
+            with mock.patch.multiple(sys, platform="linux", executable=python):
+                self.assertEqual(utils.python_executable(), python)
 
     def test_update_available_plugins(self):
         utils.plugin_paths = [os.path.join(unitTestDataPath(), "test_plugin_path")]


### PR DESCRIPTION
## Description

A plugin that starts a Python interpreter as a child process, to run pip or a virtual environment, inherits the environment the QGIS launchers set up for the embedded interpreter: `PYTHONHOME`, `PYTHONPATH`, `PYTHONEXECUTABLE` on Windows, and the QGIS directories at the front of `PATH`. A child interpreter which is not the QGIS one breaks on each of them, in a different way each time.

We build the AI Segmentation plugin at TerraLab. It downloads its own CPython and installs torch into a virtual environment, because torch cannot go into the QGIS interpreter. Three of the failures our Windows users reported in the first months came down to one of those variables, and each one was found the hard way, from the error in the report:

- `PYTHONHOME` set: the child interpreter read the QGIS standard library, which is not its own, and stopped at startup with `No module named 'encodings'`.
- `PYTHONEXECUTABLE` set: the OSGeo4W launcher exports it pointing at the QGIS interpreter, and Python honours it on every platform, not only on macOS as its documentation says. The venv interpreter computed its prefix from that path, found no `pyvenv.cfg` next to it, and no longer considered itself inside a venv. pip then installed every package next to the base interpreter and reported success; the plugin later failed to import anything from a venv that had been empty the whole time.
- QGIS `bin` at the front of `PATH`: a package built from source ran a bare `python`, got the QGIS one, now started without the `PYTHONHOME` it needs, and died with the same `encodings` error.

The fix on our side is a 180-line helper which returns a cleaned copy of `os.environ`, and every plugin that spawns an interpreter (QPIP, Deepness, the Earth Engine plugin) has a version of it. This PR moves that helper into `qgis.utils.subprocess_environment()`: `PYTHONHOME`, `PYTHONPATH`, `PYTHONEXECUTABLE` and `__PYVENV_LAUNCHER__` are removed, and the entries of `PATH` under the QGIS prefix, `OSGEO4W_ROOT` or `sys.prefix` are dropped. Directories shared with the system (`/usr`, `/usr/local`, `/opt`, ...) are kept, so a Linux build installed in `/usr` keeps its `PATH` intact. Everything else (`PROJ_DATA`, `GDAL_DATA`, proxies, locale) is passed on unchanged: this is about Python, not about GIS libraries.

```python
subprocess.run([sys.executable, "-m", "pip", "install", "shapely"],
               env=qgis.utils.subprocess_environment())
```

Tested on the macOS bundles of 3.44.7 and 4.0.0, inside the running application: the bundled interpreter starts with the returned environment, and pip answers through it. The new test also runs a child interpreter with the cleaned environment. The Windows cases above are the ones from our user reports; I have not built this PR on Windows.

Stacked on #67318, which makes `sys.executable` usable in the first place; the first commit here is that PR. Both are small and either could go in alone.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
