### PR TITLE
[arcgisrest] Fix esri <Null> string not threated as null

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -868,7 +868,9 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     for ( const QVariant &category : categories )
     {
       const QVariantMap categoryData = category.toMap();
-      const QString value = categoryData.value( u"value"_s ).toString();
+      const QString valueString = categoryData.value( u"value"_s ).toString();
+      // Esri uses the literal string "<Null>" to represent a NULL field value in unique value renderers.
+      const QVariant value = valueString == "<Null>"_L1 ? QVariant() : QVariant( valueString );
       const QString label = categoryData.value( u"label"_s ).toString();
       std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( categoryData.value( u"symbol"_s ).toMap(), context ) );
       if ( symbol )

--- a/tests/src/core/testqgsarcgisrestutils.cpp
+++ b/tests/src/core/testqgsarcgisrestutils.cpp
@@ -68,6 +68,7 @@ class TestQgsArcGisRestUtils : public QObject
     void testParsePictureFillSymbolNullOutline();
     void testParseRendererSimple();
     void testParseRendererCategorized();
+    void testParseRendererCategorizedNullValue();
     void testRendererTransparency();
     void testVisualVariableRotationGeographic();
     void testVisualVariableRotationArithmetic();
@@ -731,6 +732,53 @@ void TestQgsArcGisRestUtils::testParseRendererCategorized()
   QVERIFY( catRenderer->categories().at( 0 ).symbol() );
   QCOMPARE( catRenderer->categories().at( 1 ).value().toString(), u"Canada"_s );
   QCOMPARE( catRenderer->categories().at( 1 ).label(), u"Canada"_s );
+  QVERIFY( catRenderer->categories().at( 1 ).symbol() );
+}
+
+void TestQgsArcGisRestUtils::testParseRendererCategorizedNullValue()
+{
+  // ArcGIS represents a NULL field value in a unique value renderer using the literal
+  // string "<Null>" as the category's value -- this should be converted to a real NULL
+  // match rather than being treated as the literal text "<Null>"
+  const QVariantMap map = jsonStringToMap(
+    "{"
+    "\"type\": \"uniqueValue\","
+    "\"field1\": \"zone\","
+    "\"uniqueValueInfos\": ["
+    "{"
+    "\"value\": \"1\","
+    "\"symbol\": {"
+    "\"color\": [255, 0, 0, 255],"
+    "\"type\": \"esriSFS\","
+    "\"style\": \"esriSFSSolid\""
+    "},"
+    "\"label\": \"Zone 1\""
+    "},"
+    "{"
+    "\"value\": \"<Null>\","
+    "\"symbol\": {"
+    "\"color\": [0, 0, 0, 255],"
+    "\"type\": \"esriSFS\","
+    "\"style\": \"esriSFSBackwardDiagonal\""
+    "},"
+    "\"label\": \"PSI/ZWILAG\""
+    "}"
+    "]"
+    "}"
+  );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map, context ) );
+  QgsCategorizedSymbolRenderer *catRenderer = dynamic_cast<QgsCategorizedSymbolRenderer *>( renderer.get() );
+  QVERIFY( catRenderer );
+  QCOMPARE( catRenderer->categories().count(), 2 );
+  QCOMPARE( catRenderer->categories().at( 0 ).value().toString(), u"1"_s );
+  QCOMPARE( catRenderer->categories().at( 0 ).label(), u"Zone 1"_s );
+  QVERIFY( catRenderer->categories().at( 0 ).symbol() );
+
+  // the "<Null>" category value must be stored as an invalid (NULL) QVariant, not the literal string "<Null>"
+  QVERIFY( !catRenderer->categories().at( 1 ).value().isValid() );
+  QCOMPARE( catRenderer->categories().at( 1 ).label(), u"PSI/ZWILAG"_s );
   QVERIFY( catRenderer->categories().at( 1 ).symbol() );
 }
 


### PR DESCRIPTION
## Description

Fix esri <Null> string not threated as null

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
