### PR TITLE
mark source location in PDAL algorithms

### DIFF
--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -862,7 +862,7 @@ class GenericAlgorithmsTest(QgisTestCase):
 
         # enable when all native algorithms have QGS_MARK_ALGORITHM_SOURCE
         if False:
-            if alg.provider().id() in ("native",):
+            if alg.provider().id() in ("native", "pdal"):
                 self.assertTrue(
                     alg.implementationSourceUri(),
                     f"Algorithm {alg.id()} has no QGS_MARK_ALGORITHM_SOURCE macro inserted!",

--- a/src/analysis/processing/pdal/qgsalgorithmpdalassignprojection.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalassignprojection.cpp
@@ -78,6 +78,8 @@ void QgsPdalAssignProjectionAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalAssignProjectionAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalboundary.cpp
@@ -79,6 +79,8 @@ void QgsPdalBoundaryAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalBoundaryAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalbuildvpc.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalbuildvpc.cpp
@@ -102,6 +102,8 @@ void QgsPdalBuildVpcAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalBuildVpcAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   const QList<QgsMapLayer *> layers = parameterAsLayerList( parameters, u"LAYERS"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalclassifyground.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalclassifyground.cpp
@@ -104,6 +104,8 @@ void QgsPdalClassifyGroundAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalClassifyGroundAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalclip.cpp
@@ -80,6 +80,8 @@ void QgsPdalClipAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalClipAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( !layer )
     throw QgsProcessingException( invalidPointCloudError( parameters, u"INPUT"_s ) );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalcompare.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalcompare.cpp
@@ -163,6 +163,8 @@ bool QgsPdalCompareAlgorithm::checkParameterValues( const QVariantMap &parameter
 
 QStringList QgsPdalCompareAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
 // raise exception if PDAL version is older than 2.10 - can be removed when PDAL 2.10 is minimum requirement
 #ifdef HAVE_PDAL_QGIS
 #if PDAL_VERSION_MAJOR_INT < 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT < 10 )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalconvertformat.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalconvertformat.cpp
@@ -77,6 +77,8 @@ void QgsPdalConvertFormatAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalConvertFormatAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalcreatecopc.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalcreatecopc.cpp
@@ -95,6 +95,8 @@ bool QgsPdalCreateCopcAlgorithm::prepareAlgorithm( const QVariantMap &parameters
 
 QVariantMap QgsPdalCreateCopcAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
 #if defined( HAVE_PDAL_QGIS ) && QT_CONFIG( process )
   const QList<QgsMapLayer *> layers = parameterAsLayerList( parameters, u"LAYERS"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( layers.empty() )

--- a/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaldensity.cpp
@@ -88,6 +88,8 @@ void QgsPdalDensityAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalDensityAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportraster.cpp
@@ -89,6 +89,8 @@ void QgsPdalExportRasterAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalExportRasterAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -94,6 +94,8 @@ void QgsPdalExportRasterTinAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportvector.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportvector.cpp
@@ -76,6 +76,8 @@ void QgsPdalExportVectorAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalExportVectorAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilter.cpp
@@ -80,6 +80,8 @@ void QgsPdalFilterAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalFilterAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilternoiseradius.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilternoiseradius.cpp
@@ -83,6 +83,8 @@ void QgsPdalFilterNoiseRadiusAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalFilterNoiseRadiusAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilternoisestatistical.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilternoisestatistical.cpp
@@ -86,6 +86,8 @@ void QgsPdalFilterNoiseStatisticalAlgorithm::initAlgorithm( const QVariantMap & 
 
 QStringList QgsPdalFilterNoiseStatisticalAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundnearestneighbour.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundnearestneighbour.cpp
@@ -86,6 +86,8 @@ void QgsPdalHeightAboveGroundNearestNeighbourAlgorithm::initAlgorithm( const QVa
 
 QStringList QgsPdalHeightAboveGroundNearestNeighbourAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundtriangulation.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundtriangulation.cpp
@@ -86,6 +86,8 @@ void QgsPdalHeightAboveGroundTriangulationAlgorithm::initAlgorithm( const QVaria
 
 QStringList QgsPdalHeightAboveGroundTriangulationAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalinformation.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalinformation.cpp
@@ -74,6 +74,8 @@ void QgsPdalInformationAlgorithm::initAlgorithm( const QVariantMap & )
 
 QVariantMap QgsPdalInformationAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
 #if QT_CONFIG( process )
   const QStringList processArgs = createArgumentLists( parameters, context, feedback );
   const QString wrenchPath = wrenchExecutableBinary();

--- a/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalmerge.cpp
@@ -75,6 +75,8 @@ void QgsPdalMergeAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalMergeAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   const QList<QgsMapLayer *> layers = parameterAsLayerList( parameters, u"LAYERS"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
@@ -82,6 +82,8 @@ void QgsPdalReprojectAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalReprojectAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalthinbydecimate.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalthinbydecimate.cpp
@@ -79,6 +79,8 @@ void QgsPdalThinByDecimateAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalThinByDecimateAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalthinbyradius.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalthinbyradius.cpp
@@ -79,6 +79,8 @@ void QgsPdalThinByRadiusAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalThinByRadiusAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdaltile.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaltile.cpp
@@ -83,6 +83,8 @@ void QgsPdalTileAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalTileAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   const QList<QgsMapLayer *> layers = parameterAsLayerList( parameters, u"LAYERS"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );

--- a/src/analysis/processing/pdal/qgsalgorithmpdaltransform.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdaltransform.cpp
@@ -96,6 +96,8 @@ void QgsPdalTransformAlgorithm::initAlgorithm( const QVariantMap & )
 
 QStringList QgsPdalTransformAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+  QGS_MARK_ALGORITHM_SOURCE
+
   Q_UNUSED( feedback );
 
   QgsPointCloudLayer *layer = parameterAsPointCloudLayer( parameters, u"INPUT"_s, context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );


### PR DESCRIPTION
## Description

Mark source code location in PDAL algorithms. We point to the `createArgumentLists()` method as this is where `wrench` command line is assembled.

Also include PDAL provider in the (currently disabled) test.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
