### PR TITLE
mark algorithm source location for most of the native algorithms

### DIFF
--- a/src/analysis/processing/qgsalgorithmcellstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmcellstatistics.cpp
@@ -141,6 +141,8 @@ bool QgsCellStatisticsAlgorithmBase::prepareAlgorithm( const QVariantMap &parame
 
 QVariantMap QgsCellStatisticsAlgorithmBase::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
   // handle backwards compatibility parameter CREATE_OPTIONS
   const QString optionsString = parameterAsString( parameters, u"CREATE_OPTIONS"_s, context );

--- a/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
@@ -305,6 +305,8 @@ QgsFilterByLayerTypeAlgorithm *QgsFilterByLayerTypeAlgorithm::createInstance() c
 
 QVariantMap QgsFilterByLayerTypeAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QgsMapLayer *layer = parameterAsLayer( parameters, u"INPUT"_s, context );
   if ( !layer )
     throw QgsProcessingException( QObject::tr( "Could not load input layer" ) );

--- a/src/analysis/processing/qgsalgorithmraiseexception.cpp
+++ b/src/analysis/processing/qgsalgorithmraiseexception.cpp
@@ -169,6 +169,8 @@ void QgsRaiseWarningAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsRaiseWarningAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString expression = parameterAsExpression( parameters, u"CONDITION"_s, context );
   if ( !expression.isEmpty() )
   {
@@ -251,6 +253,8 @@ void QgsRaiseMessageAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsRaiseMessageAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString expression = parameterAsExpression( parameters, u"CONDITION"_s, context );
   if ( !expression.isEmpty() )
   {

--- a/src/analysis/processing/qgsalgorithmrandomextract.cpp
+++ b/src/analysis/processing/qgsalgorithmrandomextract.cpp
@@ -149,6 +149,8 @@ void QgsRandomExtractAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsRandomExtractAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsProcessingFeatureSource> source( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !source )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmrastersampling.cpp
+++ b/src/analysis/processing/qgsalgorithmrastersampling.cpp
@@ -92,6 +92,8 @@ bool QgsRasterSamplingAlgorithm::prepareAlgorithm( const QVariantMap &parameters
 
 QVariantMap QgsRasterSamplingAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsFeatureSource> source( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !source )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmrasterstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterstatistics.cpp
@@ -82,6 +82,8 @@ void QgsRasterStatisticsAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsRasterStatisticsAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsRasterLayer *layer = parameterAsRasterLayer( parameters, u"INPUT"_s, context );
 
   if ( !layer )

--- a/src/analysis/processing/qgsalgorithmrastersurfacevolume.cpp
+++ b/src/analysis/processing/qgsalgorithmrastersurfacevolume.cpp
@@ -129,6 +129,8 @@ bool QgsRasterSurfaceVolumeAlgorithm::prepareAlgorithm( const QVariantMap &param
 
 QVariantMap QgsRasterSurfaceVolumeAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString outputFile = parameterAsFileOutput( parameters, u"OUTPUT_HTML_FILE"_s, context );
   QString areaUnit = QgsUnitTypes::toAbbreviatedString( QgsUnitTypes::distanceToAreaUnit( mCrs.mapUnits() ) );
 

--- a/src/analysis/processing/qgsalgorithmrasterzonalstats.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterzonalstats.cpp
@@ -169,6 +169,8 @@ bool QgsRasterLayerZonalStatsAlgorithm::prepareAlgorithm( const QVariantMap &par
 
 QVariantMap QgsRasterLayerZonalStatsAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QString areaUnit = QgsUnitTypes::toAbbreviatedString( QgsUnitTypes::distanceToAreaUnit( mCrs.mapUnits() ) );
 
   QString tableDest;

--- a/src/analysis/processing/qgsalgorithmrectanglesovalsdiamonds.cpp
+++ b/src/analysis/processing/qgsalgorithmrectanglesovalsdiamonds.cpp
@@ -162,6 +162,8 @@ bool QgsRectanglesOvalsDiamondsAlgorithm::prepareAlgorithm( const QVariantMap &p
 
 QgsFeatureList QgsRectanglesOvalsDiamondsAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature outFeature = feature;
   if ( outFeature.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmrefactorfields.cpp
+++ b/src/analysis/processing/qgsalgorithmrefactorfields.cpp
@@ -162,6 +162,8 @@ bool QgsRefactorFieldsAlgorithm::prepareAlgorithm( const QVariantMap &parameters
 
 QgsFeatureList QgsRefactorFieldsAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   if ( !mExpressionsPrepared )
   {
     for ( auto it = mExpressions.begin(); it != mExpressions.end(); ++it )

--- a/src/analysis/processing/qgsalgorithmrelief.cpp
+++ b/src/analysis/processing/qgsalgorithmrelief.cpp
@@ -124,6 +124,8 @@ bool QgsReliefAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsPro
 
 QVariantMap QgsReliefAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const double zFactor = parameterAsDouble( parameters, u"Z_FACTOR"_s, context );
   const bool automaticColors = parameterAsBoolean( parameters, u"AUTO_COLORS"_s, context );
   const QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();

--- a/src/analysis/processing/qgsalgorithmremoveduplicatesbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatesbyattribute.cpp
@@ -83,6 +83,8 @@ QgsRemoveDuplicatesByAttributeAlgorithm *QgsRemoveDuplicatesByAttributeAlgorithm
 
 QVariantMap QgsRemoveDuplicatesByAttributeAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsProcessingFeatureSource> source( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !source )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmremoveduplicatevertices.cpp
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatevertices.cpp
@@ -120,6 +120,8 @@ bool QgsAlgorithmRemoveDuplicateVertices::prepareAlgorithm( const QVariantMap &p
 
 QgsFeatureList QgsAlgorithmRemoveDuplicateVertices::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmremoveholes.cpp
+++ b/src/analysis/processing/qgsalgorithmremoveholes.cpp
@@ -111,6 +111,8 @@ bool QgsRemoveHolesAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Q
 
 QgsFeatureList QgsRemoveHolesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmremovenullgeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmremovenullgeometry.cpp
@@ -83,6 +83,8 @@ QgsRemoveNullGeometryAlgorithm *QgsRemoveNullGeometryAlgorithm::createInstance()
 
 QVariantMap QgsRemoveNullGeometryAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsProcessingFeatureSource> source( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !source )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmremovepartsbyarea.cpp
+++ b/src/analysis/processing/qgsalgorithmremovepartsbyarea.cpp
@@ -116,6 +116,8 @@ bool QgsRemovePartsByAreaAlgorithm::prepareAlgorithm( const QVariantMap &paramet
 
 QgsFeatureList QgsRemovePartsByAreaAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmremovepartsbylength.cpp
+++ b/src/analysis/processing/qgsalgorithmremovepartsbylength.cpp
@@ -116,6 +116,8 @@ bool QgsRemovePartsByLengthAlgorithm::prepareAlgorithm( const QVariantMap &param
 
 QgsFeatureList QgsRemovePartsByLengthAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmrenamelayer.cpp
+++ b/src/analysis/processing/qgsalgorithmrenamelayer.cpp
@@ -77,6 +77,8 @@ void QgsRenameLayerAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsRenameLayerAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsMapLayer *layer = parameterAsLayer( parameters, u"INPUT"_s, context );
   const QString name = parameterAsString( parameters, u"NAME"_s, context );
 

--- a/src/analysis/processing/qgsalgorithmrepairshapefile.cpp
+++ b/src/analysis/processing/qgsalgorithmrepairshapefile.cpp
@@ -79,6 +79,8 @@ void QgsRepairShapefileAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsRepairShapefileAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString path = parameterAsFile( parameters, u"INPUT"_s, context );
 
   if ( !QFile::exists( path ) )

--- a/src/analysis/processing/qgsalgorithmrescaleraster.cpp
+++ b/src/analysis/processing/qgsalgorithmrescaleraster.cpp
@@ -148,6 +148,8 @@ bool QgsRescaleRasterAlgorithm::prepareAlgorithm( const QVariantMap &parameters,
 
 QVariantMap QgsRescaleRasterAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   feedback->pushInfo( QObject::tr( "Calculating raster minimum and maximum values…" ) );
   const QgsRasterBandStats stats = mInterface->bandStatistics( mBand, Qgis::RasterBandStatistic::Min | Qgis::RasterBandStatistic::Max, QgsRectangle(), 0 );
 

--- a/src/analysis/processing/qgsalgorithmreverselinedirection.cpp
+++ b/src/analysis/processing/qgsalgorithmreverselinedirection.cpp
@@ -89,6 +89,8 @@ Qgis::ProcessingFeatureSourceFlags QgsReverseLineDirectionAlgorithm ::sourceFlag
 
 QgsFeatureList QgsReverseLineDirectionAlgorithm ::processFeature( const QgsFeature &f, QgsProcessingContext &, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature feature = f;
   if ( feature.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmrotate.cpp
+++ b/src/analysis/processing/qgsalgorithmrotate.cpp
@@ -101,6 +101,8 @@ bool QgsRotateFeaturesAlgorithm::prepareAlgorithm( const QVariantMap &parameters
 
 QgsFeatureList QgsRotateFeaturesAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   if ( mUseAnchor && !mTransformedAnchor )
   {
     mTransformedAnchor = true;

--- a/src/analysis/processing/qgsalgorithmroundness.cpp
+++ b/src/analysis/processing/qgsalgorithmroundness.cpp
@@ -93,6 +93,8 @@ QgsFields QgsRoundnessAlgorithm::outputFields( const QgsFields &inputFields ) co
 
 QgsFeatureList QgsRoundnessAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   QgsAttributes attributes = f.attributes();
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmroundrastervalues.cpp
+++ b/src/analysis/processing/qgsalgorithmroundrastervalues.cpp
@@ -151,6 +151,8 @@ bool QgsRoundRasterValuesAlgorithm::prepareAlgorithm( const QVariantMap &paramet
 
 QVariantMap QgsRoundRasterValuesAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   //prepare output dataset
   QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
   // handle backwards compatibility parameter CREATE_OPTIONS

--- a/src/analysis/processing/qgsalgorithmruggedness.cpp
+++ b/src/analysis/processing/qgsalgorithmruggedness.cpp
@@ -118,6 +118,8 @@ bool QgsRuggednessAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qg
 
 QVariantMap QgsRuggednessAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const double zFactor = parameterAsDouble( parameters, u"Z_FACTOR"_s, context );
   const QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
   const double outputNodata = parameterAsDouble( parameters, u"NODATA"_s, context );

--- a/src/analysis/processing/qgsalgorithmsavefeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmsavefeatures.cpp
@@ -106,6 +106,8 @@ void QgsSaveFeaturesAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsSaveFeaturesAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsProcessingFeatureSource> source( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !source )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmsavelog.cpp
+++ b/src/analysis/processing/qgsalgorithmsavelog.cpp
@@ -80,6 +80,8 @@ void QgsSaveLogToFileAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsSaveLogToFileAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString file = parameterAsFile( parameters, u"OUTPUT"_s, context );
   const bool useHtml = parameterAsBool( parameters, u"USE_HTML"_s, context );
   if ( !file.isEmpty() )

--- a/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
@@ -86,6 +86,8 @@ bool QgsSaveSelectedFeatures::prepareAlgorithm( const QVariantMap &parameters, Q
 
 QVariantMap QgsSaveSelectedFeatures::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsVectorLayer *selectLayer = parameterAsVectorLayer( parameters, u"INPUT"_s, context );
   if ( !selectLayer )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmsegmentize.cpp
+++ b/src/analysis/processing/qgsalgorithmsegmentize.cpp
@@ -108,6 +108,8 @@ bool QgsSegmentizeByMaximumDistanceAlgorithm::prepareAlgorithm( const QVariantMa
 
 QgsFeatureList QgsSegmentizeByMaximumDistanceAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {
@@ -208,6 +210,8 @@ bool QgsSegmentizeByMaximumAngleAlgorithm::prepareAlgorithm( const QVariantMap &
 
 QgsFeatureList QgsSegmentizeByMaximumAngleAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmselectbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmselectbyattribute.cpp
@@ -116,6 +116,8 @@ void QgsSelectByAttributeAlgorithm::initAlgorithm( const QVariantMap & )
 
 bool QgsSelectByAttributeAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsVectorLayer *layer = parameterAsVectorLayer( parameters, u"INPUT"_s, context );
   if ( !layer )
   {

--- a/src/analysis/processing/qgsalgorithmselectbyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmselectbyexpression.cpp
@@ -104,6 +104,8 @@ void QgsSelectByExpressionAlgorithm::initAlgorithm( const QVariantMap & )
 
 bool QgsSelectByExpressionAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsVectorLayer *layer = parameterAsVectorLayer( parameters, u"INPUT"_s, context );
   if ( !layer )
   {

--- a/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
+++ b/src/analysis/processing/qgsalgorithmserviceareafromlayer.cpp
@@ -111,6 +111,8 @@ void QgsServiceAreaFromLayerAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsServiceAreaFromLayerAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   loadCommonParams( parameters, context, feedback );
 
   std::unique_ptr<QgsProcessingFeatureSource> startPoints( parameterAsSource( parameters, u"START_POINTS"_s, context ) );

--- a/src/analysis/processing/qgsalgorithmserviceareafrompoint.cpp
+++ b/src/analysis/processing/qgsalgorithmserviceareafrompoint.cpp
@@ -103,6 +103,8 @@ void QgsServiceAreaFromPointAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsServiceAreaFromPointAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   loadCommonParams( parameters, context, feedback );
 
   const QgsPointXY startPoint = parameterAsPoint( parameters, u"START_POINT"_s, context, mNetwork->sourceCrs() );

--- a/src/analysis/processing/qgsalgorithmsetlayerencoding.cpp
+++ b/src/analysis/processing/qgsalgorithmsetlayerencoding.cpp
@@ -80,6 +80,8 @@ void QgsSetLayerEncodingAlgorithm::initAlgorithm( const QVariantMap & )
 
 bool QgsSetLayerEncodingAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsVectorLayer *layer = parameterAsVectorLayer( parameters, u"INPUT"_s, context );
 
   if ( !layer )

--- a/src/analysis/processing/qgsalgorithmsetmvalue.cpp
+++ b/src/analysis/processing/qgsalgorithmsetmvalue.cpp
@@ -116,6 +116,8 @@ bool QgsSetMValueAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
 
 QgsFeatureList QgsSetMValueAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
 
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmsetvariable.cpp
+++ b/src/analysis/processing/qgsalgorithmsetvariable.cpp
@@ -72,6 +72,8 @@ QgsSetProjectVariableAlgorithm *QgsSetProjectVariableAlgorithm::createInstance()
 
 bool QgsSetProjectVariableAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   // this is all nice and quick, we can (and should) do it in the main thread without issue
   const QString name = parameterAsString( parameters, u"NAME"_s, context );
   const QString value = parameterAsString( parameters, u"VALUE"_s, context );

--- a/src/analysis/processing/qgsalgorithmsetzvalue.cpp
+++ b/src/analysis/processing/qgsalgorithmsetzvalue.cpp
@@ -116,6 +116,8 @@ bool QgsSetZValueAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
 
 QgsFeatureList QgsSetZValueAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
 
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmshortestline.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestline.cpp
@@ -114,6 +114,8 @@ bool QgsShortestLineAlgorithm::prepareAlgorithm( const QVariantMap &parameters, 
 
 QVariantMap QgsShortestLineAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   if ( mKNeighbors > mDestination->featureCount() )
     mKNeighbors = mDestination->featureCount();
 

--- a/src/analysis/processing/qgsalgorithmshortestpathlayertopoint.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestpathlayertopoint.cpp
@@ -89,6 +89,8 @@ void QgsShortestPathLayerToPointAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsShortestPathLayerToPointAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   loadCommonParams( parameters, context, feedback );
 
   const QgsPointXY endPoint = parameterAsPoint( parameters, u"END_POINT"_s, context, mNetwork->sourceCrs() );

--- a/src/analysis/processing/qgsalgorithmshortestpathpointtolayer.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestpathpointtolayer.cpp
@@ -94,6 +94,8 @@ void QgsShortestPathPointToLayerAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsShortestPathPointToLayerAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   loadCommonParams( parameters, context, feedback );
 
   const QgsPointXY startPoint = parameterAsPoint( parameters, u"START_POINT"_s, context, mNetwork->sourceCrs() );

--- a/src/analysis/processing/qgsalgorithmshortestpathpointtopoint.cpp
+++ b/src/analysis/processing/qgsalgorithmshortestpathpointtopoint.cpp
@@ -76,6 +76,8 @@ void QgsShortestPathPointToPointAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsShortestPathPointToPointAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   loadCommonParams( parameters, context, feedback );
 
   QgsFields fields;

--- a/src/analysis/processing/qgsalgorithmshpencodinginfo.cpp
+++ b/src/analysis/processing/qgsalgorithmshpencodinginfo.cpp
@@ -82,6 +82,8 @@ void QgsShapefileEncodingInfoAlgorithm::initAlgorithm( const QVariantMap & )
 
 bool QgsShapefileEncodingInfoAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString path = parameterAsFile( parameters, u"INPUT"_s, context );
 
   mCpgEncoding = QgsOgrUtils::readShapefileEncodingFromCpg( path );

--- a/src/analysis/processing/qgsalgorithmsimplify.cpp
+++ b/src/analysis/processing/qgsalgorithmsimplify.cpp
@@ -113,6 +113,8 @@ bool QgsSimplifyAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsP
 
 QgsFeatureList QgsSimplifyAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmsinglesidedbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmsinglesidedbuffer.cpp
@@ -126,6 +126,8 @@ bool QgsSingleSidedBufferAlgorithm::prepareAlgorithm( const QVariantMap &paramet
 
 QgsFeatureList QgsSingleSidedBufferAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
 
   if ( f.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmslope.cpp
+++ b/src/analysis/processing/qgsalgorithmslope.cpp
@@ -105,6 +105,8 @@ bool QgsSlopeAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProc
 
 QVariantMap QgsSlopeAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const double zFactor = parameterAsDouble( parameters, u"Z_FACTOR"_s, context );
   const QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
   const double outputNodata = parameterAsDouble( parameters, u"NODATA"_s, context );

--- a/src/analysis/processing/qgsalgorithmsmooth.cpp
+++ b/src/analysis/processing/qgsalgorithmsmooth.cpp
@@ -131,6 +131,8 @@ bool QgsSmoothAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsPro
 
 QgsFeatureList QgsSmoothAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmsnapgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmsnapgeometries.cpp
@@ -133,6 +133,8 @@ QgsSnapGeometriesAlgorithm *QgsSnapGeometriesAlgorithm::createInstance() const
 
 QVariantMap QgsSnapGeometriesAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsProcessingFeatureSource> source( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !source )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
@@ -133,6 +133,8 @@ bool QgsSnapToGridAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qg
 
 QgsFeatureList QgsSnapToGridAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmstringconcatenation.cpp
+++ b/src/analysis/processing/qgsalgorithmstringconcatenation.cpp
@@ -77,6 +77,8 @@ void QgsStringConcatenationAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsStringConcatenationAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString input_1 = parameterAsString( parameters, u"INPUT_1"_s, context );
   const QString input_2 = parameterAsString( parameters, u"INPUT_2"_s, context );
 

--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -92,6 +92,8 @@ Qgis::WkbType QgsSubdivideAlgorithm::outputWkbType( Qgis::WkbType inputWkbType )
 
 QgsFeatureList QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature feature = f;
   if ( feature.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmsumlinelength.cpp
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.cpp
@@ -197,6 +197,8 @@ bool QgsSumLineLengthAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) c
 
 QgsFeatureList QgsSumLineLengthAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature outputFeature = feature;
   if ( !feature.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmswapxy.cpp
+++ b/src/analysis/processing/qgsalgorithmswapxy.cpp
@@ -93,6 +93,8 @@ Qgis::ProcessingFeatureSourceFlags QgsSwapXYAlgorithm::sourceFlags() const
 
 QgsFeatureList QgsSwapXYAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeatureList list;
   QgsFeature feature = f;
   if ( feature.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmsymmetricaldifference.cpp
+++ b/src/analysis/processing/qgsalgorithmsymmetricaldifference.cpp
@@ -91,6 +91,8 @@ void QgsSymmetricalDifferenceAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsSymmetricalDifferenceAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsFeatureSource> sourceA( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !sourceA )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmtininterpolation.cpp
+++ b/src/analysis/processing/qgsalgorithmtininterpolation.cpp
@@ -128,6 +128,8 @@ void QgsTinInterpolationAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsTinInterpolationAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString interpolationData = parameterAsString( parameters, u"INTERPOLATION_DATA"_s, context );
   const int method = parameterAsEnum( parameters, u"METHOD"_s, context );
   const QgsRectangle boundingBox = parameterAsExtent( parameters, u"EXTENT"_s, context );

--- a/src/analysis/processing/qgsalgorithmtinmeshcreation.cpp
+++ b/src/analysis/processing/qgsalgorithmtinmeshcreation.cpp
@@ -147,6 +147,8 @@ bool QgsTinMeshCreationAlgorithm::prepareAlgorithm( const QVariantMap &parameter
 
 QVariantMap QgsTinMeshCreationAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsMeshTriangulation triangulation;
   QgsCoordinateReferenceSystem destinationCrs = parameterAsCrs( parameters, u"CRS_OUTPUT"_s, context );
   if ( !destinationCrs.isValid() && context.project() )

--- a/src/analysis/processing/qgsalgorithmtotalcurvature.cpp
+++ b/src/analysis/processing/qgsalgorithmtotalcurvature.cpp
@@ -109,6 +109,8 @@ bool QgsTotalCurvatureAlgorithm::prepareAlgorithm( const QVariantMap &parameters
 
 QVariantMap QgsTotalCurvatureAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const double zFactor = parameterAsDouble( parameters, u"Z_FACTOR"_s, context );
   const QString creationOptions = parameterAsString( parameters, u"CREATION_OPTIONS"_s, context ).trimmed();
   const double outputNodata = parameterAsDouble( parameters, u"NODATA"_s, context );

--- a/src/analysis/processing/qgsalgorithmtransectbase.cpp
+++ b/src/analysis/processing/qgsalgorithmtransectbase.cpp
@@ -84,6 +84,8 @@ void QgsTransectAlgorithmBase::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsTransectAlgorithmBase::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   mOrientation = static_cast<QgsTransectAlgorithmBase::Side>( parameterAsInt( parameters, u"SIDE"_s, context ) );
   mAngle = fabs( parameterAsDouble( parameters, u"ANGLE"_s, context ) );
   mDynamicAngle = QgsProcessingParameters::isDynamic( parameters, u"ANGLE"_s );

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -122,6 +122,8 @@ bool QgsTransformAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
 
 QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature feature = f;
   if ( !mCreatedTransform )
   {

--- a/src/analysis/processing/qgsalgorithmtranslate.cpp
+++ b/src/analysis/processing/qgsalgorithmtranslate.cpp
@@ -126,6 +126,8 @@ bool QgsTranslateAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Qgs
 
 QgsFeatureList QgsTranslateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {

--- a/src/analysis/processing/qgsalgorithmtruncatetable.cpp
+++ b/src/analysis/processing/qgsalgorithmtruncatetable.cpp
@@ -80,6 +80,8 @@ void QgsTruncateTableAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsTruncateTableAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsVectorLayer *layer = parameterAsVectorLayer( parameters, u"INPUT"_s, context );
 
   if ( !layer )

--- a/src/analysis/processing/qgsalgorithmunion.cpp
+++ b/src/analysis/processing/qgsalgorithmunion.cpp
@@ -101,6 +101,8 @@ void QgsUnionAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsUnionAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsFeatureSource> sourceA( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !sourceA )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmuniquevalues.cpp
+++ b/src/analysis/processing/qgsalgorithmuniquevalues.cpp
@@ -75,6 +75,8 @@ void QgsUniqueValuesAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsUniqueValuesAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsProcessingFeatureSource> source( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !source )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmurlopener.cpp
+++ b/src/analysis/processing/qgsalgorithmurlopener.cpp
@@ -78,6 +78,8 @@ void QgsOpenUrlAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsOpenUrlAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString url = parameterAsString( parameters, u"URL"_s, context );
   if ( url.isEmpty() )
     throw QgsProcessingException( tr( "No URL or file path specified" ) );

--- a/src/analysis/processing/qgsalgorithmvalidatenetwork.cpp
+++ b/src/analysis/processing/qgsalgorithmvalidatenetwork.cpp
@@ -185,6 +185,8 @@ void QgsValidateNetworkAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsValidateNetworkAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsFeatureSource> networkSource( parameterAsSource( parameters, u"INPUT"_s, context ) );
   if ( !networkSource )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/qgsalgorithmvirtualrastercalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmvirtualrastercalculator.cpp
@@ -90,6 +90,8 @@ void QgsVirtualRasterCalculatorAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsVirtualRasterCalculatorAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   const QList<QgsMapLayer *> layers = parameterAsLayerList( parameters, u"LAYERS"_s, context );
@@ -227,6 +229,8 @@ QgsVirtualRasterCalculatorModelerAlgorithm *QgsVirtualRasterCalculatorModelerAlg
 
 QVariantMap QgsVirtualRasterCalculatorModelerAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   const QList<QgsMapLayer *> layers = parameterAsLayerList( parameters, u"INPUT"_s, context );

--- a/src/analysis/processing/qgsalgorithmvoronoipolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmvoronoipolygons.cpp
@@ -96,6 +96,8 @@ bool QgsVoronoiPolygonsAlgorithm::prepareAlgorithm( const QVariantMap &parameter
 
 QVariantMap QgsVoronoiPolygonsAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QString dest;
   if ( mCopyAttributes )
   {

--- a/src/analysis/processing/qgsalgorithmwedgebuffers.cpp
+++ b/src/analysis/processing/qgsalgorithmwedgebuffers.cpp
@@ -161,6 +161,8 @@ bool QgsWedgeBuffersAlgorithm::prepareAlgorithm( const QVariantMap &parameters, 
 
 QgsFeatureList QgsWedgeBuffersAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsFeature f = feature;
   if ( f.hasGeometry() && QgsWkbTypes::geometryType( f.geometry().wkbType() ) == Qgis::GeometryType::Point )
   {

--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -319,6 +319,8 @@ void QgsXyzTilesDirectoryAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsXyzTilesDirectoryAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const bool tms = parameterAsBoolean( parameters, u"TMS_CONVENTION"_s, context );
   const QString title = parameterAsString( parameters, u"HTML_TITLE"_s, context );
   const QString attribution = parameterAsString( parameters, u"HTML_ATTRIBUTION"_s, context );
@@ -511,6 +513,8 @@ void QgsXyzTilesMbtilesAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsXyzTilesMbtilesAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   const QString outputFile = parameterAsString( parameters, u"OUTPUT_FILE"_s, context );
 
   mMbtilesWriter = std::make_unique<QgsMbTiles>( outputFile );

--- a/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
@@ -121,6 +121,8 @@ bool QgsZonalHistogramAlgorithm::prepareAlgorithm( const QVariantMap &parameters
 
 QVariantMap QgsZonalHistogramAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   std::unique_ptr<QgsFeatureSource> zones( parameterAsSource( parameters, u"INPUT_VECTOR"_s, context ) );
   if ( !zones )
     throw QgsProcessingException( invalidSourceError( parameters, u"INPUT_VECTOR"_s ) );

--- a/src/analysis/processing/qgsalgorithmzonalminmaxpoint.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalminmaxpoint.cpp
@@ -149,6 +149,8 @@ bool QgsZonalMinimumMaximumPointAlgorithm::prepareAlgorithm( const QVariantMap &
 
 QgsFeatureList QgsZonalMinimumMaximumPointAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   if ( !mCreatedTransform )
   {
     mCreatedTransform = true;

--- a/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatistics.cpp
@@ -127,6 +127,8 @@ bool QgsZonalStatisticsAlgorithm::prepareAlgorithm( const QVariantMap &parameter
 
 QVariantMap QgsZonalStatisticsAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsVectorLayer *layer = parameterAsVectorLayer( parameters, u"INPUT_VECTOR"_s, context );
   if ( !layer )
     throw QgsProcessingException( QObject::tr( "Invalid zones layer" ) );

--- a/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalstatisticsfeaturebased.cpp
@@ -159,6 +159,8 @@ bool QgsZonalStatisticsFeatureBasedAlgorithm::prepareAlgorithm( const QVariantMa
 
 QgsFeatureList QgsZonalStatisticsFeatureBasedAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   if ( !mCreatedTransform )
   {
     mCreatedTransform = true;

--- a/src/analysis/processing/qgsprojectstylealgorithms.cpp
+++ b/src/analysis/processing/qgsprojectstylealgorithms.cpp
@@ -201,6 +201,8 @@ bool QgsStyleFromProjectAlgorithm::prepareAlgorithm( const QVariantMap &paramete
 
 QVariantMap QgsStyleFromProjectAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   if ( !mProjectPath.isEmpty() )
   {
     // load project from path


### PR DESCRIPTION
## Description

Mark algorithm source locations for the majority of unmarked native algorithms. Only few algorithms are left without the macro:

- exportmeshvertices
- exportmeshfaces
- extractzvalues
- extractmvalues
- highestpositioninrasterstack
- lowestpositioninrasterstack
- reclassifybytable
- reclassifybylayer
- transect
- transectfixeddistance
- pixelstopoints
- pixelstopolygons
- writevectortiles_mbtiles
- writevectortiles_xyz

All of them use an approach where base class algorithm defines `processAlgorithm()` method and subclasses only implement a small helper. Not sure if we should point to the helper or to the `processAlgorithm()` in this case. Anyway, macro seems does not handle the case with subclasses.

Also I have no strong opinion on how to mark `renametablefield` algorithm. It is a feature-based algorithm and main logic is in the `outputFields()` method but actual processing happens in the `processFeature()`.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.