### PR TITLE
Introduce unique_ptr dynamic and static cast

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -5147,7 +5147,7 @@ QgsGeometry QgsGeometry::doChamferFillet( ChamferFilletOperationType op, int ver
         }
         partIndex++;
       }
-      finalGeom.reset( dynamic_cast<QgsAbstractGeometry *>( newMultiPoly.release() ) );
+      finalGeom = std::move( newMultiPoly );
     }
     else
     {

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -253,7 +253,7 @@ Qgis::GeometryOperationResult QgsGeometryEditUtils::addPart( QgsAbstractGeometry
     }
     else if ( QgsWkbTypes::flatType( part->wkbType() ) == Qgis::WkbType::MultiPolygon || QgsWkbTypes::flatType( part->wkbType() ) == Qgis::WkbType::MultiSurface )
     {
-      std::unique_ptr<QgsGeometryCollection> parts( static_cast<QgsGeometryCollection *>( part.release() ) );
+      auto parts = qgis::unique_ptr_static_cast<QgsGeometryCollection>( std::move( part ) );
 
       int i;
       const int n = geomCollection->numGeometries();

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -7747,6 +7747,44 @@ namespace qgis
   {
     return QList<T>( set.begin(), set.end() );
   }
+
+  /**
+   * Use unique_ptr_static_cast to static_cast a std::unique_ptr as equivalent of
+   * static_cast<Derived*>(unique_ptr_to_base.release()) with safe checking in debug
+   * mode.
+   *
+   * \param f std::unique_ptr to a base class
+   * \return std::unique_ptr to a derived class
+   */
+  template<typename To, typename From> inline std::unique_ptr<To> unique_ptr_static_cast( std::unique_ptr<From> f )
+  {
+    static_assert( ( std::is_base_of<From, To>::value ), "target type not derived from source type" );
+    Q_ASSERT( !f || dynamic_cast<To *>( f.get() ) != nullptr );
+    return std::unique_ptr<To>( static_cast<To *>( f.release() ) );
+  }
+
+  /**
+   * dynamic_cast a std::unique_ptr. If cast fails, \a f is unchanged. If cast succeeds, memory
+   * ownership is transferred to returned unique_ptr and \a f is empty
+   *
+   * \param f std::unique_ptr to a base class
+   * \return std::unique_ptr to a derived class
+   */
+  template<typename To, typename From> inline std::unique_ptr<To> unique_ptr_dynamic_cast( std::unique_ptr<From> &&f )
+  {
+    static_assert( ( std::is_base_of<From, To>::value ), "target type not derived from source type" );
+    if ( To *casted = dynamic_cast<To *>( f.get() ) )
+    {
+      return std::unique_ptr< To >( dynamic_cast<To *>( f.release() ) );
+    }
+    else
+    {
+      //could not cast
+      return nullptr;
+    }
+  }
+
+
 } //namespace qgis
 
 ///@endcond

--- a/src/core/qgsrecentstylehandler.h
+++ b/src/core/qgsrecentstylehandler.h
@@ -94,15 +94,7 @@ class CORE_EXPORT QgsRecentStyleHandler
     template<class SymbolType> std::unique_ptr< SymbolType > recentSymbol( const QString &identifier ) const SIP_SKIP
     {
       std::unique_ptr< QgsSymbol > tmpSymbol( recentSymbol( identifier ) );
-      if ( SymbolType *symbolCastToType = dynamic_cast<SymbolType *>( tmpSymbol.get() ) )
-      {
-        return std::unique_ptr< SymbolType >( dynamic_cast<SymbolType *>( tmpSymbol.release() ) );
-      }
-      else
-      {
-        //could not cast
-        return nullptr;
-      }
+      return qgis::unique_ptr_dynamic_cast<SymbolType>( std::move( tmpSymbol ) );
     }
 
   private:

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -438,19 +438,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
      */
     template<class SymbolType> static std::unique_ptr< SymbolType > loadSymbol( const QDomElement &element, const QgsReadWriteContext &context ) SIP_SKIP
     {
-      std::unique_ptr< QgsSymbol > tmpSymbol = QgsSymbolLayerUtils::loadSymbol( element, context );
-      const bool canCast = dynamic_cast<SymbolType *>( tmpSymbol.get() );
-
-      if ( canCast )
-      {
-        std::unique_ptr< SymbolType > castRes( static_cast<SymbolType *>( tmpSymbol.release() ) );
-        return castRes;
-      }
-      else
-      {
-        //could not cast
-        return nullptr;
-      }
+      return qgis::unique_ptr_dynamic_cast<SymbolType>( QgsSymbolLayerUtils::loadSymbol( element, context ) );
     }
 
     //! Reads and returns symbol layer from XML. Caller is responsible for deleting the returned object

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -1009,6 +1009,16 @@ void TestQgis::testDoubleGreaterThanOrNear()
 
 void TestQgis::testUniquePtrCast()
 {
+  // dynamic cast of nullptr
+  {
+    auto widget = std::unique_ptr<QWidget>( nullptr );
+    QVERIFY( !widget );
+
+    auto cb = qgis::unique_ptr_dynamic_cast<QCheckBox>( std::move( widget ) );
+    QVERIFY( !cb );
+    QVERIFY( !widget );
+  }
+
   // dynamic cast to proper type, original unique_ptr is then empty
   {
     auto widget = std::unique_ptr<QWidget>( new QCheckBox( "test" ) );

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -18,6 +18,7 @@
 
 #include <QApplication>
 #include <QCheckBox>
+#include <QLabel>
 #include <QObject>
 #include <QSignalSpy>
 #include <QString>
@@ -83,6 +84,7 @@ class TestQgis : public QgsTest
     void testDoubleLessThanOrNear();
     void testDoubleGreaterThanOrNear_data();
     void testDoubleGreaterThanOrNear();
+    void testUniquePtrCast();
 };
 
 void TestQgis::permissiveToDouble()
@@ -1004,6 +1006,42 @@ void TestQgis::testDoubleGreaterThanOrNear()
   else
     QCOMPARE( qgsDoubleGreaterThanOrNear( a, b, epsilon ), expected );
 }
+
+void TestQgis::testUniquePtrCast()
+{
+  // dynamic cast to proper type, original unique_ptr is then empty
+  {
+    auto widget = std::unique_ptr<QWidget>( new QCheckBox( "test" ) );
+    QVERIFY( widget );
+
+    auto cb = qgis::unique_ptr_dynamic_cast<QCheckBox>( std::move( widget ) );
+    QVERIFY( cb );
+    QVERIFY( !widget );
+  }
+
+  // dynamic cast to wrong type, original unique_ptr stays untouched, cast return nullptr
+  {
+    auto widget = std::unique_ptr<QWidget>( new QCheckBox( "test" ) );
+    QVERIFY( widget );
+
+    auto cb = qgis::unique_ptr_dynamic_cast<QLabel>( std::move( widget ) );
+    QVERIFY( !cb );
+    QVERIFY( widget );
+  }
+
+  // static cast to proper type, original unique_is then empty
+  {
+    auto widget = std::unique_ptr<QWidget>( new QCheckBox( "test" ) );
+    QVERIFY( widget );
+
+    auto cb = qgis::unique_ptr_static_cast<QCheckBox>( std::move( widget ) );
+    QVERIFY( cb );
+    QVERIFY( !widget );
+  }
+
+  // cannot test static_cast to wrong type or it would crash the test
+}
+
 
 QGSTEST_MAIN( TestQgis )
 #include "testqgis.moc"

--- a/tests/src/core/testqgscurve.cpp
+++ b/tests/src/core/testqgscurve.cpp
@@ -50,21 +50,22 @@ class TestQgsCurve : public QObject
 };
 
 
-#define TEST_C2L( circularString, tol, toltype, exp, prec )                                                                      \
-  {                                                                                                                              \
-    std::unique_ptr<QgsLineString> lineString( circularString->curveToLine( tol, toltype ) );                                    \
-    QVERIFY( lineString.get() );                                                                                                 \
-    QString wkt_out = lineString->asWkt( prec );                                                                                 \
-    QCOMPARE( wkt_out, QString( exp ) );                                                                                         \
-    /* Test reverse */                                                                                                           \
-    std::unique_ptr<QgsCircularString> reversed( circularString->reversed() );                                                   \
-    lineString.reset( reversed->curveToLine( tol, toltype ) );                                                                   \
-    wkt_out = lineString->asWkt( prec );                                                                                         \
-    lineString.reset( reversed->curveToLine( tol, toltype ) );                                                                   \
-    std::unique_ptr<QgsLineString> expgeom( dynamic_cast<QgsLineString *>( QgsGeometryFactory::geomFromWkt( exp ).release() ) ); \
-    expgeom.reset( expgeom->reversed() );                                                                                        \
-    QString exp_reversed = expgeom->asWkt( prec );                                                                               \
-    QCOMPARE( wkt_out, exp_reversed );                                                                                           \
+#define TEST_C2L( circularString, tol, toltype, exp, prec )                                                \
+  {                                                                                                        \
+    std::unique_ptr<QgsLineString> lineString( circularString->curveToLine( tol, toltype ) );              \
+    QVERIFY( lineString.get() );                                                                           \
+    QString wkt_out = lineString->asWkt( prec );                                                           \
+    QCOMPARE( wkt_out, QString( exp ) );                                                                   \
+    /* Test reverse */                                                                                     \
+    std::unique_ptr<QgsCircularString> reversed( circularString->reversed() );                             \
+    lineString.reset( reversed->curveToLine( tol, toltype ) );                                             \
+    wkt_out = lineString->asWkt( prec );                                                                   \
+    lineString.reset( reversed->curveToLine( tol, toltype ) );                                             \
+    auto expgeom = qgis::unique_ptr_dynamic_cast<QgsLineString>( QgsGeometryFactory::geomFromWkt( exp ) ); \
+    QVERIFY( expgeom );                                                                                    \
+    expgeom.reset( expgeom->reversed() );                                                                  \
+    QString exp_reversed = expgeom->asWkt( prec );                                                         \
+    QCOMPARE( wkt_out, exp_reversed );                                                                     \
   }
 
 void TestQgsCurve::curveToLine()
@@ -72,7 +73,7 @@ void TestQgsCurve::curveToLine()
   std::unique_ptr<QgsCircularString> circularString;
 
   /* input: 2 quadrants arc (180 degrees, PI radians) */
-  circularString.reset( dynamic_cast<QgsCircularString *>( QgsGeometryFactory::geomFromWkt( u"CIRCULARSTRING(0 0,100 100,200 0)"_s ).release() ) );
+  circularString = qgis::unique_ptr_dynamic_cast<QgsCircularString>( QgsGeometryFactory::geomFromWkt( u"CIRCULARSTRING(0 0,100 100,200 0)"_s ) );
   QVERIFY( circularString.get() );
 
   /* op: Maximum of 10 units of difference, symmetric */
@@ -91,7 +92,7 @@ void TestQgsCurve::curveToLine()
   TEST_C2L( circularString, 70 * M_PI / 180, QgsAbstractGeometry::MaximumAngle, "LineString (0 0, 50 86.6, 150 86.6, 200 0)", 2 );
 
   /* input: 2 arcs of 2 quadrants each (180 degrees + 180 degrees other direction) */
-  circularString.reset( dynamic_cast<QgsCircularString *>( QgsGeometryFactory::geomFromWkt( u"CIRCULARSTRING(0 0,100 100,200 0,300 -100,400 0)"_s ).release() ) );
+  circularString = qgis::unique_ptr_dynamic_cast<QgsCircularString>( QgsGeometryFactory::geomFromWkt( u"CIRCULARSTRING(0 0,100 100,200 0,300 -100,400 0)"_s ) );
   QVERIFY( circularString.get() );
 
   /* op: Maximum of M_PI / 3 degrees of angle */

--- a/tests/src/core/testqgsstyle.cpp
+++ b/tests/src/core/testqgsstyle.cpp
@@ -530,14 +530,14 @@ void TestStyle::testCreateMaterialSettings()
 
   QVERIFY( mStyle->materialSettingsNames().contains( u"test_settings"_s ) );
   QCOMPARE( mStyle->materialSettingsCount(), 1 );
-  std::unique_ptr<QgsGoochMaterialSettings> retrieved( dynamic_cast<QgsGoochMaterialSettings *>( mStyle->materialSettings( u"test_settings"_s ).release() ) );
+  auto retrieved = qgis::unique_ptr_dynamic_cast<QgsGoochMaterialSettings>( mStyle->materialSettings( u"test_settings"_s ) );
   QCOMPARE( retrieved->warm().name(), u"#0000ff"_s );
 
   settings.setWarm( QColor( 0, 255, 255 ) );
   QVERIFY( mStyle->addMaterialSettings( "test_settings", settings.clone(), true ) );
   QVERIFY( mStyle->materialSettingsNames().contains( u"test_settings"_s ) );
   QCOMPARE( mStyle->materialSettingsCount(), 1 );
-  retrieved.reset( dynamic_cast<QgsGoochMaterialSettings *>( mStyle->materialSettings( u"test_settings"_s ).release() ) );
+  retrieved = qgis::unique_ptr_dynamic_cast<QgsGoochMaterialSettings>( mStyle->materialSettings( u"test_settings"_s ) );
   QCOMPARE( retrieved->warm().name(), u"#00ffff"_s );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spyChanged.count(), 1 );
@@ -547,9 +547,9 @@ void TestStyle::testCreateMaterialSettings()
   QVERIFY( mStyle->addMaterialSettings( "test_format2", phong.clone(), true ) );
   QVERIFY( mStyle->materialSettingsNames().contains( u"test_format2"_s ) );
   QCOMPARE( mStyle->materialSettingsCount(), 2 );
-  retrieved.reset( dynamic_cast<QgsGoochMaterialSettings *>( mStyle->materialSettings( u"test_settings"_s ).release() ) );
+  retrieved = qgis::unique_ptr_dynamic_cast<QgsGoochMaterialSettings>( mStyle->materialSettings( u"test_settings"_s ) );
   QCOMPARE( retrieved->warm().name(), u"#00ffff"_s );
-  std::unique_ptr<QgsPhongMaterialSettings> retrieved2( dynamic_cast<QgsPhongMaterialSettings *>( mStyle->materialSettings( u"test_format2"_s ).release() ) );
+  auto retrieved2 = qgis::unique_ptr_dynamic_cast<QgsPhongMaterialSettings>( mStyle->materialSettings( u"test_format2"_s ) );
   QCOMPARE( retrieved2->ambient().name(), u"#009bff"_s );
   QCOMPARE( spy.count(), 2 );
   QCOMPARE( spyChanged.count(), 1 );
@@ -563,9 +563,9 @@ void TestStyle::testCreateMaterialSettings()
   QVERIFY( style2.materialSettingsNames().contains( u"test_settings"_s ) );
   QVERIFY( style2.materialSettingsNames().contains( u"test_format2"_s ) );
   QCOMPARE( style2.materialSettingsCount(), 2 );
-  retrieved.reset( dynamic_cast<QgsGoochMaterialSettings *>( style2.materialSettings( u"test_settings"_s ).release() ) );
+  retrieved = qgis::unique_ptr_dynamic_cast<QgsGoochMaterialSettings>( style2.materialSettings( u"test_settings"_s ) );
   QCOMPARE( retrieved->warm().name(), u"#00ffff"_s );
-  retrieved2.reset( dynamic_cast<QgsPhongMaterialSettings *>( style2.materialSettings( u"test_format2"_s ).release() ) );
+  retrieved2 = qgis::unique_ptr_dynamic_cast<QgsPhongMaterialSettings>( style2.materialSettings( u"test_format2"_s ) );
   QCOMPARE( retrieved2->ambient().name(), u"#009bff"_s );
 
   QCOMPARE( mStyle->allNames( QgsStyle::MaterialSettingsEntity ), QStringList() << u"test_format2"_s << u"test_settings"_s );


### PR DESCRIPTION
## Description

This PR is part of QEP [#417](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-417-remove-sip-factory.md)

Provides clean way of down casting a unique_ptr with safe checking in debug mode.

Dynamic cast will make the given unique_ptr parameter empty if cast succeeds, and will let it untouched if it fails.

I'm open to suggestion for method names, I hesitated with something more concise like qgis::static_cast but it's maybe better to be explicit.

## AI tool usage

None

**Funded by the QGIS Grant programme 2026**