### PR TITLE
Remove QgsProject::instance() references from QgsMapLayer  (QEP 423) 

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1638,7 +1638,19 @@ QString QgsMapLayer::loadNamedProperty( const QString &uri, QgsMapLayer::Propert
   }
   else
   {
-    const QFileInfo project( QgsProject::instance()->fileName() ); // skip-keyword-check
+    QString projectFileName;
+    if ( QgsProject *lProject = project() )
+    {
+      projectFileName = lProject->fileName();
+    }
+    // TODO QGIS 5.0 -- Remove the else branch with fallback to current QGIS project, the code will work but if the MapLayer is not associated with project it will not provide result
+    else
+    {
+      QgsDebugError( "QgsMapLayer is not associated with QGIS project. Using current QGIS project as fallback. This will stop working in QGIS 5.0." );
+      projectFileName = QgsProject::instance()->fileName(); // skip-keyword-check
+    }
+
+    const QFileInfo project( projectFileName );
     QgsDebugMsgLevel( u"project fileName: %1"_s.arg( project.absoluteFilePath() ), 4 );
 
     QString xml;


### PR DESCRIPTION
## Description

In `QgsMapLayer::loadNamedProperty()`  there was a call to `QgsProject::instance()` instead of using `project()` to get project associated with the `QgsMapLayer`. 

This could also be considered a bug as property from project that is not associated with layer could be obtained trough the layer. 

This fix uses filename of project if there is a project associated with the MapLayer, otherwise the filename will be empty string. That sets `QFileInfo project` empty and subsequent usages checks guarded by `project.exists()` to be skipped.  

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 
