### PR TITLE
Fix argument format for max triangle edge length

### DIFF
--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -128,7 +128,7 @@ QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariant
 #if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 6 )
   if ( parameters.value( u"MAX_EDGE_LENGTH"_s ).isValid() )
   {
-    args << u"--max_triangle_edge_length=%1"_s.arg( parameterAsDouble( parameters, u"MAX_EDGE_LENGTH"_s, context ) );
+    args << u"--max-triangle-edge-length=%1"_s.arg( parameterAsDouble( parameters, u"MAX_EDGE_LENGTH"_s, context ) );
   }
 #endif
 #endif

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -611,7 +611,7 @@ void TestQgsProcessingPdalAlgs::exportRasterTin()
 #if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 6 )
   parameters.insert( u"MAX_EDGE_LENGTH"_s, 25 );
   args = alg->createArgumentLists( parameters, *context, &feedback );
-  QCOMPARE( args, QStringList() << u"to_raster_tin"_s << u"--input=%1"_s.arg( mPointCloudLayerPath ) << u"--output=%1"_s.arg( outputFile ) << u"--resolution=0.5"_s << u"--tile-size=100"_s << u"--tile-origin-x=1"_s << u"--tile-origin-y=10"_s << u"--max_triangle_edge_length=25"_s );
+  QCOMPARE( args, QStringList() << u"to_raster_tin"_s << u"--input=%1"_s.arg( mPointCloudLayerPath ) << u"--output=%1"_s.arg( outputFile ) << u"--resolution=0.5"_s << u"--tile-size=100"_s << u"--tile-origin-x=1"_s << u"--tile-origin-y=10"_s << u"--max-triangle-edge-length=25"_s );
   parameters.remove( u"MAX_EDGE_LENGTH"_s );
 #endif
 #endif


### PR DESCRIPTION
amended line 131 --max_triangle_edge_length is now --max-triangle-edge-length

## Description

Changed to suit PDAL tools
https://github.com/PDAL/wrench/blob/main/src/to_raster_tin.cpp
argMaxTriangleEdgeLength = &programArgs.add("max-triangle-edge-length", "Maximum triangle edge length", maxTriangleEdgeLength); 

Fixed #67353 

Needs to be backported to 4.x releases only.. 3.x releases do not have this parameter
https://github.com/Kapanther/QGIS/blob/release-3_44/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp