### PR TITLE
[macos] Quote the interpreter path in the python wrapper

### DIFF
--- a/platform/macos/python.in
+++ b/platform/macos/python.in
@@ -3,4 +3,4 @@
 # to make it relocatable.
 BASEDIR="$(cd "$(dirname "$0")" && pwd)"
 export PYTHONHOME="${BASEDIR}/../Frameworks"
-exec ${BASEDIR}/@PYTHON_EXECUTABLE@ "$@"
+exec "${BASEDIR}/@PYTHON_EXECUTABLE@" "$@"


### PR DESCRIPTION
## Description

`platform/macos/python.in` execs the bundled interpreter through an unquoted path. When the bundle is installed under a path with a space, `exec` splits it and the wrapper fails to start Python. Quote the path.

Spotted while working on #67318.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
