### PR TITLE
[core/raster] methods should return a unique_ptr

### DIFF
--- a/python/PyQt6/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -108,7 +108,7 @@ Returns the source color ramp.
 .. seealso:: :py:func:`setSourceColorRamp`
 %End
 
-    QgsColorRamp *createColorRamp() const /Factory/;
+    std::unique_ptr<QgsColorRamp> createColorRamp() const;
 %Docstring
 Creates a gradient color ramp from shader settings.
 

--- a/python/PyQt6/core/auto_generated/raster/qgshillshaderenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgshillshaderenderer.sip.in
@@ -37,7 +37,7 @@ A renderer for generating live hillshade models.
     virtual Qgis::RasterRendererFlags flags() const;
 
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) /Factory/;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 %Docstring
 Factory method to create a new renderer
 

--- a/python/PyQt6/core/auto_generated/raster/qgsmultibandcolorrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsmultibandcolorrenderer.sip.in
@@ -52,7 +52,7 @@ Constructor for QgsMultiBandColorRenderer.
     virtual Qgis::RasterRendererFlags flags() const;
 
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) /Factory/;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = 0 ) /Factory/;
 

--- a/python/PyQt6/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
@@ -73,7 +73,7 @@ Constructor for QgsPalettedRasterRenderer.
     virtual Qgis::RasterRendererFlags flags() const;
 
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) /Factory/;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = 0 ) /Factory/;
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterattributetable.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterattributetable.sip.in
@@ -438,7 +438,7 @@ Returns the color ramp for an athematic Raster Attribute Table setting
 the labels in ``labels``, optionally generated from ``labelColumn``.
 %End
 
-    QgsRasterRenderer *createRenderer( QgsRasterDataProvider *provider, const int bandNumber, const int classificationColumn = -1 ) /Factory/;
+    std::unique_ptr<QgsRasterRenderer> createRenderer( QgsRasterDataProvider *provider, const int bandNumber, const int classificationColumn = -1 );
 %Docstring
 Creates and returns a (possibly ``None``) raster renderer for the
 specified ``provider`` and ``bandNumber`` and optionally reclassified by
@@ -493,7 +493,7 @@ Returns the translated human readable name of ``fieldUsage``.
 Returns the list of field usages for colors and values.
 %End
 
-    static QgsRasterAttributeTable *createFromRaster( QgsRasterLayer *rasterLayer, int *bandNumber /Out/ = 0 ) /Factory/;
+    static std::unique_ptr<QgsRasterAttributeTable> createFromRaster( QgsRasterLayer *rasterLayer, int *bandNumber /Out/ = 0 );
 %Docstring
 Creates a new Raster Attribute Table from a raster layer, the renderer
 must be Paletted or SingleBandPseudoColor, optionally reporting the

--- a/python/PyQt6/core/auto_generated/raster/qgsrastercontourrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrastercontourrenderer.sip.in
@@ -35,7 +35,7 @@ Creates a contour renderer
     virtual Qgis::RasterRendererFlags flags() const;
 
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) /Factory/;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 %Docstring
 Creates an instance of the renderer based on definition from XML (used
 by renderer registry)

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterlabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterlabeling.sip.in
@@ -35,7 +35,7 @@ Abstract base class for labeling settings for raster layers.
     QgsAbstractRasterLayerLabeling();
     virtual ~QgsAbstractRasterLayerLabeling();
 
-    static QgsAbstractRasterLayerLabeling *defaultLabelingForLayer( QgsRasterLayer *layer ) /Factory/;
+    static std::unique_ptr<QgsAbstractRasterLayerLabeling> defaultLabelingForLayer( QgsRasterLayer *layer );
 %Docstring
 Creates default labeling for a raster ``layer``.
 %End
@@ -97,7 +97,7 @@ The ``scale`` value indicates the scale denominator, e.g. 1000.0 for a
 %End
 
 
-    static QgsAbstractRasterLayerLabeling *createFromElement( const QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsAbstractRasterLayerLabeling> createFromElement( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Tries to create an instance of an implementation based on the XML data.
 %End
@@ -152,7 +152,7 @@ Basic implementation of the labeling interface for raster layers.
     virtual void multiplyOpacity( double opacityFactor );
 
 
-    static QgsRasterLayerSimpleLabeling *create( const QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsRasterLayerSimpleLabeling> create( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a QgsRasterLayerSimpleLabeling from a DOM element with saved
 configuration

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterrendererregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterrendererregistry.sip.in
@@ -56,7 +56,7 @@ Returns the capabilities for the renderer with the specified name.
 .. versionadded:: 3.38
 %End
 
-    QgsRasterRenderer *defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle drawingStyle, QgsRasterDataProvider *provider ) const /Factory/;
+    std::unique_ptr<QgsRasterRenderer> defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle drawingStyle, QgsRasterDataProvider *provider ) const;
 %Docstring
 Creates a default renderer for a raster drawing style (considering user
 options such as default contrast enhancement). Caller takes ownership.

--- a/python/PyQt6/core/auto_generated/raster/qgsrastersinglecolorrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrastersinglecolorrenderer.sip.in
@@ -34,7 +34,7 @@ Creates a single ``color`` renderer
     virtual Qgis::RasterRendererFlags flags() const;
 
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) /Factory/;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 %Docstring
 Creates an instance of the renderer based on definition from XML (used
 by the renderer registry)

--- a/python/PyQt6/core/auto_generated/raster/qgssinglebandcolordatarenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgssinglebandcolordatarenderer.sip.in
@@ -28,7 +28,7 @@ Raster renderer pipe for single band color.
     virtual Qgis::RasterRendererFlags flags() const;
 
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) /Factory/;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     virtual bool setInput( QgsRasterInterface *input );
 

--- a/python/PyQt6/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgssinglebandgrayrenderer.sip.in
@@ -35,7 +35,7 @@ Raster renderer pipe for single band gray.
     virtual Qgis::RasterRendererFlags flags() const;
 
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) /Factory/;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = 0 ) /Factory/;
 

--- a/python/PyQt6/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
@@ -30,7 +30,7 @@ Note: takes ownership of :py:class:`QgsRasterShader`
 
     virtual Qgis::RasterRendererFlags flags() const;
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) /Factory/;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = 0 ) /Factory/;
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -1537,7 +1537,7 @@ void QgsAppLayerTreeViewMenuProvider::toggleLabels( bool enabled )
       if ( enabled && !rasterLayer->labeling() )
       {
         // no labeling setup - create default labeling for layer
-        rasterLayer->setLabeling( QgsAbstractRasterLayerLabeling::defaultLabelingForLayer( rasterLayer ) );
+        rasterLayer->setLabeling( QgsAbstractRasterLayerLabeling::defaultLabelingForLayer( rasterLayer ).release() );
         rasterLayer->setLabelsEnabled( true );
       }
       else

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -589,8 +589,16 @@ QList<QgsLayerTreeModelLegendNode *> QgsDefaultMeshLayerLegend::createLayerTreeM
           // for interpolated shaders we use a ramp legend node
           if ( !shader.colorRampItemList().isEmpty() )
           {
-            nodes
-              << new QgsColorRampLegendNode( nodeLayer, shader.createColorRamp(), shader.legendSettings() ? *shader.legendSettings() : QgsColorRampLegendNodeSettings(), shader.minimumValue(), shader.maximumValue(), nullptr, u"scalarLegend"_s, scalarNameKey );
+            nodes << new QgsColorRampLegendNode(
+              nodeLayer,
+              shader.createColorRamp().release(),
+              shader.legendSettings() ? *shader.legendSettings() : QgsColorRampLegendNodeSettings(),
+              shader.minimumValue(),
+              shader.maximumValue(),
+              nullptr,
+              u"scalarLegend"_s,
+              scalarNameKey
+            );
           }
           break;
         }
@@ -638,7 +646,7 @@ QList<QgsLayerTreeModelLegendNode *> QgsDefaultMeshLayerLegend::createLayerTreeM
               {
                 nodes << new QgsColorRampLegendNode(
                   nodeLayer,
-                  shader.createColorRamp(),
+                  shader.createColorRamp().release(),
                   shader.legendSettings() ? *shader.legendSettings() : QgsColorRampLegendNodeSettings(),
                   shader.minimumValue(),
                   shader.maximumValue(),

--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -143,7 +143,7 @@ QgsColorRamp *QgsColorRampShader::sourceColorRamp() const
   return mSourceColorRamp.get();
 }
 
-QgsColorRamp *QgsColorRampShader::createColorRamp() const
+std::unique_ptr<QgsColorRamp> QgsColorRampShader::createColorRamp() const
 {
   auto ramp = std::make_unique< QgsGradientColorRamp >();
   const int count = mColorRampItemList.size();
@@ -184,7 +184,7 @@ QgsColorRamp *QgsColorRampShader::createColorRamp() const
     ramp->setStops( stops );
   }
 
-  return ramp.release();
+  return ramp;
 }
 
 void QgsColorRampShader::setSourceColorRamp( QgsColorRamp *colorramp )

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -155,7 +155,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
      * Creates a gradient color ramp from shader settings.
      * \since QGIS 3.18
      */
-    QgsColorRamp *createColorRamp() const SIP_FACTORY;
+    std::unique_ptr<QgsColorRamp> createColorRamp() const;
 
     /**
      * Set the source color ramp. Ownership is transferred to the shader.

--- a/src/core/raster/qgshillshaderenderer.cpp
+++ b/src/core/raster/qgshillshaderenderer.cpp
@@ -63,7 +63,7 @@ Qgis::RasterRendererFlags QgsHillshadeRenderer::flags() const
   return Qgis::RasterRendererFlag::InternalLayerOpacityHandling;
 }
 
-QgsRasterRenderer *QgsHillshadeRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+std::unique_ptr<QgsRasterRenderer> QgsHillshadeRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
 {
   if ( elem.isNull() )
   {
@@ -75,7 +75,7 @@ QgsRasterRenderer *QgsHillshadeRenderer::create( const QDomElement &elem, QgsRas
   double angle = elem.attribute( u"angle"_s, u"45"_s ).toDouble();
   double zFactor = elem.attribute( u"zfactor"_s, u"1"_s ).toDouble();
   bool multiDirectional = elem.attribute( u"multidirection"_s, u"0"_s ).toInt();
-  QgsHillshadeRenderer *r = new QgsHillshadeRenderer( input, band, azimuth, angle );
+  auto r = std::make_unique<QgsHillshadeRenderer>( input, band, azimuth, angle );
   r->readXml( elem );
 
   r->setZFactor( zFactor );

--- a/src/core/raster/qgshillshaderenderer.h
+++ b/src/core/raster/qgshillshaderenderer.h
@@ -53,7 +53,7 @@ class CORE_EXPORT QgsHillshadeRenderer : public QgsRasterRenderer
      * \param input The raster input interface.
      * \returns A new QgsHillshadeRenderer.
      */
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     void writeXml( QDomDocument &doc, QDomElement &parentElem ) const override;
 

--- a/src/core/raster/qgsmultibandcolorrenderer.cpp
+++ b/src/core/raster/qgsmultibandcolorrenderer.cpp
@@ -104,7 +104,7 @@ void QgsMultiBandColorRenderer::setBlueContrastEnhancement( QgsContrastEnhanceme
   mBlueContrastEnhancement.reset( ce );
 }
 
-QgsRasterRenderer *QgsMultiBandColorRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+std::unique_ptr<QgsRasterRenderer> QgsMultiBandColorRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
 {
   if ( elem.isNull() )
   {
@@ -141,7 +141,7 @@ QgsRasterRenderer *QgsMultiBandColorRenderer::create( const QDomElement &elem, Q
     blueContrastEnhancement->readXml( blueContrastElem );
   }
 
-  QgsRasterRenderer *r = new QgsMultiBandColorRenderer( input, redBand, greenBand, blueBand, redContrastEnhancement, greenContrastEnhancement, blueContrastEnhancement );
+  auto r = std::make_unique<QgsMultiBandColorRenderer>( input, redBand, greenBand, blueBand, redContrastEnhancement, greenContrastEnhancement, blueContrastEnhancement );
   r->readXml( elem );
   return r;
 }

--- a/src/core/raster/qgsmultibandcolorrenderer.h
+++ b/src/core/raster/qgsmultibandcolorrenderer.h
@@ -61,7 +61,7 @@ class CORE_EXPORT QgsMultiBandColorRenderer : public QgsRasterRenderer
     QgsMultiBandColorRenderer *clone() const override SIP_FACTORY;
     Qgis::RasterRendererFlags flags() const override;
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override SIP_FACTORY;
 

--- a/src/core/raster/qgspalettedrasterrenderer.cpp
+++ b/src/core/raster/qgspalettedrasterrenderer.cpp
@@ -101,7 +101,7 @@ Qgis::RasterRendererFlags QgsPalettedRasterRenderer::flags() const
   return Qgis::RasterRendererFlag::InternalLayerOpacityHandling;
 }
 
-QgsRasterRenderer *QgsPalettedRasterRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+std::unique_ptr<QgsRasterRenderer> QgsPalettedRasterRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
 {
   if ( elem.isNull() )
   {
@@ -133,7 +133,7 @@ QgsRasterRenderer *QgsPalettedRasterRenderer::create( const QDomElement &elem, Q
     }
   }
 
-  QgsPalettedRasterRenderer *r = new QgsPalettedRasterRenderer( input, bandNumber, classData );
+  auto r = std::make_unique<QgsPalettedRasterRenderer>( input, bandNumber, classData );
   r->readXml( elem );
 
   // try to load color ramp (optional)

--- a/src/core/raster/qgspalettedrasterrenderer.h
+++ b/src/core/raster/qgspalettedrasterrenderer.h
@@ -102,7 +102,7 @@ class CORE_EXPORT QgsPalettedRasterRenderer : public QgsRasterRenderer
     QgsPalettedRasterRenderer *clone() const override SIP_FACTORY;
     Qgis::RasterRendererFlags flags() const override;
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override SIP_FACTORY;
 

--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -1099,7 +1099,7 @@ QList<Qgis::RasterAttributeTableFieldUsage> QgsRasterAttributeTable::valueAndCol
   return valueColorUsages;
 }
 
-QgsRasterAttributeTable *QgsRasterAttributeTable::createFromRaster( QgsRasterLayer *raster, int *bandNumber )
+std::unique_ptr<QgsRasterAttributeTable> QgsRasterAttributeTable::createFromRaster( QgsRasterLayer *raster, int *bandNumber )
 {
   if ( !raster || !raster->dataProvider() || !raster->isValid() )
   {
@@ -1115,7 +1115,7 @@ QgsRasterAttributeTable *QgsRasterAttributeTable::createFromRaster( QgsRasterLay
 
   if ( const QgsPalettedRasterRenderer *palettedRenderer = dynamic_cast<const QgsPalettedRasterRenderer *>( renderer ) )
   {
-    QgsRasterAttributeTable *rat = new QgsRasterAttributeTable();
+    auto rat = std::make_unique<QgsRasterAttributeTable>();
     rat->appendField( u"Value"_s, Qgis::RasterAttributeTableFieldUsage::MinMax, QMetaType::Type::Double );
     rat->appendField( u"Class"_s, Qgis::RasterAttributeTableFieldUsage::Name, QMetaType::Type::QString );
     rat->appendField( u"Red"_s, Qgis::RasterAttributeTableFieldUsage::Red, QMetaType::Type::Int );
@@ -1143,7 +1143,7 @@ QgsRasterAttributeTable *QgsRasterAttributeTable::createFromRaster( QgsRasterLay
     {
       if ( const QgsColorRampShader *shaderFunction = dynamic_cast<const QgsColorRampShader *>( shader->rasterShaderFunction() ) )
       {
-        QgsRasterAttributeTable *rat = new QgsRasterAttributeTable();
+        auto rat = std::make_unique<QgsRasterAttributeTable>();
         switch ( shaderFunction->colorRampType() )
         {
           case Qgis::ShaderInterpolationMethod::Linear:
@@ -1557,7 +1557,7 @@ QgsGradientColorRamp QgsRasterAttributeTable::colorRamp( QStringList &labels, co
   return ramp;
 }
 
-QgsRasterRenderer *QgsRasterAttributeTable::createRenderer( QgsRasterDataProvider *provider, const int bandNumber, const int classificationColumn )
+std::unique_ptr<QgsRasterRenderer> QgsRasterAttributeTable::createRenderer( QgsRasterDataProvider *provider, const int bandNumber, const int classificationColumn )
 {
   if ( !provider )
   {
@@ -1639,7 +1639,7 @@ QgsRasterRenderer *QgsRasterAttributeTable::createRenderer( QgsRasterDataProvide
     renderer = std::move( pseudoColorRenderer );
   }
 
-  return renderer.release();
+  return renderer;
 }
 
 QList<QList<QVariant> > QgsRasterAttributeTable::orderedRows() const

--- a/src/core/raster/qgsrasterattributetable.h
+++ b/src/core/raster/qgsrasterattributetable.h
@@ -394,7 +394,7 @@ class CORE_EXPORT QgsRasterAttributeTable
      *       the renderer will still use the \a classificationColumn for
      *       generating the class labels.
      */
-    QgsRasterRenderer *createRenderer( QgsRasterDataProvider *provider, const int bandNumber, const int classificationColumn = -1 ) SIP_FACTORY;
+    std::unique_ptr<QgsRasterRenderer> createRenderer( QgsRasterDataProvider *provider, const int bandNumber, const int classificationColumn = -1 );
 
     /**
      * Returns the data rows ordered by the value column(s) in ascending order, if
@@ -440,7 +440,7 @@ class CORE_EXPORT QgsRasterAttributeTable
      * \param bandNumber band number
      * \returns NULLPTR in case of errors or unsupported renderer.
      */
-    static QgsRasterAttributeTable *createFromRaster( QgsRasterLayer *rasterLayer, int *bandNumber SIP_OUT = nullptr ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterAttributeTable> createFromRaster( QgsRasterLayer *rasterLayer, int *bandNumber SIP_OUT = nullptr );
 
     /**
      * Returns information about supported Raster Attribute Table usages.

--- a/src/core/raster/qgsrastercontourrenderer.cpp
+++ b/src/core/raster/qgsrastercontourrenderer.cpp
@@ -52,14 +52,14 @@ Qgis::RasterRendererFlags QgsRasterContourRenderer::flags() const
   return Qgis::RasterRendererFlag::UseNoDataForOutOfRangePixels;
 }
 
-QgsRasterRenderer *QgsRasterContourRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+std::unique_ptr<QgsRasterRenderer> QgsRasterContourRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
 {
   if ( elem.isNull() )
   {
     return nullptr;
   }
 
-  QgsRasterContourRenderer *r = new QgsRasterContourRenderer( input );
+  auto r = std::make_unique<QgsRasterContourRenderer>( input );
   r->readXml( elem );
 
   const int inputBand = elem.attribute( u"band"_s, u"-1"_s ).toInt();

--- a/src/core/raster/qgsrastercontourrenderer.h
+++ b/src/core/raster/qgsrastercontourrenderer.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsRasterContourRenderer : public QgsRasterRenderer
     Qgis::RasterRendererFlags flags() const override;
 
     //! Creates an instance of the renderer based on definition from XML (used by renderer registry)
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     void writeXml( QDomDocument &doc, QDomElement &parentElem ) const override;
 

--- a/src/core/raster/qgsrasterlabeling.cpp
+++ b/src/core/raster/qgsrasterlabeling.cpp
@@ -308,7 +308,7 @@ bool QgsAbstractRasterLayerLabeling::isInScaleRange( double ) const
   return true;
 }
 
-QgsAbstractRasterLayerLabeling *QgsAbstractRasterLayerLabeling::createFromElement( const QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsAbstractRasterLayerLabeling> QgsAbstractRasterLayerLabeling::createFromElement( const QDomElement &element, const QgsReadWriteContext &context )
 {
   const QString type = element.attribute( u"type"_s );
   if ( type == "simple"_L1 )
@@ -465,7 +465,7 @@ bool QgsRasterLayerSimpleLabeling::hasNonDefaultCompositionMode() const
   return mTextFormat.hasNonDefaultCompositionMode();
 }
 
-QgsRasterLayerSimpleLabeling *QgsRasterLayerSimpleLabeling::create( const QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsRasterLayerSimpleLabeling> QgsRasterLayerSimpleLabeling::create( const QDomElement &element, const QgsReadWriteContext &context )
 {
   auto res = std::make_unique< QgsRasterLayerSimpleLabeling >();
   res->setBand( element.attribute( u"band"_s, u"1"_s ).toInt() );
@@ -505,7 +505,7 @@ QgsRasterLayerSimpleLabeling *QgsRasterLayerSimpleLabeling::create( const QDomEl
   res->mMinimumScale = renderingElem.attribute( u"scaleMax"_s, u"0"_s ).toDouble();
   res->mScaleVisibility = renderingElem.attribute( u"scaleVisibility"_s ).toInt();
 
-  return res.release();
+  return res;
 }
 
 QgsTextFormat QgsRasterLayerSimpleLabeling::textFormat() const
@@ -602,10 +602,10 @@ void QgsRasterLayerSimpleLabeling::multiplyOpacity( double opacityFactor )
   mTextFormat.multiplyOpacity( opacityFactor );
 }
 
-QgsAbstractRasterLayerLabeling *QgsAbstractRasterLayerLabeling::defaultLabelingForLayer( QgsRasterLayer *layer )
+std::unique_ptr<QgsAbstractRasterLayerLabeling> QgsAbstractRasterLayerLabeling::defaultLabelingForLayer( QgsRasterLayer *layer )
 {
   auto res = std::make_unique< QgsRasterLayerSimpleLabeling >();
   res->setTextFormat( QgsStyle::defaultTextFormatForProject( layer->project() ) );
   res->setBand( 1 );
-  return res.release();
+  return res;
 }

--- a/src/core/raster/qgsrasterlabeling.h
+++ b/src/core/raster/qgsrasterlabeling.h
@@ -187,7 +187,7 @@ class CORE_EXPORT QgsAbstractRasterLayerLabeling SIP_ABSTRACT
     /**
      * Creates default labeling for a raster \a layer.
      */
-    static QgsAbstractRasterLayerLabeling *defaultLabelingForLayer( QgsRasterLayer *layer ) SIP_FACTORY;
+    static std::unique_ptr<QgsAbstractRasterLayerLabeling> defaultLabelingForLayer( QgsRasterLayer *layer );
 
     //! Unique type string of the labeling configuration implementation
     virtual QString type() const = 0;
@@ -249,7 +249,7 @@ class CORE_EXPORT QgsAbstractRasterLayerLabeling SIP_ABSTRACT
     /**
      * Tries to create an instance of an implementation based on the XML data.
      */
-    static QgsAbstractRasterLayerLabeling *createFromElement( const QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsAbstractRasterLayerLabeling> createFromElement( const QDomElement &element, const QgsReadWriteContext &context );
 
     /**
      * Writes the SE 1.1 TextSymbolizer element based on the current layer labeling settings
@@ -294,7 +294,7 @@ class CORE_EXPORT QgsRasterLayerSimpleLabeling : public QgsAbstractRasterLayerLa
     void multiplyOpacity( double opacityFactor ) override;
 
     //! Creates a QgsRasterLayerSimpleLabeling from a DOM element with saved configuration
-    static QgsRasterLayerSimpleLabeling *create( const QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterLayerSimpleLabeling> create( const QDomElement &element, const QgsReadWriteContext &context );
 
     /**
      * Returns the text format used for rendering the labels.

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -324,7 +324,7 @@ void QgsRasterLayer::setRendererForDrawingStyle( Qgis::RasterDrawingStyle drawin
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( drawingStyle, mDataProvider ) );
+  setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( drawingStyle, mDataProvider ).release() );
 }
 
 QgsRasterDataProvider *QgsRasterLayer::dataProvider()
@@ -2094,8 +2094,8 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
       QgsRasterRendererRegistryEntry rendererEntry;
       if ( mDataProvider && QgsApplication::rasterRendererRegistry()->rendererData( rendererType, rendererEntry ) )
       {
-        QgsRasterRenderer *renderer = rendererEntry.rendererCreateFunction( rasterRendererElem, mDataProvider );
-        mPipe->set( renderer );
+        std::unique_ptr<QgsRasterRenderer> renderer = rendererEntry.rendererCreateFunction( rasterRendererElem, mDataProvider );
+        mPipe->set( renderer.release() );
       }
     }
 
@@ -2174,9 +2174,9 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
     QDomElement labelingElement = layer_node.firstChildElement( u"labeling"_s );
     if ( !labelingElement.isNull() )
     {
-      QgsAbstractRasterLayerLabeling *labeling = QgsAbstractRasterLayerLabeling::createFromElement( labelingElement, context );
+      std::unique_ptr<QgsAbstractRasterLayerLabeling> labeling = QgsAbstractRasterLayerLabeling::createFromElement( labelingElement, context );
       mLabelsEnabled = layer_node.toElement().attribute( u"labelsEnabled"_s, u"0"_s ).toInt();
-      setLabeling( labeling );
+      setLabeling( labeling.release() );
     }
   }
 

--- a/src/core/raster/qgsrasterrendererregistry.cpp
+++ b/src/core/raster/qgsrasterrendererregistry.cpp
@@ -131,7 +131,7 @@ Qgis::RasterRendererCapabilities QgsRasterRendererRegistry::rendererCapabilities
   return Qgis::RasterRendererCapabilities();
 }
 
-QgsRasterRenderer *QgsRasterRendererRegistry::defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle drawingStyle, QgsRasterDataProvider *provider ) const
+std::unique_ptr<QgsRasterRenderer> QgsRasterRendererRegistry::defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle drawingStyle, QgsRasterDataProvider *provider ) const
 {
   if ( !provider || provider->bandCount() < 1 )
   {
@@ -192,7 +192,7 @@ QgsRasterRenderer *QgsRasterRendererRegistry::defaultRendererForDrawingStyle( Qg
       QString ratErrorMessage;
       if ( QgsRasterAttributeTable *rat = provider->attributeTable( grayBand ); rat && rat->isValid( &ratErrorMessage ) )
       {
-        renderer.reset( rat->createRenderer( provider, grayBand ) );
+        renderer = rat->createRenderer( provider, grayBand );
       }
 
       if ( !ratErrorMessage.isEmpty() )
@@ -264,7 +264,7 @@ QgsRasterRenderer *QgsRasterRendererRegistry::defaultRendererForDrawingStyle( Qg
     tr->setTransparentThreeValuePixelList( {} );
   }
   renderer->setRasterTransparency( tr.release() );
-  return renderer.release();
+  return renderer;
 }
 
 bool QgsRasterRendererRegistry::minMaxValuesForBand( int band, QgsRasterDataProvider *provider, double &minValue, double &maxValue ) const

--- a/src/core/raster/qgsrasterrendererregistry.h
+++ b/src/core/raster/qgsrasterrendererregistry.h
@@ -36,7 +36,7 @@ class QgsRasterDataProvider;
 class QgsRectangle;
 
 #ifndef SIP_RUN
-typedef QgsRasterRenderer *( *QgsRasterRendererCreateFunc )( const QDomElement &, QgsRasterInterface *input );
+typedef std::unique_ptr<QgsRasterRenderer> ( *QgsRasterRendererCreateFunc )( const QDomElement &, QgsRasterInterface *input );
 typedef QgsRasterRendererWidget *( *QgsRasterRendererWidgetCreateFunc )( QgsRasterLayer *, const QgsRectangle &extent );
 
 /**
@@ -144,7 +144,7 @@ class CORE_EXPORT QgsRasterRendererRegistry
      * Creates a default renderer for a raster drawing style (considering user options such as default contrast enhancement).
      * Caller takes ownership.
     */
-    QgsRasterRenderer *defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle drawingStyle, QgsRasterDataProvider *provider ) const SIP_FACTORY;
+    std::unique_ptr<QgsRasterRenderer> defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle drawingStyle, QgsRasterDataProvider *provider ) const;
 
   private:
     QHash< QString, QgsRasterRendererRegistryEntry > mEntries;

--- a/src/core/raster/qgsrastersinglecolorrenderer.cpp
+++ b/src/core/raster/qgsrastersinglecolorrenderer.cpp
@@ -44,7 +44,7 @@ Qgis::RasterRendererFlags QgsRasterSingleColorRenderer::flags() const
   return Qgis::RasterRendererFlag::InternalLayerOpacityHandling;
 }
 
-QgsRasterRenderer *QgsRasterSingleColorRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+std::unique_ptr<QgsRasterRenderer> QgsRasterSingleColorRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
 {
   if ( elem.isNull() )
   {
@@ -53,7 +53,7 @@ QgsRasterRenderer *QgsRasterSingleColorRenderer::create( const QDomElement &elem
 
   const QColor color = QgsColorUtils::colorFromString( elem.attribute( u"color"_s, u"0,0,0"_s ) );
   const int band = elem.attribute( u"band"_s, u"1"_s ).toInt();
-  QgsRasterSingleColorRenderer *r = new QgsRasterSingleColorRenderer( input, band, color );
+  auto r = std::make_unique<QgsRasterSingleColorRenderer>( input, band, color );
   r->readXml( elem );
 
   return r;

--- a/src/core/raster/qgsrastersinglecolorrenderer.h
+++ b/src/core/raster/qgsrastersinglecolorrenderer.h
@@ -46,7 +46,7 @@ class CORE_EXPORT QgsRasterSingleColorRenderer : public QgsRasterRenderer
     Qgis::RasterRendererFlags flags() const override;
 
     //! Creates an instance of the renderer based on definition from XML (used by the renderer registry)
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override SIP_FACTORY;
 

--- a/src/core/raster/qgssinglebandcolordatarenderer.cpp
+++ b/src/core/raster/qgssinglebandcolordatarenderer.cpp
@@ -46,7 +46,7 @@ Qgis::RasterRendererFlags QgsSingleBandColorDataRenderer::flags() const
   return Qgis::RasterRendererFlag::InternalLayerOpacityHandling;
 }
 
-QgsRasterRenderer *QgsSingleBandColorDataRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+std::unique_ptr<QgsRasterRenderer> QgsSingleBandColorDataRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
 {
   if ( elem.isNull() )
   {
@@ -54,7 +54,7 @@ QgsRasterRenderer *QgsSingleBandColorDataRenderer::create( const QDomElement &el
   }
 
   const int band = elem.attribute( u"band"_s, u"-1"_s ).toInt();
-  QgsRasterRenderer *r = new QgsSingleBandColorDataRenderer( input, band );
+  auto r = std::make_unique<QgsSingleBandColorDataRenderer>( input, band );
   r->readXml( elem );
   return r;
 }

--- a/src/core/raster/qgssinglebandcolordatarenderer.h
+++ b/src/core/raster/qgssinglebandcolordatarenderer.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsSingleBandColorDataRenderer : public QgsRasterRenderer
     QgsSingleBandColorDataRenderer *clone() const override SIP_FACTORY;
     Qgis::RasterRendererFlags flags() const override;
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     bool setInput( QgsRasterInterface *input ) override;
     int inputBand() const override;

--- a/src/core/raster/qgssinglebandgrayrenderer.cpp
+++ b/src/core/raster/qgssinglebandgrayrenderer.cpp
@@ -61,7 +61,7 @@ Qgis::RasterRendererFlags QgsSingleBandGrayRenderer::flags() const
   return Qgis::RasterRendererFlag::InternalLayerOpacityHandling;
 }
 
-QgsRasterRenderer *QgsSingleBandGrayRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+std::unique_ptr<QgsRasterRenderer> QgsSingleBandGrayRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
 {
   if ( elem.isNull() )
   {
@@ -69,7 +69,7 @@ QgsRasterRenderer *QgsSingleBandGrayRenderer::create( const QDomElement &elem, Q
   }
 
   const int grayBand = elem.attribute( u"grayBand"_s, u"-1"_s ).toInt();
-  QgsSingleBandGrayRenderer *r = new QgsSingleBandGrayRenderer( input, grayBand );
+  auto r = std::make_unique<QgsSingleBandGrayRenderer>( input, grayBand );
   r->readXml( elem );
 
   if ( elem.attribute( u"gradient"_s ) == "WhiteToBlack"_L1 )

--- a/src/core/raster/qgssinglebandgrayrenderer.h
+++ b/src/core/raster/qgssinglebandgrayrenderer.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsSingleBandGrayRenderer : public QgsRasterRenderer
     QgsSingleBandGrayRenderer *clone() const override SIP_FACTORY;
     Qgis::RasterRendererFlags flags() const override;
 
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override SIP_FACTORY;
 

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -142,7 +142,7 @@ void QgsSingleBandPseudoColorRenderer::createShader(
   setShader( rasterShader );
 }
 
-QgsRasterRenderer *QgsSingleBandPseudoColorRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+std::unique_ptr<QgsRasterRenderer> QgsSingleBandPseudoColorRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
 {
   if ( elem.isNull() )
   {
@@ -158,7 +158,7 @@ QgsRasterRenderer *QgsSingleBandPseudoColorRenderer::create( const QDomElement &
     shader->readXml( rasterShaderElem );
   }
 
-  QgsSingleBandPseudoColorRenderer *r = new QgsSingleBandPseudoColorRenderer( input, band, shader );
+  auto r = std::make_unique<QgsSingleBandPseudoColorRenderer>( input, band, shader );
   r->readXml( elem );
 
   // TODO: add _readXML in superclass?
@@ -480,7 +480,11 @@ QList<QgsLayerTreeModelLegendNode *> QgsSingleBandPseudoColorRenderer::createLeg
         if ( !rampShader->colorRampItemList().isEmpty() )
         {
           res << new QgsColorRampLegendNode(
-            nodeLayer, rampShader->createColorRamp(), rampShader->legendSettings() ? *rampShader->legendSettings() : QgsColorRampLegendNodeSettings(), rampShader->minimumValue(), rampShader->maximumValue()
+            nodeLayer,
+            rampShader->createColorRamp().release(),
+            rampShader->legendSettings() ? *rampShader->legendSettings() : QgsColorRampLegendNodeSettings(),
+            rampShader->minimumValue(),
+            rampShader->maximumValue()
           );
         }
         break;

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.h
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.h
@@ -44,7 +44,7 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer : public QgsRasterRenderer
 
     QgsSingleBandPseudoColorRenderer *clone() const override SIP_FACTORY;
     Qgis::RasterRendererFlags flags() const override;
-    static QgsRasterRenderer *create( const QDomElement &elem, QgsRasterInterface *input ) SIP_FACTORY;
+    static std::unique_ptr<QgsRasterRenderer> create( const QDomElement &elem, QgsRasterInterface *input );
 
     QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override SIP_FACTORY;
 

--- a/src/gui/raster/qgscreaterasterattributetabledialog.cpp
+++ b/src/gui/raster/qgscreaterasterattributetabledialog.cpp
@@ -134,7 +134,7 @@ void QgsCreateRasterAttributeTableDialog::accept()
 {
   QString errorMessage;
   int bandNumber { 0 };
-  QgsRasterAttributeTable *rat { QgsRasterAttributeTable::createFromRaster( mRasterLayer, &bandNumber ) };
+  std::unique_ptr<QgsRasterAttributeTable> rat { QgsRasterAttributeTable::createFromRaster( mRasterLayer, &bandNumber ) };
   bool success { false };
 
   if ( !rat )
@@ -143,7 +143,7 @@ void QgsCreateRasterAttributeTableDialog::accept()
   }
   else
   {
-    mRasterLayer->dataProvider()->setAttributeTable( bandNumber, rat );
+    mRasterLayer->dataProvider()->setAttributeTable( bandNumber, rat.release() );
 
     // Save it
     const bool storageIsFile { saveToFile() };

--- a/src/gui/raster/qgsrasterattributetablewidget.cpp
+++ b/src/gui/raster/qgsrasterattributetablewidget.cpp
@@ -26,6 +26,7 @@
 #include "qgsrasterattributetableaddcolumndialog.h"
 #include "qgsrasterattributetableaddrowdialog.h"
 #include "qgsrasterlayer.h"
+#include "qgsrasterrenderer.h"
 
 #include <QAction>
 #include <QFileDialog>
@@ -331,9 +332,9 @@ void QgsRasterAttributeTableWidget::classify()
   if ( QMessageBox::question( nullptr, tr( "Apply Style From Attribute Table" ), confirmMessage.append( tr( "The existing symbology for the raster will be replaced by a new symbology from the attribute table and any unsaved changes to the current symbology will be lost, do you want to proceed?" ) ) )
        == QMessageBox::Yes )
   {
-    if ( QgsRasterRenderer *renderer = mAttributeTableBuffer->createRenderer( mRasterLayer->dataProvider(), mCurrentBand, mClassifyComboBox->currentData().toInt() ) )
+    if ( std::unique_ptr<QgsRasterRenderer> renderer = mAttributeTableBuffer->createRenderer( mRasterLayer->dataProvider(), mCurrentBand, mClassifyComboBox->currentData().toInt() ) )
     {
-      mRasterLayer->setRenderer( renderer );
+      mRasterLayer->setRenderer( renderer.release() );
       mRasterLayer->triggerRepaint();
       emit rendererChanged();
     }

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -640,12 +640,12 @@ void QgsRasterLayerProperties::setRendererWidget( const QString &rendererName )
       {
         if ( rendererName == "singlebandgray"_L1 )
         {
-          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle::SingleBandGray, mRasterLayer->dataProvider() ) );
+          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle::SingleBandGray, mRasterLayer->dataProvider() ).release() );
           whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
         }
         else if ( rendererName == "multibandcolor"_L1 )
         {
-          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle::MultiBandColor, mRasterLayer->dataProvider() ) );
+          whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle::MultiBandColor, mRasterLayer->dataProvider() ).release() );
           whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
         }
       }

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -309,12 +309,14 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
         {
           if ( rendererName == "singlebandgray"_L1 )
           {
-            whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle::SingleBandGray, mRasterLayer->dataProvider() ) );
+            whileBlocking( mRasterLayer )
+              ->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle::SingleBandGray, mRasterLayer->dataProvider() ).release() );
             whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
           }
           else if ( rendererName == "multibandcolor"_L1 )
           {
-            whileBlocking( mRasterLayer )->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle::MultiBandColor, mRasterLayer->dataProvider() ) );
+            whileBlocking( mRasterLayer )
+              ->setRenderer( QgsApplication::rasterRendererRegistry()->defaultRendererForDrawingStyle( Qgis::RasterDrawingStyle::MultiBandColor, mRasterLayer->dataProvider() ).release() );
             whileBlocking( mRasterLayer )->setDefaultContrastEnhancement();
           }
         }


### PR DESCRIPTION
## Description

This PR is part of QEP [#417](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-417-remove-sip-factory.md)

It concerns only core/raster folder and method with non-QObject return type.

## AI tool usage

None

**Funded by the QGIS Grant programme 2026**