### PR TITLE
[core/symbology] methods should return a unique_ptr

### DIFF
--- a/cmake/SIPMacros.cmake
+++ b/cmake/SIPMacros.cmake
@@ -29,7 +29,7 @@
 # SIP_BUILD_EXTRA_OPTIONS - Extra command line options which should be passed on to
 #     sip-build.
 
-SET(SIP_CONCAT_PARTS 24)
+SET(SIP_CONCAT_PARTS 25)
 SET(SIP_DISABLE_FEATURES)
 SET(SIP_BUILD_EXTRA_OPTIONS)
 

--- a/python/PyQt6/core/auto_generated/qgscolorrampimpl.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscolorrampimpl.sip.in
@@ -119,7 +119,7 @@ Constructor for QgsGradientColorRamp
 :param stops: optional list of additional color stops
 %End
 
-    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsColorRamp> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new :py:class:`QgsColorRamp` from a map of properties
 %End
@@ -783,7 +783,7 @@ Constructor for QgsCptCityColorRamp
 :param doLoadFile: load cpt-city ramp from file
 %End
 
-    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsColorRamp> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates the symbol layer
 %End

--- a/python/PyQt6/core/auto_generated/symbology/qgs25drenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgs25drenderer.sip.in
@@ -20,7 +20,7 @@ A vector renderer which represents 3D features in an isometric view.
   public:
     Qgs25DRenderer();
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Create a new 2.5D renderer from XML
 
@@ -98,7 +98,7 @@ Gets the shadow's spread distance in map units
 Set the shadow's spread distance in map units
 %End
 
-    static Qgs25DRenderer *convertFromRenderer( QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<Qgs25DRenderer> convertFromRenderer( QgsFeatureRenderer *renderer );
 %Docstring
 Try to convert from an existing renderer. If it is not of the same type
 we assume that the internals are not compatible and create a new default

--- a/python/PyQt6/core/auto_generated/symbology/qgsarrowsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsarrowsymbollayer.sip.in
@@ -27,7 +27,7 @@ Simple constructor
 %End
     ~QgsArrowSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Create a new QgsArrowSymbolLayer
 

--- a/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -360,7 +360,7 @@ renderer categories.
 .. seealso:: :py:func:`classAttribute`
 %End
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a categorized renderer from an XML ``element``.
 %End
@@ -438,7 +438,7 @@ Update the color ramp used and all symbols colors.
 
     virtual QString legendClassificationAttribute() const;
 
-    static QgsCategorizedSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer = 0 ) /Factory/;
+    static std::unique_ptr<QgsCategorizedSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer = 0 );
 %Docstring
 Creates a new QgsCategorizedSymbolRenderer from an existing
 ``renderer``.

--- a/python/PyQt6/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsellipsesymbollayer.sip.in
@@ -59,11 +59,11 @@ Returns ``True`` if a ``shape`` has a fill.
     QgsEllipseSymbolLayer();
     ~QgsEllipseSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates the symbol layer
 %End
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     virtual void renderPoint( QPointF point, QgsSymbolRenderContext &context );
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsembeddedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsembeddedsymbolrenderer.sip.in
@@ -76,7 +76,7 @@ Ownership of ``symbol`` is transferred to the renderer.
 .. seealso:: :py:func:`defaultSymbol`
 %End
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a new embedded symbol renderer from an XML ``element``, using
 the supplied read/write ``context``.
@@ -84,7 +84,7 @@ the supplied read/write ``context``.
 The caller takes ownership of the returned renderer.
 %End
 
-    static QgsEmbeddedSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsEmbeddedSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 %Docstring
 Creates a QgsEmbeddedSymbolRenderer from an existing ``renderer``.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -34,7 +34,7 @@ Renders polygons using a single fill and stroke color.
     ~QgsSimpleFillSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsSimpleFillSymbolLayer using the specified
 ``properties`` map containing symbol properties (see
@@ -42,7 +42,7 @@ Creates a new QgsSimpleFillSymbolLayer using the specified
 
 Caller takes ownership of the returned symbol layer.
 %End
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
 
     virtual QString layerType() const;
@@ -224,7 +224,7 @@ Constructor for QgsGradientFillSymbolLayer.
     ~QgsGradientFillSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsGradientFillSymbolLayer using the specified
 ``properties`` map containing symbol properties (see
@@ -523,7 +523,7 @@ Constructor for QgsShapeburstFillSymbolLayer.
 
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsShapeburstFillSymbolLayer using the specified
 ``properties`` map containing symbol properties (see
@@ -961,13 +961,13 @@ specified ``imageFilePath``.
 
     ~QgsRasterFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsRasterFillSymbolLayer from a ``properties`` map. The
 caller takes ownership of the returned object.
 %End
 
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 %Docstring
 Creates a new QgsRasterFillSymbolLayer from a SLD ``element``. The
 caller takes ownership of the returned object.
@@ -1358,13 +1358,13 @@ data.
 
     ~QgsSVGFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsSVGFillSymbolLayer from a ``properties`` map. The
 caller takes ownership of the returned object.
 %End
 
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 %Docstring
 Creates a new QgsSVGFillSymbolLayer from a SLD ``element``. The caller
 takes ownership of the returned object.
@@ -1664,13 +1664,13 @@ A symbol fill consisting of repeated parallel lines.
     QgsLinePatternFillSymbolLayer();
     ~QgsLinePatternFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsLinePatternFillSymbolLayer from a ``properties`` map.
 The caller takes ownership of the returned object.
 %End
 
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 %Docstring
 Creates a new QgsLinePatternFillSymbolLayer from a SLD ``element``. The
 caller takes ownership of the returned object.
@@ -1967,7 +1967,7 @@ symbols.
     QgsPointPatternFillSymbolLayer();
     ~QgsPointPatternFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsPointPatternFillSymbolLayer using the specified
 ``properties`` map containing symbol properties (see
@@ -1975,7 +1975,7 @@ Creates a new QgsPointPatternFillSymbolLayer using the specified
 
 Caller takes ownership of the returned symbol layer.
 %End
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     virtual QString layerType() const;
 
@@ -2684,7 +2684,7 @@ with every map refresh.
 
     ~QgsRandomMarkerFillSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsRandomMarkerFillSymbolLayer using the specified
 ``properties`` map containing symbol properties (see
@@ -2885,7 +2885,7 @@ polygon geometry.
     ~QgsCentroidFillSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsCentroidFillSymbolLayer using the specified
 ``properties`` map containing symbol properties (see
@@ -2893,7 +2893,7 @@ Creates a new QgsCentroidFillSymbolLayer using the specified
 
 Caller takes ownership of the returned symbol layer.
 %End
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
 
     virtual QString layerType() const;

--- a/python/PyQt6/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
@@ -22,7 +22,7 @@ use of QGIS expressions.
   public:
     ~QgsGeometryGeneratorSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties );
 %Docstring
 Creates the symbol layer
 %End

--- a/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -371,7 +371,7 @@ Creates a new graduated renderer.
 .. deprecated:: 3.10
 %End
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 create renderer from XML element
 %End
@@ -490,7 +490,7 @@ Set the ``method`` used for graduation (either size or color).
 
     virtual QString legendClassificationAttribute() const;
 
-    static QgsGraduatedSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsGraduatedSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 %Docstring
 creates a QgsGraduatedSymbolRenderer from an existing renderer.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsheatmaprenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsheatmaprenderer.sip.in
@@ -38,13 +38,13 @@ A renderer which draws points as a live heatmap.
 
     virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a new heatmap renderer instance from XML
 %End
     virtual QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context );
 
-    static QgsHeatmapRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsHeatmapRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
     virtual QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) const /Factory/;

--- a/python/PyQt6/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsinterpolatedlinerenderer.sip.in
@@ -320,7 +320,7 @@ The interpolation is done between two values defined at the extremities.
   public:
     QgsInterpolatedLineSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties );
 %Docstring
 Creates the symbol layer
 %End

--- a/python/PyQt6/core/auto_generated/symbology/qgsinvertedpolygonrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsinvertedpolygonrenderer.sip.in
@@ -44,7 +44,7 @@ Constructor
     virtual QString dump() const;
 
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a renderer out of an XML, for loading
 %End
@@ -74,7 +74,7 @@ computations and is thus disabled by default.
 .. seealso:: :py:func:`preprocessingEnabled`
 %End
 
-    static QgsInvertedPolygonRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsInvertedPolygonRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 %Docstring
 Creates a QgsInvertedPolygonRenderer by a conversion from an existing
 renderer.

--- a/python/PyQt6/core/auto_generated/symbology/qgslinearreferencingsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgslinearreferencingsymbollayer.sip.in
@@ -28,7 +28,7 @@ from z or m values.
     QgsLinearReferencingSymbolLayer();
     ~QgsLinearReferencingSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsLinearReferencingSymbolLayer, using the specified
 ``properties``.

--- a/python/PyQt6/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -31,14 +31,14 @@ in the specified ``color``, ``width`` (in millimeters) and ``penStyle``.
     ~QgsSimpleLineSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsSimpleLineSymbolLayer, using the settings serialized in
 the ``properties`` map (corresponding to the output from
 :py:func:`QgsSimpleLineSymbolLayer.properties()` ).
 %End
 
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 %Docstring
 Creates a new QgsSimpleLineSymbolLayer from an SLD XML DOM ``element``.
 %End
@@ -1264,14 +1264,14 @@ symbols should be rotated to match the line segment alignment.
     ~QgsMarkerLineSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsMarkerLineSymbolLayer, using the settings serialized in
 the ``properties`` map (corresponding to the output from
 :py:func:`QgsMarkerLineSymbolLayer.properties()` ).
 %End
 
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 %Docstring
 Creates a new QgsMarkerLineSymbolLayer from an SLD XML DOM ``element``.
 %End
@@ -1379,7 +1379,7 @@ should be rotated to match the line segment alignment.
 
     ~QgsHashedLineSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsHashedLineSymbolLayer, using the settings serialized in
 the ``properties`` map (corresponding to the output from
@@ -1592,7 +1592,7 @@ image path.
 %End
     ~QgsRasterLineSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsRasterLineSymbolLayer, using the settings serialized in
 the ``properties`` map (corresponding to the output from
@@ -1695,7 +1695,7 @@ end gradient colors.
 %End
     ~QgsLineburstSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsLineburstSymbolLayer, using the settings serialized in
 the ``properties`` map (corresponding to the output from
@@ -1810,7 +1810,7 @@ layer and used to fill the inside of the stroked line. If no
 %End
     ~QgsFilledLineSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsFilledLineSymbolLayer, using the settings serialized in
 the ``properties`` map (corresponding to the output from

--- a/python/PyQt6/core/auto_generated/symbology/qgsmapinfosymbolconverter.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmapinfosymbolconverter.sip.in
@@ -55,7 +55,7 @@ Handles conversion of MapInfo symbols to QGIS symbology.
 #include "qgsmapinfosymbolconverter.h"
 %End
   public:
-    static QgsLineSymbol *convertLineSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, double size, Qgis::RenderUnit sizeUnit, bool interleaved = false ) /Factory/;
+    static std::unique_ptr<QgsLineSymbol> convertLineSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, double size, Qgis::RenderUnit sizeUnit, bool interleaved = false );
 %Docstring
 Converts the MapInfo line symbol with the specified ``identifier`` to a
 :py:class:`QgsLineSymbol`.
@@ -63,7 +63,7 @@ Converts the MapInfo line symbol with the specified ``identifier`` to a
 The caller takes ownership of the returned symbol.
 %End
 
-    static QgsFillSymbol *convertFillSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, const QColor &backColor = QColor() ) /Factory/;
+    static std::unique_ptr<QgsFillSymbol> convertFillSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, const QColor &backColor = QColor() );
 %Docstring
 Converts the MapInfo fill symbol with the specified ``identifier`` to a
 :py:class:`QgsFillSymbol`.
@@ -71,7 +71,7 @@ Converts the MapInfo fill symbol with the specified ``identifier`` to a
 The caller takes ownership of the returned symbol.
 %End
 
-    static QgsMarkerSymbol *convertMarkerSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &color, double size, Qgis::RenderUnit sizeUnit ) /Factory/;
+    static std::unique_ptr<QgsMarkerSymbol> convertMarkerSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &color, double size, Qgis::RenderUnit sizeUnit );
 %Docstring
 Converts the MapInfo marker symbol with the specified ``identifier`` to
 a :py:class:`QgsMarkerSymbol`.

--- a/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -204,7 +204,7 @@ Constructor for QgsSimpleMarkerSymbolLayer.
     ~QgsSimpleMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsSimpleMarkerSymbolLayer.
 
@@ -214,7 +214,7 @@ Creates a new QgsSimpleMarkerSymbolLayer.
 :return: new QgsSimpleMarkerSymbolLayer
 %End
 
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 %Docstring
 Creates a new QgsSimpleMarkerSymbolLayer from an SLD XML element.
 
@@ -505,7 +505,7 @@ Constructor for QgsFilledMarkerSymbolLayer.
 
     ~QgsFilledMarkerSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsFilledMarkerSymbolLayer.
 
@@ -575,11 +575,11 @@ to a SVG file
     ~QgsSvgMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates the symbol
 %End
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     static void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving );
 %Docstring
@@ -794,14 +794,14 @@ path to a raster image file
     ~QgsRasterMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a raster marker symbol layer from a string map of properties.
 
 :param properties: QVariantMap properties object
 %End
 
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 %Docstring
 Creates a new QgsRasterMarkerSymbolLayer from an SLD XML element.
 
@@ -1000,13 +1000,13 @@ Constructs a font marker symbol layer.
     ~QgsFontMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates a new QgsFontMarkerSymbolLayer from a property map (see
 :py:func:`~QgsFontMarkerSymbolLayer.properties`)
 %End
 
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 %Docstring
 Creates a new QgsFontMarkerSymbolLayer from an SLD XML ``element``.
 %End
@@ -1220,7 +1220,7 @@ image ``path``.
     ~QgsAnimatedMarkerSymbolLayer();
 
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates an animated marker symbol layer from a string map of
 ``properties``.

--- a/python/PyQt6/core/auto_generated/symbology/qgsmasksymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmasksymbollayer.sip.in
@@ -29,7 +29,7 @@ Simple constructor
 
     ~QgsMaskMarkerSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) /Factory/;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Create a new QgsMaskMarkerSymbolLayer
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsmergedfeaturerenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsmergedfeaturerenderer.sip.in
@@ -36,7 +36,7 @@ Constructor for QgsMergedFeatureRenderer.
 %End
 
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a renderer out of an XML, for loading
 %End
@@ -117,7 +117,7 @@ the embedded feature renderer
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
-    static QgsMergedFeatureRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsMergedFeatureRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 %Docstring
 Creates a QgsMergedFeatureRenderer by a conversion from an existing
 renderer.

--- a/python/PyQt6/core/auto_generated/symbology/qgsnullsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsnullsymbolrenderer.sip.in
@@ -45,7 +45,7 @@ Selected features will also be drawn with a default symbol.
     virtual QgsSymbolList symbols( QgsRenderContext &context ) const;
 
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a null renderer from XML element.
 
@@ -58,7 +58,7 @@ Creates a null renderer from XML element.
     virtual QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context );
 
 
-    static QgsNullSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsNullSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 %Docstring
 Creates a QgsNullSymbolRenderer from an existing renderer.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgspointclusterrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgspointclusterrenderer.sip.in
@@ -37,7 +37,7 @@ position.
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
-    static QgsFeatureRenderer *create( QDomElement &symbologyElem, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &symbologyElem, const QgsReadWriteContext &context );
 %Docstring
 Creates a renderer from XML element
 %End
@@ -60,7 +60,7 @@ Sets the symbol for rendering clustered groups.
 .. seealso:: :py:func:`clusterSymbol`
 %End
 
-    static QgsPointClusterRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsPointClusterRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 %Docstring
 Creates a QgsPointClusterRenderer from an existing renderer.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgspointdisplacementrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgspointdisplacementrenderer.sip.in
@@ -49,7 +49,7 @@ Constructor for QgsPointDisplacementRenderer.
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
-    static QgsFeatureRenderer *create( QDomElement &symbologyElem, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &symbologyElem, const QgsReadWriteContext &context );
 %Docstring
 Create a renderer from XML element
 %End
@@ -164,7 +164,7 @@ Sets the center symbol for a displacement group.
 .. seealso:: :py:func:`centerSymbol`
 %End
 
-    static QgsPointDisplacementRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsPointDisplacementRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 %Docstring
 Creates a QgsPointDisplacementRenderer from an existing renderer.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrenderer.sip.in
@@ -106,7 +106,7 @@ Returns the symbol property definitions.
 %End
 
 
-    static QgsFeatureRenderer *defaultRenderer( Qgis::GeometryType geomType ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> defaultRenderer( Qgis::GeometryType geomType );
 %Docstring
 Returns a new renderer - used by default in vector layers
 %End
@@ -298,7 +298,7 @@ Returns list of symbols used by the renderer.
     bool usingSymbolLevels() const;
     void setUsingSymbolLevels( bool usingSymbolLevels );
 
-    static QgsFeatureRenderer *load( QDomElement &symbologyElem, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> load( QDomElement &symbologyElem, const QgsReadWriteContext &context );
 %Docstring
 create a renderer from XML element
 %End
@@ -319,7 +319,7 @@ create the SLD UserStyle element following the SLD v1.1 specs with the
 given name
 %End
 
-    static QgsFeatureRenderer *loadSld( const QDomNode &node, Qgis::GeometryType geomType, QString &errorMessage ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> loadSld( const QDomNode &node, Qgis::GeometryType geomType, QString &errorMessage );
 %Docstring
 Create a new renderer according to the information contained in the
 UserStyle element of a SLD style document

--- a/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
@@ -278,7 +278,7 @@ Sets if this rule is active
 :param state: Determines if the rule should be activated or deactivated
 %End
 
-        QgsRuleBasedRenderer::Rule *clone() const /Factory/;
+        std::unique_ptr<QgsRuleBasedRenderer::Rule> clone() const;
 %Docstring
 clone this rule, return new instance
 %End
@@ -299,7 +299,7 @@ Saves the rule to SLD.
 .. versionadded:: 3.44
 %End
 
-        static QgsRuleBasedRenderer::Rule *createFromSld( QDomElement &element, Qgis::GeometryType geomType ) /Factory/;
+        static std::unique_ptr<QgsRuleBasedRenderer::Rule> createFromSld( QDomElement &element, Qgis::GeometryType geomType );
 %Docstring
 Create a rule from the SLD provided in element and for the specified
 geometry type.
@@ -379,7 +379,7 @@ rule
 :param context: The rendering context
 %End
 
-        static QgsRuleBasedRenderer::Rule *create( QDomElement &ruleElem, QgsSymbolMap &symbolMap, bool reuseId = true, const QgsReadWriteContext &context = QgsReadWriteContext() ) /Factory/;
+        static std::unique_ptr<QgsRuleBasedRenderer::Rule> create( QDomElement &ruleElem, QgsSymbolMap &symbolMap, bool reuseId = true, const QgsReadWriteContext &context = QgsReadWriteContext() );
 %Docstring
 Create a rule from an XML definition
 
@@ -484,7 +484,7 @@ or ``False`` if visiting should be canceled.
     };
 
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a new rule-based renderer instance from XML
 %End
@@ -537,7 +537,7 @@ there could be more symbols for a feature
     virtual bool toSld( QDomDocument &doc, QDomElement &element, QgsSldExportContext &context ) const;
 
 
-    static QgsFeatureRenderer *createFromSld( QDomElement &element, Qgis::GeometryType geomType ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> createFromSld( QDomElement &element, Qgis::GeometryType geomType );
 %Docstring
 Creates a new rule based renderer from an SLD XML element.
 %End
@@ -596,7 +596,7 @@ take a rule and create a list of new rules with intervals of scales
 given by the passed scale denominators
 %End
 
-    static QgsRuleBasedRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer = 0 ) /Factory/;
+    static std::unique_ptr<QgsRuleBasedRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer = 0 );
 %Docstring
 Creates a new QgsRuleBasedRenderer from an existing ``renderer``.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgssinglesymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssinglesymbolrenderer.sip.in
@@ -67,7 +67,7 @@ the symbol is transferred to the renderer.
     virtual bool toSld( QDomDocument &doc, QDomElement &element, QgsSldExportContext &context ) const;
 
 
-    static QgsFeatureRenderer *createFromSld( QDomElement &element, Qgis::GeometryType geomType ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> createFromSld( QDomElement &element, Qgis::GeometryType geomType );
 %Docstring
 Creates a new single symbol renderer from an SLD ``element``.
 
@@ -81,7 +81,7 @@ The caller takes ownership of the returned renderer.
     virtual QgsSymbolList symbols( QgsRenderContext &context ) const;
 
 
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Creates a new single symbol renderer from an XML ``element``, using the
 supplied read/write ``context``.
@@ -100,7 +100,7 @@ The caller takes ownership of the returned renderer.
     virtual void setLegendSymbolItem( const QString &key, QgsSymbol *symbol /Transfer/ );
 
 
-    static QgsSingleSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    static std::unique_ptr<QgsSingleSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 %Docstring
 Creates a new single symbol renderer from an existing ``renderer``.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
@@ -333,7 +333,7 @@ Returns a list of all tags in the style database
 Removes all contents of the style
 %End
 
-    QgsColorRamp *colorRamp( const QString &name ) const /Factory/;
+    std::unique_ptr<QgsColorRamp> colorRamp( const QString &name ) const;
 %Docstring
 Returns a new copy of the specified color ramp. The caller takes
 responsibility for deleting the returned object.
@@ -419,7 +419,7 @@ patch shape is not present.
 .. versionadded:: 3.14
 %End
 
-    QgsAbstract3DSymbol *symbol3D( const QString &name ) const /Factory/;
+    std::unique_ptr<QgsAbstract3DSymbol> symbol3D( const QString &name ) const;
 %Docstring
 Returns a new copy of the 3D symbol with the specified ``name``.
 
@@ -546,7 +546,7 @@ Renames a symbol from ``oldName`` to ``newName``.
 Returns ``True`` if symbol was successfully renamed.
 %End
 
-    QgsSymbol *symbol( const QString &name ) /Factory/;
+    std::unique_ptr<QgsSymbol> symbol( const QString &name );
 %Docstring
 Returns a NEW copy of symbol
 %End

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbol.sip.in
@@ -262,7 +262,7 @@ Returns the symbol property definitions.
 
     virtual ~QgsSymbol();
 
-    static QgsSymbol *defaultSymbol( Qgis::GeometryType geomType ) /Factory/;
+    static std::unique_ptr<QgsSymbol> defaultSymbol( Qgis::GeometryType geomType );
 %Docstring
 Returns a new default symbol for the specified geometry type.
 

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -850,7 +850,7 @@ top-level element
 
     static void clearSymbolMap( QgsSymbolMap &symbols );
 
-    static QMimeData *symbolToMimeData( const QgsSymbol *symbol ) /Factory/;
+    static std::unique_ptr<QMimeData> symbolToMimeData( const QgsSymbol *symbol );
 %Docstring
 Creates new mime data from a ``symbol``. This also sets the mime color
 data to match the symbol's color, so that copied symbols can be paste in
@@ -927,7 +927,7 @@ formats, including hex codes, rgb and rgba strings.
 :return: list of parsed colors
 %End
 
-    static QMimeData *colorToMimeData( const QColor &color ) /Factory/;
+    static std::unique_ptr<QMimeData> colorToMimeData( const QColor &color );
 %Docstring
 Creates mime data from a color. Sets both the mime data's color data,
 and the mime data's text with the color's hex code.
@@ -958,7 +958,7 @@ Attempts to parse mime data as a list of named colors
 :return: list of parsed colors
 %End
 
-    static QMimeData *colorListToMimeData( const QgsNamedColorList &colorList, bool allFormats = true ) /Factory/;
+    static std::unique_ptr<QMimeData> colorListToMimeData( const QgsNamedColorList &colorList, bool allFormats = true );
 %Docstring
 Creates mime data from a list of named colors
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsvectorfieldsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsvectorfieldsymbollayer.sip.in
@@ -45,11 +45,11 @@ layer attributes.
     QgsVectorFieldSymbolLayer();
     ~QgsVectorFieldSymbolLayer();
 
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() );
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 %Docstring
 Creates the symbol layer
 %End
-    static QgsSymbolLayer *createFromSld( QDomElement &element );
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     virtual QString layerType() const;
 

--- a/src/3d/symbols/qgspoint3dbillboardmaterial.cpp
+++ b/src/3d/symbols/qgspoint3dbillboardmaterial.cpp
@@ -194,8 +194,8 @@ void QgsPoint3DBillboardMaterial::setTexture2DFromImage( const QImage &image )
 void QgsPoint3DBillboardMaterial::useDefaultSymbol( const Qgs3DRenderContext &context, bool selected )
 {
   // Default texture
-  const std::unique_ptr<QgsMarkerSymbol> defaultSymbol( static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
-  setTexture2DFromSymbol( defaultSymbol.get(), context, selected );
+  std::unique_ptr<QgsSymbol> defaultSymbol = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  setTexture2DFromSymbol( static_cast<QgsMarkerSymbol *>( defaultSymbol.get() ), context, selected );
 }
 
 QImage QgsPoint3DBillboardMaterial::renderSymbolToImage( const QgsMarkerSymbol *markerSymbol, const Qgs3DRenderContext &context, bool selected )

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -45,7 +45,7 @@ QgsAbstract3DSymbol *QgsPoint3DSymbol::create()
 QgsPoint3DSymbol::QgsPoint3DSymbol()
   : mMaterialSettings( std::make_unique<QgsMetalRoughMaterialSettings>() )
 {
-  setBillboardSymbol( static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
+  setBillboardSymbol( qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ).release() );
 }
 
 QgsPoint3DSymbol::QgsPoint3DSymbol( const QgsPoint3DSymbol &other )

--- a/src/analysis/processing/qgsstylealgorithms.cpp
+++ b/src/analysis/processing/qgsstylealgorithms.cpp
@@ -152,7 +152,7 @@ QVariantMap QgsCombineStylesAlgorithm::processAlgorithm( const QVariantMap &para
       for ( const QString &name : symbolNames )
       {
         const QString newName = makeUniqueName( name, QgsStyle::SymbolEntity );
-        style.addSymbol( newName, sourceStyle.symbol( name ), true );
+        style.addSymbol( newName, sourceStyle.symbol( name ).release(), true );
         style.tagSymbol( QgsStyle::SymbolEntity, newName, sourceStyle.tagsOfSymbol( QgsStyle::SymbolEntity, name ) );
       }
     }
@@ -162,7 +162,7 @@ QVariantMap QgsCombineStylesAlgorithm::processAlgorithm( const QVariantMap &para
       for ( const QString &name : colorRampNames )
       {
         const QString newName = makeUniqueName( name, QgsStyle::ColorrampEntity );
-        style.addColorRamp( newName, sourceStyle.colorRamp( name ), true );
+        style.addColorRamp( newName, sourceStyle.colorRamp( name ).release(), true );
         style.tagSymbol( QgsStyle::ColorrampEntity, newName, sourceStyle.tagsOfSymbol( QgsStyle::ColorrampEntity, name ) );
       }
     }

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -271,7 +271,7 @@ QgsAbstract3DSymbol *QgsPoint3DSymbolWidget::symbol()
 {
   QVariantMap vm;
   auto sym = std::make_unique<QgsPoint3DSymbol>();
-  sym->setBillboardSymbol( static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
+  sym->setBillboardSymbol( qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ).release() );
   switch ( cboShape->currentData().value<Qgis::Point3DShape>() )
   {
     case Qgis::Point3DShape::Sphere:

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -1276,7 +1276,7 @@ void QgsAppLayerTreeViewMenuProvider::copyVectorSymbol( const QString &layerId )
 
   if ( singleRenderer )
   {
-    QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( singleRenderer->symbol() ) );
+    QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( singleRenderer->symbol() ).release() );
   }
 }
 
@@ -1411,7 +1411,7 @@ void QgsAppLayerTreeViewMenuProvider::copySymbolLegendNodeSymbol( const QString 
   if ( !originalSymbol )
     return;
 
-  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( originalSymbol ) );
+  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( originalSymbol ).release() );
 }
 
 void QgsAppLayerTreeViewMenuProvider::pasteSymbolLegendNodeSymbol( const QString &layerId, const QString &ruleKey )

--- a/src/core/effects/qgsgloweffect.cpp
+++ b/src/core/effects/qgsgloweffect.cpp
@@ -206,11 +206,11 @@ void QgsGlowEffect::readProperties( const QVariantMap &props )
   mRamp.reset();
   if ( props.contains( u"rampType"_s ) && props[u"rampType"_s] == QgsCptCityColorRamp::typeString() )
   {
-    mRamp.reset( QgsCptCityColorRamp::create( props ) );
+    mRamp = QgsCptCityColorRamp::create( props );
   }
   else
   {
-    mRamp.reset( QgsGradientColorRamp::create( props ) );
+    mRamp = QgsGradientColorRamp::create( props );
   }
 }
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1607,9 +1607,9 @@ void QgsMeshLayer::setMeshSimplificationSettings( const QgsMeshSimplificationSet
   mSimplificationSettings = simplifySettings;
 }
 
-static QgsColorRamp *_createDefaultColorRamp()
+static std::unique_ptr<QgsColorRamp> _createDefaultColorRamp()
 {
-  QgsColorRamp *ramp = QgsStyle::defaultStyle()->colorRamp( u"Plasma"_s );
+  std::unique_ptr<QgsColorRamp> ramp = QgsStyle::defaultStyle()->colorRamp( u"Plasma"_s );
   if ( ramp )
     return ramp;
 
@@ -1638,7 +1638,7 @@ void QgsMeshLayer::assignDefaultStyleToDatasetGroup( int groupIndex )
   const double groupMin = metadata.minimum();
   const double groupMax = metadata.maximum();
 
-  QgsColorRampShader fcn( groupMin, groupMax, _createDefaultColorRamp() );
+  QgsColorRampShader fcn( groupMin, groupMax, _createDefaultColorRamp().release() );
   fcn.classifyColorRamp( 5, -1, QgsRectangle(), nullptr );
 
   QgsMeshRendererScalarSettings scalarSettings;

--- a/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudattributebyramprenderer.cpp
@@ -30,7 +30,7 @@ using namespace Qt::StringLiterals;
 
 QgsPointCloudAttributeByRampRenderer::QgsPointCloudAttributeByRampRenderer()
 {
-  mColorRampShader.setSourceColorRamp( QgsStyle::defaultStyle()->colorRamp( u"Viridis"_s ) );
+  mColorRampShader.setSourceColorRamp( QgsStyle::defaultStyle()->colorRamp( u"Viridis"_s ).release() );
   mColorRampShader.classifyColorRamp( 5, -1, QgsRectangle(), nullptr );
 }
 

--- a/src/core/qgscolorrampimpl.cpp
+++ b/src/core/qgscolorrampimpl.cpp
@@ -243,7 +243,7 @@ QgsGradientColorRamp::QgsGradientColorRamp( const QColor &color1, const QColor &
   , mFunc( _interpolateRgb )
 {}
 
-QgsColorRamp *QgsGradientColorRamp::create( const QVariantMap &props )
+std::unique_ptr<QgsColorRamp> QgsGradientColorRamp::create( const QVariantMap &props )
 {
   // color1 and color2
   QColor color1 = DEFAULT_GRADIENT_COLOR1;
@@ -301,7 +301,7 @@ QgsColorRamp *QgsGradientColorRamp::create( const QVariantMap &props )
       info[it.key().mid( 5 )] = it.value().toString();
   }
 
-  QgsGradientColorRamp *r = new QgsGradientColorRamp( color1, color2, discrete, stops );
+  auto r = std::make_unique<QgsGradientColorRamp>( color1, color2, discrete, stops );
   r->setInfo( info );
 
   if ( props.contains( u"spec"_s ) )
@@ -976,7 +976,7 @@ QgsCptCityColorRamp::QgsCptCityColorRamp( const QString &schemeName, const QStri
     loadFile();
 }
 
-QgsColorRamp *QgsCptCityColorRamp::create( const QVariantMap &props ) // cppcheck-suppress duplInheritedMember
+std::unique_ptr<QgsColorRamp> QgsCptCityColorRamp::create( const QVariantMap &props ) // cppcheck-suppress duplInheritedMember
 {
   QString schemeName = DEFAULT_CPTCITY_SCHEMENAME;
   QString variantName = DEFAULT_CPTCITY_VARIANTNAME;
@@ -989,7 +989,7 @@ QgsColorRamp *QgsCptCityColorRamp::create( const QVariantMap &props ) // cppchec
   if ( props.contains( u"inverted"_s ) )
     inverted = props[u"inverted"_s].toInt();
 
-  return new QgsCptCityColorRamp( schemeName, variantName, inverted );
+  return std::make_unique<QgsCptCityColorRamp>( schemeName, variantName, inverted );
 }
 
 QString QgsCptCityColorRamp::type() const

--- a/src/core/qgscolorrampimpl.h
+++ b/src/core/qgscolorrampimpl.h
@@ -141,7 +141,7 @@ class CORE_EXPORT QgsGradientColorRamp : public QgsColorRamp
     QgsGradientColorRamp( const QColor &color1 = DEFAULT_GRADIENT_COLOR1, const QColor &color2 = DEFAULT_GRADIENT_COLOR2, bool discrete = false, const QgsGradientStopsList &stops = QgsGradientStopsList() );
 
     //! Creates a new QgsColorRamp from a map of properties
-    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsColorRamp> create( const QVariantMap &properties = QVariantMap() );
 
     int count() const override { return mStops.count() + 2; }
     double value( int index ) const override;
@@ -730,7 +730,7 @@ class CORE_EXPORT QgsCptCityColorRamp : public QgsGradientColorRamp
     QgsCptCityColorRamp( const QString &schemeName, const QStringList &variantList, const QString &variantName = QString(), bool inverted = false, bool doLoadFile = true );
 
     //! Creates the symbol layer
-    static QgsColorRamp *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY; // cppcheck-suppress duplInheritedMember
+    static std::unique_ptr<QgsColorRamp> create( const QVariantMap &properties = QVariantMap() ); // cppcheck-suppress duplInheritedMember
 
     /**
      * Returns the string identifier for QgsCptCityColorRamp.

--- a/src/core/raster/qgsrastercontourrenderer.cpp
+++ b/src/core/raster/qgsrastercontourrenderer.cpp
@@ -29,7 +29,7 @@ using namespace Qt::StringLiterals;
 QgsRasterContourRenderer::QgsRasterContourRenderer( QgsRasterInterface *input )
   : QgsRasterRenderer( input, u"contour"_s )
 {
-  mContourSymbol.reset( static_cast<QgsLineSymbol *>( QgsLineSymbol::defaultSymbol( Qgis::GeometryType::Line ) ) );
+  mContourSymbol = qgis::unique_ptr_static_cast<QgsLineSymbol>( QgsLineSymbol::defaultSymbol( Qgis::GeometryType::Line ) );
 }
 
 QgsRasterContourRenderer::~QgsRasterContourRenderer() = default;

--- a/src/core/symbology/qgs25drenderer.cpp
+++ b/src/core/symbology/qgs25drenderer.cpp
@@ -77,23 +77,19 @@ Qgs25DRenderer::Qgs25DRenderer()
 
   mSymbol->deleteSymbolLayer( 0 ); // We never asked for the default layer
 
-  QgsSymbolLayer *floor = QgsSimpleFillSymbolLayer::create();
+  std::unique_ptr<QgsSymbolLayer> floor = QgsSimpleFillSymbolLayer::create();
 
   QVariantMap wallProperties;
   wallProperties.insert( u"geometryModifier"_s, WALL_EXPRESSION );
   wallProperties.insert( u"symbolType"_s, u"Fill"_s );
-  QgsSymbolLayer *walls = QgsGeometryGeneratorSymbolLayer::create( wallProperties );
+  std::unique_ptr<QgsSymbolLayer> walls = QgsGeometryGeneratorSymbolLayer::create( wallProperties );
 
   QVariantMap roofProperties;
   roofProperties.insert( u"geometryModifier"_s, ROOF_EXPRESSION );
   roofProperties.insert( u"symbolType"_s, u"Fill"_s );
-  QgsSymbolLayer *roof = QgsGeometryGeneratorSymbolLayer::create( roofProperties );
+  std::unique_ptr<QgsSymbolLayer> roof = QgsGeometryGeneratorSymbolLayer::create( roofProperties );
 
   floor->setLocked( true );
-
-  mSymbol->appendSymbolLayer( floor );
-  mSymbol->appendSymbolLayer( walls );
-  mSymbol->appendSymbolLayer( roof );
 
   QgsEffectStack *effectStack = new QgsEffectStack();
   QgsOuterGlowEffect *glowEffect = new QgsOuterGlowEffect();
@@ -101,6 +97,11 @@ Qgs25DRenderer::Qgs25DRenderer()
   glowEffect->setSpreadUnit( Qgis::RenderUnit::MapUnits );
   effectStack->appendEffect( glowEffect );
   floor->setPaintEffect( effectStack );
+
+  mSymbol->appendSymbolLayer( floor.release() );
+  mSymbol->appendSymbolLayer( walls.release() );
+  mSymbol->appendSymbolLayer( roof.release() );
+
 
   // These methods must only be used after the above initialization!
 
@@ -143,9 +144,9 @@ Qgis::FeatureRendererFlags Qgs25DRenderer::flags() const
   return res;
 }
 
-QgsFeatureRenderer *Qgs25DRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> Qgs25DRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
-  Qgs25DRenderer *renderer = new Qgs25DRenderer();
+  auto renderer = std::make_unique<Qgs25DRenderer>();
 
   const QDomNodeList symbols = element.elementsByTagName( u"symbol"_s );
   if ( symbols.size() )
@@ -285,16 +286,16 @@ void Qgs25DRenderer::setRoofColor( const QColor &roofColor ) const
   roofLayer()->setStrokeColor( roofColor );
 }
 
-Qgs25DRenderer *Qgs25DRenderer::convertFromRenderer( QgsFeatureRenderer *renderer )
+std::unique_ptr<Qgs25DRenderer> Qgs25DRenderer::convertFromRenderer( QgsFeatureRenderer *renderer )
 {
   if ( renderer->type() == "25dRenderer"_L1 )
   {
-    return static_cast<Qgs25DRenderer *>( renderer->clone() );
+    return std::unique_ptr<Qgs25DRenderer>( static_cast<Qgs25DRenderer *>( renderer->clone() ) );
   }
   else
   {
     auto res = std::make_unique< Qgs25DRenderer >();
     renderer->copyRendererData( res.get() );
-    return res.release();
+    return res;
   }
 }

--- a/src/core/symbology/qgs25drenderer.h
+++ b/src/core/symbology/qgs25drenderer.h
@@ -38,7 +38,7 @@ class CORE_EXPORT Qgs25DRenderer : public QgsFeatureRenderer
      * \param element XML information
      * \param context reading context
      */
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
     Qgis::FeatureRendererFlags flags() const override;
     void startRender( QgsRenderContext &context, const QgsFields &fields ) override;
@@ -106,7 +106,7 @@ class CORE_EXPORT Qgs25DRenderer : public QgsFeatureRenderer
      * we assume that the internals are not compatible and create a new default
      * 2.5D renderer.
      */
-    static Qgs25DRenderer *convertFromRenderer( QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<Qgs25DRenderer> convertFromRenderer( QgsFeatureRenderer *renderer );
 
     /**
      * Is the shadow enabled

--- a/src/core/symbology/qgsarrowsymbollayer.cpp
+++ b/src/core/symbology/qgsarrowsymbollayer.cpp
@@ -49,9 +49,9 @@ bool QgsArrowSymbolLayer::setSubSymbol( QgsSymbol *symbol )
   return false;
 }
 
-QgsSymbolLayer *QgsArrowSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsArrowSymbolLayer::create( const QVariantMap &props )
 {
-  QgsArrowSymbolLayer *l = new QgsArrowSymbolLayer();
+  auto l = std::make_unique<QgsArrowSymbolLayer>();
 
   if ( props.contains( u"arrow_width"_s ) )
     l->setArrowWidth( props[u"arrow_width"_s].toDouble() );
@@ -122,7 +122,7 @@ QgsSymbolLayer *QgsArrowSymbolLayer::create( const QVariantMap &props )
 
 QgsArrowSymbolLayer *QgsArrowSymbolLayer::clone() const
 {
-  QgsArrowSymbolLayer *l = static_cast<QgsArrowSymbolLayer *>( create( properties() ) );
+  QgsArrowSymbolLayer *l = static_cast<QgsArrowSymbolLayer *>( create( properties() ).release() );
   l->setSubSymbol( mSymbol->clone() );
   copyCommonProperties( l );
   return l;

--- a/src/core/symbology/qgsarrowsymbollayer.h
+++ b/src/core/symbology/qgsarrowsymbollayer.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsArrowSymbolLayer : public QgsLineSymbolLayer
      *
      * \returns A new QgsArrowSymbolLayer
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     QgsArrowSymbolLayer *clone() const override SIP_FACTORY;
     QgsSymbol *subSymbol() override;

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -659,7 +659,7 @@ bool QgsCategorizedSymbolRenderer::accept( QgsStyleEntityVisitorInterface *visit
   return true;
 }
 
-QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsCategorizedSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
   QDomElement symbolsElem = element.firstChildElement( u"symbols"_s );
   if ( symbolsElem.isNull() )
@@ -767,7 +767,7 @@ QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, 
 
   QString attrName = element.attribute( u"attr"_s );
 
-  QgsCategorizedSymbolRenderer *r = new QgsCategorizedSymbolRenderer( attrName, cats );
+  auto r = std::make_unique<QgsCategorizedSymbolRenderer>( attrName, cats );
 
   // delete symbols if there are any more
   QgsSymbolLayerUtils::clearSymbolMap( symbolMap );
@@ -1244,7 +1244,7 @@ void QgsCategorizedSymbolRenderer::checkLegendSymbolItem( const QString &key, bo
   }
 }
 
-QgsCategorizedSymbolRenderer *QgsCategorizedSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer )
+std::unique_ptr<QgsCategorizedSymbolRenderer> QgsCategorizedSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer )
 {
   std::unique_ptr< QgsCategorizedSymbolRenderer > r;
   if ( renderer->type() == "categorizedSymbol"_L1 )
@@ -1356,13 +1356,13 @@ QgsCategorizedSymbolRenderer *QgsCategorizedSymbolRenderer::convertFromRenderer(
   {
     const QgsPointDistanceRenderer *pointDistanceRenderer = dynamic_cast<const QgsPointDistanceRenderer *>( renderer );
     if ( pointDistanceRenderer )
-      r.reset( convertFromRenderer( pointDistanceRenderer->embeddedRenderer() ) );
+      r = convertFromRenderer( pointDistanceRenderer->embeddedRenderer() );
   }
   else if ( renderer->type() == "invertedPolygonRenderer"_L1 )
   {
     const QgsInvertedPolygonRenderer *invertedPolygonRenderer = dynamic_cast<const QgsInvertedPolygonRenderer *>( renderer );
     if ( invertedPolygonRenderer )
-      r.reset( convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() ) );
+      r = convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() );
   }
   else if ( renderer->type() == "embeddedSymbol"_L1 && layer )
   {
@@ -1401,7 +1401,7 @@ QgsCategorizedSymbolRenderer *QgsCategorizedSymbolRenderer::convertFromRenderer(
 
   renderer->copyRendererData( r.get() );
 
-  return r.release();
+  return r;
 }
 
 void QgsCategorizedSymbolRenderer::setDataDefinedSizeLegend( QgsDataDefinedSizeLegend *settings )

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -342,7 +342,7 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
     /**
      * Creates a categorized renderer from an XML \a element.
      */
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
     QgsLegendSymbolList legendSymbolItems() const override;
@@ -418,7 +418,7 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
      *
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsCategorizedSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer = nullptr ) SIP_FACTORY;
+    static std::unique_ptr<QgsCategorizedSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer = nullptr );
 
     /**
      * Configures appearance of legend when renderer is configured to use data-defined size for marker symbols.

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -49,9 +49,9 @@ QgsEllipseSymbolLayer::QgsEllipseSymbolLayer()
 
 QgsEllipseSymbolLayer::~QgsEllipseSymbolLayer() = default;
 
-QgsSymbolLayer *QgsEllipseSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsEllipseSymbolLayer::create( const QVariantMap &properties )
 {
-  QgsEllipseSymbolLayer *layer = new QgsEllipseSymbolLayer();
+  auto layer = std::make_unique<QgsEllipseSymbolLayer>();
   if ( properties.contains( u"symbol_name"_s ) )
   {
     layer->setShape( decodeShape( properties[u"symbol_name"_s].toString() ) );
@@ -504,7 +504,7 @@ bool QgsEllipseSymbolLayer::writeSldMarker( QDomDocument &doc, QDomElement &elem
   return true;
 }
 
-QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
 {
   QgsDebugMsgLevel( u"Entered."_s, 4 );
 
@@ -549,7 +549,7 @@ QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
       angle = d;
   }
 
-  QgsEllipseSymbolLayer *m = new QgsEllipseSymbolLayer();
+  auto m = std::make_unique<QgsEllipseSymbolLayer>();
   m->setOutputUnit( sldUnitSize );
   m->setShape( decodeShape( name ) );
   m->setFillColor( fillColor );

--- a/src/core/symbology/qgsellipsesymbollayer.h
+++ b/src/core/symbology/qgsellipsesymbollayer.h
@@ -67,8 +67,8 @@ class CORE_EXPORT QgsEllipseSymbolLayer : public QgsMarkerSymbolLayer
     ~QgsEllipseSymbolLayer() override;
 
     //! Creates the symbol layer
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     void renderPoint( QPointF point, QgsSymbolRenderContext &context ) override;
     QString layerType() const override;

--- a/src/core/symbology/qgsembeddedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsembeddedsymbolrenderer.cpp
@@ -106,7 +106,7 @@ QgsFeatureRenderer::Capabilities QgsEmbeddedSymbolRenderer::capabilities()
   return SymbolLevels;
 }
 
-QgsFeatureRenderer *QgsEmbeddedSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsEmbeddedSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
   QDomElement symbolsElem = element.firstChildElement( u"symbols"_s );
   if ( symbolsElem.isNull() )
@@ -117,21 +117,21 @@ QgsFeatureRenderer *QgsEmbeddedSymbolRenderer::create( QDomElement &element, con
   if ( !symbolMap.contains( u"0"_s ) )
     return nullptr;
 
-  QgsEmbeddedSymbolRenderer *r = new QgsEmbeddedSymbolRenderer( symbolMap.take( u"0"_s ) );
+  auto r = std::make_unique<QgsEmbeddedSymbolRenderer>( symbolMap.take( u"0"_s ) );
   return r;
 }
 
-QgsEmbeddedSymbolRenderer *QgsEmbeddedSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
+std::unique_ptr<QgsEmbeddedSymbolRenderer> QgsEmbeddedSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
   if ( renderer->type() == "embeddedSymbol"_L1 )
   {
-    return dynamic_cast<QgsEmbeddedSymbolRenderer *>( renderer->clone() );
+    return std::unique_ptr<QgsEmbeddedSymbolRenderer>( dynamic_cast<QgsEmbeddedSymbolRenderer *>( renderer->clone() ) );
   }
   else if ( renderer->type() == "singleSymbol"_L1 )
   {
     auto symbolRenderer = std::make_unique< QgsEmbeddedSymbolRenderer >( static_cast< const QgsSingleSymbolRenderer * >( renderer )->symbol()->clone() );
     renderer->copyRendererData( symbolRenderer.get() );
-    return symbolRenderer.release();
+    return symbolRenderer;
   }
   else
   {

--- a/src/core/symbology/qgsembeddedsymbolrenderer.h
+++ b/src/core/symbology/qgsembeddedsymbolrenderer.h
@@ -76,13 +76,13 @@ class CORE_EXPORT QgsEmbeddedSymbolRenderer : public QgsFeatureRenderer
      *
      * The caller takes ownership of the returned renderer.
      */
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 
     /**
      * Creates a QgsEmbeddedSymbolRenderer from an existing \a renderer.
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsEmbeddedSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<QgsEmbeddedSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 
   private:
 #ifdef SIP_RUN

--- a/src/core/symbology/qgsfillsymbol.cpp
+++ b/src/core/symbology/qgsfillsymbol.cpp
@@ -20,12 +20,12 @@
 
 std::unique_ptr< QgsFillSymbol > QgsFillSymbol::createSimple( const QVariantMap &properties )
 {
-  QgsSymbolLayer *sl = QgsSimpleFillSymbolLayer::create( properties );
+  std::unique_ptr<QgsSymbolLayer> sl = QgsSimpleFillSymbolLayer::create( properties );
   if ( !sl )
     return nullptr;
 
   QgsSymbolLayerList layers;
-  layers.append( sl );
+  layers.append( sl.release() );
   return std::make_unique< QgsFillSymbol >( layers );
 }
 

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -171,7 +171,7 @@ void QgsSimpleFillSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
 }
 
 
-QgsSymbolLayer *QgsSimpleFillSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsSimpleFillSymbolLayer::create( const QVariantMap &props )
 {
   QColor color = DEFAULT_SIMPLEFILL_COLOR;
   Qt::BrushStyle style = DEFAULT_SIMPLEFILL_STYLE;
@@ -254,7 +254,7 @@ QgsSymbolLayer *QgsSimpleFillSymbolLayer::create( const QVariantMap &props )
 
   sl->restoreOldDataDefinedProperties( props );
 
-  return sl.release();
+  return sl;
 }
 
 
@@ -490,7 +490,7 @@ QString QgsSimpleFillSymbolLayer::ogrFeatureStyle( double mmScaleFactor, double 
   return symbolStyle;
 }
 
-QgsSymbolLayer *QgsSimpleFillSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsSimpleFillSymbolLayer::createFromSld( QDomElement &element )
 {
   QColor color, strokeColor;
   Qt::BrushStyle fillStyle;
@@ -516,7 +516,7 @@ QgsSymbolLayer *QgsSimpleFillSymbolLayer::createFromSld( QDomElement &element )
   auto sl = std::make_unique< QgsSimpleFillSymbolLayer >( color, fillStyle, strokeColor, strokeStyle, strokeWidth );
   sl->setOutputUnit( sldUnitSize );
   sl->setOffset( offset );
-  return sl.release();
+  return sl;
 }
 
 double QgsSimpleFillSymbolLayer::estimateMaxBleed( const QgsRenderContext &context ) const
@@ -619,7 +619,7 @@ QgsGradientFillSymbolLayer::QgsGradientFillSymbolLayer(
 QgsGradientFillSymbolLayer::~QgsGradientFillSymbolLayer()
 {}
 
-QgsSymbolLayer *QgsGradientFillSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsGradientFillSymbolLayer::create( const QVariantMap &props )
 {
   //default to a two-color, linear gradient with feature mode and pad spreading
   Qgis::GradientType type = Qgis::GradientType::Linear;
@@ -673,7 +673,7 @@ QgsSymbolLayer *QgsGradientFillSymbolLayer::create( const QVariantMap &props )
     offset = QgsSymbolLayerUtils::decodePoint( props[u"offset"_s].toString() );
 
   //attempt to create color ramp from props
-  QgsColorRamp *gradientRamp = nullptr;
+  std::unique_ptr<QgsColorRamp> gradientRamp;
   if ( props.contains( u"rampType"_s ) && props[u"rampType"_s] == QgsCptCityColorRamp::typeString() )
   {
     gradientRamp = QgsCptCityColorRamp::create( props );
@@ -696,11 +696,11 @@ QgsSymbolLayer *QgsGradientFillSymbolLayer::create( const QVariantMap &props )
   sl->setReferencePoint2IsCentroid( refPoint2IsCentroid );
   sl->setAngle( angle );
   if ( gradientRamp )
-    sl->setColorRamp( gradientRamp );
+    sl->setColorRamp( gradientRamp.release() );
 
   sl->restoreOldDataDefinedProperties( props );
 
-  return sl.release();
+  return sl;
 }
 
 Qgis::SymbolLayerFlags QgsGradientFillSymbolLayer::flags() const
@@ -1130,7 +1130,7 @@ QgsShapeburstFillSymbolLayer::QgsShapeburstFillSymbolLayer( const QColor &color,
 
 QgsShapeburstFillSymbolLayer::~QgsShapeburstFillSymbolLayer() = default;
 
-QgsSymbolLayer *QgsShapeburstFillSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsShapeburstFillSymbolLayer::create( const QVariantMap &props )
 {
   //default to a two-color gradient
   Qgis::GradientColorSource colorType = Qgis::GradientColorSource::SimpleTwoColor;
@@ -1182,7 +1182,7 @@ QgsSymbolLayer *QgsShapeburstFillSymbolLayer::create( const QVariantMap &props )
   }
 
   //attempt to create color ramp from props
-  QgsColorRamp *gradientRamp = nullptr;
+  std::unique_ptr<QgsColorRamp> gradientRamp;
   if ( props.contains( u"rampType"_s ) && props[u"rampType"_s] == QgsCptCityColorRamp::typeString() )
   {
     gradientRamp = QgsCptCityColorRamp::create( props );
@@ -1217,12 +1217,12 @@ QgsSymbolLayer *QgsShapeburstFillSymbolLayer::create( const QVariantMap &props )
   }
   if ( gradientRamp )
   {
-    sl->setColorRamp( gradientRamp );
+    sl->setColorRamp( gradientRamp.release() );
   }
 
   sl->restoreOldDataDefinedProperties( props );
 
-  return sl.release();
+  return sl;
 }
 
 QString QgsShapeburstFillSymbolLayer::layerType() const
@@ -1983,7 +1983,7 @@ void QgsSVGFillSymbolLayer::setSvgFilePath( const QString &svgPath )
   setDefaultSvgParams();
 }
 
-QgsSymbolLayer *QgsSVGFillSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsSVGFillSymbolLayer::create( const QVariantMap &properties )
 {
   QByteArray data;
   double width = 20;
@@ -2088,7 +2088,7 @@ QgsSymbolLayer *QgsSVGFillSymbolLayer::create( const QVariantMap &properties )
 
   symbolLayer->restoreOldDataDefinedProperties( properties );
 
-  return symbolLayer.release();
+  return symbolLayer;
 }
 
 void QgsSVGFillSymbolLayer::resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving )
@@ -2417,7 +2417,7 @@ bool QgsSVGFillSymbolLayer::hasDataDefinedProperties() const
   return false;
 }
 
-QgsSymbolLayer *QgsSVGFillSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsSVGFillSymbolLayer::createFromSld( QDomElement &element )
 {
   QString path, mimeType;
   QColor fillColor, strokeColor;
@@ -2479,7 +2479,7 @@ QgsSymbolLayer *QgsSVGFillSymbolLayer::createFromSld( QDomElement &element )
     }
   }
 
-  return sl.release();
+  return sl;
 }
 
 void QgsSVGFillSymbolLayer::applyDataDefinedSettings( QgsSymbolRenderContext &context )
@@ -2804,7 +2804,7 @@ QgsMapUnitScale QgsLinePatternFillSymbolLayer::mapUnitScale() const
   return QgsMapUnitScale();
 }
 
-QgsSymbolLayer *QgsLinePatternFillSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsLinePatternFillSymbolLayer::create( const QVariantMap &properties )
 {
   auto patternLayer = std::make_unique< QgsLinePatternFillSymbolLayer >();
 
@@ -2915,7 +2915,7 @@ QgsSymbolLayer *QgsLinePatternFillSymbolLayer::create( const QVariantMap &proper
 
   patternLayer->restoreOldDataDefinedProperties( properties );
 
-  return patternLayer.release();
+  return patternLayer;
 }
 
 QString QgsLinePatternFillSymbolLayer::layerType() const
@@ -3471,13 +3471,13 @@ QVariantMap QgsLinePatternFillSymbolLayer::properties() const
 
 QgsLinePatternFillSymbolLayer *QgsLinePatternFillSymbolLayer::clone() const
 {
-  QgsLinePatternFillSymbolLayer *clonedLayer = static_cast<QgsLinePatternFillSymbolLayer *>( QgsLinePatternFillSymbolLayer::create( properties() ) );
+  auto clonedLayer = qgis::unique_ptr_static_cast<QgsLinePatternFillSymbolLayer>( QgsLinePatternFillSymbolLayer::create( properties() ) );
   if ( mFillLineSymbol )
   {
     clonedLayer->setSubSymbol( mFillLineSymbol->clone() );
   }
-  copyCommonProperties( clonedLayer );
-  return clonedLayer;
+  copyCommonProperties( clonedLayer.get() );
+  return clonedLayer.release();
 }
 
 void QgsLinePatternFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const
@@ -3593,7 +3593,7 @@ void QgsLinePatternFillSymbolLayer::applyDataDefinedSettings( QgsSymbolRenderCon
   applyPattern( context, mBrush, lineAngle, distance );
 }
 
-QgsSymbolLayer *QgsLinePatternFillSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsLinePatternFillSymbolLayer::createFromSld( QDomElement &element )
 {
   QString name;
   QColor fillColor, lineColor;
@@ -3662,7 +3662,7 @@ QgsSymbolLayer *QgsLinePatternFillSymbolLayer::createFromSld( QDomElement &eleme
     }
   }
 
-  return sl.release();
+  return sl;
 }
 
 
@@ -3768,7 +3768,7 @@ QgsMapUnitScale QgsPointPatternFillSymbolLayer::mapUnitScale() const
   return QgsMapUnitScale();
 }
 
-QgsSymbolLayer *QgsPointPatternFillSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsPointPatternFillSymbolLayer::create( const QVariantMap &properties )
 {
   auto layer = std::make_unique< QgsPointPatternFillSymbolLayer >();
   if ( properties.contains( u"distance_x"_s ) )
@@ -3907,7 +3907,7 @@ QgsSymbolLayer *QgsPointPatternFillSymbolLayer::create( const QVariantMap &prope
 
   layer->restoreOldDataDefinedProperties( properties );
 
-  return layer.release();
+  return layer;
 }
 
 QString QgsPointPatternFillSymbolLayer::layerType() const
@@ -4438,14 +4438,14 @@ QVariantMap QgsPointPatternFillSymbolLayer::properties() const
 
 QgsPointPatternFillSymbolLayer *QgsPointPatternFillSymbolLayer::clone() const
 {
-  QgsPointPatternFillSymbolLayer *clonedLayer = static_cast<QgsPointPatternFillSymbolLayer *>( QgsPointPatternFillSymbolLayer::create( properties() ) );
+  auto clonedLayer = qgis::unique_ptr_static_cast<QgsPointPatternFillSymbolLayer>( QgsPointPatternFillSymbolLayer::create( properties() ) );
   if ( mMarkerSymbol )
   {
     clonedLayer->setSubSymbol( mMarkerSymbol->clone() );
   }
   clonedLayer->setClipMode( mClipMode );
-  copyCommonProperties( clonedLayer );
-  return clonedLayer;
+  copyCommonProperties( clonedLayer.get() );
+  return clonedLayer.release();
 }
 
 void QgsPointPatternFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const
@@ -4574,7 +4574,7 @@ QImage QgsPointPatternFillSymbolLayer::toTiledPatternImage() const
   return pixmap.toImage();
 }
 
-QgsSymbolLayer *QgsPointPatternFillSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsPointPatternFillSymbolLayer::createFromSld( QDomElement &element )
 {
   // input element is PolygonSymbolizer
 
@@ -4716,7 +4716,7 @@ QgsSymbolLayer *QgsPointPatternFillSymbolLayer::createFromSld( QDomElement &elem
     }
   }
 
-  return pointPatternFillSl.release();
+  return pointPatternFillSl;
 }
 
 bool QgsPointPatternFillSymbolLayer::setSubSymbol( QgsSymbol *symbol )
@@ -4837,7 +4837,7 @@ QgsCentroidFillSymbolLayer::QgsCentroidFillSymbolLayer()
 
 QgsCentroidFillSymbolLayer::~QgsCentroidFillSymbolLayer() = default;
 
-QgsSymbolLayer *QgsCentroidFillSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsCentroidFillSymbolLayer::create( const QVariantMap &properties )
 {
   auto sl = std::make_unique< QgsCentroidFillSymbolLayer >();
 
@@ -4852,7 +4852,7 @@ QgsSymbolLayer *QgsCentroidFillSymbolLayer::create( const QVariantMap &propertie
 
   sl->restoreOldDataDefinedProperties( properties );
 
-  return sl.release();
+  return sl;
 }
 
 QString QgsCentroidFillSymbolLayer::layerType() const
@@ -5059,7 +5059,7 @@ bool QgsCentroidFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element,
   return mMarker->toSld( doc, element, context );
 }
 
-QgsSymbolLayer *QgsCentroidFillSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsCentroidFillSymbolLayer::createFromSld( QDomElement &element )
 {
   std::unique_ptr< QgsSymbolLayer > l = QgsSymbolLayerUtils::createMarkerLayerFromSld( element );
   if ( !l )
@@ -5072,7 +5072,7 @@ QgsSymbolLayer *QgsCentroidFillSymbolLayer::createFromSld( QDomElement &element 
   auto sl = std::make_unique< QgsCentroidFillSymbolLayer >();
   sl->setSubSymbol( marker.release() );
   sl->setPointOnAllParts( false );
-  return sl.release();
+  return sl;
 }
 
 
@@ -5172,7 +5172,7 @@ QgsRasterFillSymbolLayer::QgsRasterFillSymbolLayer( const QString &imageFilePath
 
 QgsRasterFillSymbolLayer::~QgsRasterFillSymbolLayer() = default;
 
-QgsSymbolLayer *QgsRasterFillSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsRasterFillSymbolLayer::create( const QVariantMap &properties )
 {
   Qgis::SymbolCoordinateReference mode = Qgis::SymbolCoordinateReference::Feature;
   double alpha = 1.0;
@@ -5235,10 +5235,10 @@ QgsSymbolLayer *QgsRasterFillSymbolLayer::create( const QVariantMap &properties 
 
   symbolLayer->restoreOldDataDefinedProperties( properties );
 
-  return symbolLayer.release();
+  return symbolLayer;
 }
 
-QgsSymbolLayer *QgsRasterFillSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsRasterFillSymbolLayer::createFromSld( QDomElement &element )
 {
   QDomElement fillElem = element.firstChildElement( u"Fill"_s );
   if ( fillElem.isNull() )
@@ -5267,7 +5267,7 @@ QgsSymbolLayer *QgsRasterFillSymbolLayer::createFromSld( QDomElement &element )
 
   auto sl = std::make_unique< QgsRasterFillSymbolLayer>( path );
 
-  return sl.release();
+  return sl;
 }
 
 void QgsRasterFillSymbolLayer::resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving )
@@ -5581,7 +5581,7 @@ QgsRandomMarkerFillSymbolLayer::QgsRandomMarkerFillSymbolLayer( int pointCount, 
 
 QgsRandomMarkerFillSymbolLayer::~QgsRandomMarkerFillSymbolLayer() = default;
 
-QgsSymbolLayer *QgsRandomMarkerFillSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsRandomMarkerFillSymbolLayer::create( const QVariantMap &properties )
 {
   const Qgis::PointCountMethod countMethod = static_cast< Qgis::PointCountMethod >( properties.value( u"count_method"_s, u"0"_s ).toInt() );
   const int pointCount = properties.value( u"point_count"_s, u"10"_s ).toInt();
@@ -5612,7 +5612,7 @@ QgsSymbolLayer *QgsRandomMarkerFillSymbolLayer::create( const QVariantMap &prope
     sl->setClipPoints( properties[u"clip_points"_s].toInt() );
   }
 
-  return sl.release();
+  return sl;
 }
 
 QString QgsRandomMarkerFillSymbolLayer::layerType() const

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -62,8 +62,8 @@ class CORE_EXPORT QgsSimpleFillSymbolLayer : public QgsFillSymbolLayer
      *
      * Caller takes ownership of the returned symbol layer.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     // implemented from base classes
 
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsGradientFillSymbolLayer : public QgsFillSymbolLayer
      *
      * Caller takes ownership of the returned symbol layer.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     // implemented from base classes
 
@@ -529,7 +529,7 @@ class CORE_EXPORT QgsShapeburstFillSymbolLayer : public QgsFillSymbolLayer
      *
      * Caller takes ownership of the returned symbol layer.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     // implemented from base classes
 
@@ -882,14 +882,14 @@ class CORE_EXPORT QgsRasterFillSymbolLayer : public QgsImageFillSymbolLayer
      * Creates a new QgsRasterFillSymbolLayer from a \a properties map. The caller takes
      * ownership of the returned object.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Creates a new QgsRasterFillSymbolLayer from a SLD \a element. The caller takes
      * ownership of the returned object.
      * \since QGIS 3.30
      */
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     /**
      * Turns relative paths in properties map to absolute when reading and vice versa when writing.
@@ -1200,13 +1200,13 @@ class CORE_EXPORT QgsSVGFillSymbolLayer : public QgsImageFillSymbolLayer
      * Creates a new QgsSVGFillSymbolLayer from a \a properties map. The caller takes
      * ownership of the returned object.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Creates a new QgsSVGFillSymbolLayer from a SLD \a element. The caller takes
      * ownership of the returned object.
      */
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     /**
      * Turns relative paths in properties map to absolute when reading and vice versa when writing.
@@ -1493,13 +1493,13 @@ class CORE_EXPORT QgsLinePatternFillSymbolLayer : public QgsImageFillSymbolLayer
      * Creates a new QgsLinePatternFillSymbolLayer from a \a properties map. The caller takes
      * ownership of the returned object.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Creates a new QgsLinePatternFillSymbolLayer from a SLD \a element. The caller takes
      * ownership of the returned object.
      */
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     QString layerType() const override;
     void startRender( QgsSymbolRenderContext &context ) override;
@@ -1769,8 +1769,8 @@ class CORE_EXPORT QgsPointPatternFillSymbolLayer : public QgsImageFillSymbolLaye
      *
      * Caller takes ownership of the returned symbol layer.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     QString layerType() const override;
     void startRender( QgsSymbolRenderContext &context ) override;
@@ -2331,7 +2331,7 @@ class CORE_EXPORT QgsRandomMarkerFillSymbolLayer : public QgsFillSymbolLayer
      *
      * Caller takes ownership of the returned symbol layer.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     QString layerType() const override;
     void startRender( QgsSymbolRenderContext &context ) override;
@@ -2515,8 +2515,8 @@ class CORE_EXPORT QgsCentroidFillSymbolLayer : public QgsFillSymbolLayer
      *
      * Caller takes ownership of the returned symbol layer.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     // implemented from base classes
 

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -34,14 +34,14 @@ using namespace Qt::StringLiterals;
 
 QgsGeometryGeneratorSymbolLayer::~QgsGeometryGeneratorSymbolLayer() = default;
 
-QgsSymbolLayer *QgsGeometryGeneratorSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsGeometryGeneratorSymbolLayer::create( const QVariantMap &properties )
 {
   QString expression = properties.value( u"geometryModifier"_s ).toString();
   if ( expression.isEmpty() )
   {
     expression = u"@geometry"_s;
   }
-  QgsGeometryGeneratorSymbolLayer *symbolLayer = new QgsGeometryGeneratorSymbolLayer( expression );
+  auto symbolLayer = std::unique_ptr<QgsGeometryGeneratorSymbolLayer>( new QgsGeometryGeneratorSymbolLayer( expression ) );
 
   if ( properties.value( u"SymbolType"_s ) == "Marker"_L1 )
   {

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
@@ -35,7 +35,7 @@ class CORE_EXPORT QgsGeometryGeneratorSymbolLayer : public QgsSymbolLayer
     ~QgsGeometryGeneratorSymbolLayer() override;
 
     //! Creates the symbol layer
-    static QgsSymbolLayer *create( const QVariantMap &properties ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties );
 
     QString layerType() const override;
 

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -481,7 +481,7 @@ void QgsGraduatedSymbolRenderer::updateClasses( const QgsVectorLayer *vl, int nc
 
   for ( QList<QgsClassificationRange>::iterator it = classes.begin(); it != classes.end(); ++it )
   {
-    QgsSymbol *newSymbol = mSourceSymbol ? mSourceSymbol->clone() : QgsSymbol::defaultSymbol( vl->geometryType() );
+    QgsSymbol *newSymbol = mSourceSymbol ? mSourceSymbol->clone() : QgsSymbol::defaultSymbol( vl->geometryType() ).release();
     addClass( QgsRendererRange( *it, newSymbol ) );
   }
   updateColorRamp( nullptr );
@@ -494,7 +494,7 @@ QgsRendererRangeLabelFormat QgsGraduatedSymbolRenderer::labelFormat() const
 }
 Q_NOWARN_DEPRECATED_POP
 
-QgsFeatureRenderer *QgsGraduatedSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsGraduatedSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
   QDomElement symbolsElem = element.firstChildElement( u"symbols"_s );
   if ( symbolsElem.isNull() )
@@ -661,7 +661,7 @@ QgsFeatureRenderer *QgsGraduatedSymbolRenderer::create( QDomElement &element, co
     r->mDataDefinedSizeLegend.reset( QgsDataDefinedSizeLegend::readXml( ddsLegendSizeElem, context ) );
   }
   // TODO: symbol levels
-  return r.release();
+  return r;
 }
 
 QDomElement QgsGraduatedSymbolRenderer::save( QDomDocument &doc, const QgsReadWriteContext &context )
@@ -1331,7 +1331,7 @@ void QgsGraduatedSymbolRenderer::setAstride( bool astride ) SIP_DEPRECATED
   mClassificationMethod->setSymmetricMode( mClassificationMethod->symmetricModeEnabled(), mClassificationMethod->symmetryPoint(), astride );
 }
 
-QgsGraduatedSymbolRenderer *QgsGraduatedSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
+std::unique_ptr<QgsGraduatedSymbolRenderer> QgsGraduatedSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
   std::unique_ptr< QgsGraduatedSymbolRenderer > r;
   if ( renderer->type() == "graduatedSymbol"_L1 )
@@ -1360,13 +1360,13 @@ QgsGraduatedSymbolRenderer *QgsGraduatedSymbolRenderer::convertFromRenderer( con
   {
     const QgsPointDistanceRenderer *pointDistanceRenderer = dynamic_cast<const QgsPointDistanceRenderer *>( renderer );
     if ( pointDistanceRenderer )
-      r.reset( convertFromRenderer( pointDistanceRenderer->embeddedRenderer() ) );
+      r = convertFromRenderer( pointDistanceRenderer->embeddedRenderer() );
   }
   else if ( renderer->type() == "invertedPolygonRenderer"_L1 )
   {
     const QgsInvertedPolygonRenderer *invertedPolygonRenderer = dynamic_cast<const QgsInvertedPolygonRenderer *>( renderer );
     if ( invertedPolygonRenderer )
-      r.reset( convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() ) );
+      r = convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() );
   }
 
   // If not one of the specifically handled renderers, then just grab the symbol from the renderer
@@ -1385,7 +1385,7 @@ QgsGraduatedSymbolRenderer *QgsGraduatedSymbolRenderer::convertFromRenderer( con
 
   renderer->copyRendererData( r.get() );
 
-  return r.release();
+  return r;
 }
 
 void QgsGraduatedSymbolRenderer::setDataDefinedSizeLegend( QgsDataDefinedSizeLegend *settings )

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -305,7 +305,7 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
     Q_NOWARN_DEPRECATED_POP;
 
     //! create renderer from XML element
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
     QgsLegendSymbolList legendSymbolItems() const override;
@@ -415,7 +415,7 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
      * creates a QgsGraduatedSymbolRenderer from an existing renderer.
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsGraduatedSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<QgsGraduatedSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 
     /**
      * Configures appearance of legend when renderer is configured to use data-defined size for marker symbols.

--- a/src/core/symbology/qgsheatmaprenderer.cpp
+++ b/src/core/symbology/qgsheatmaprenderer.cpp
@@ -312,10 +312,10 @@ void QgsHeatmapRenderer::modifyRequestExtent( QgsRectangle &extent, QgsRenderCon
   extent.setYMaximum( extent.yMaximum() + extension );
 }
 
-QgsFeatureRenderer *QgsHeatmapRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsHeatmapRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
   Q_UNUSED( context )
-  QgsHeatmapRenderer *r = new QgsHeatmapRenderer();
+  auto r = std::make_unique<QgsHeatmapRenderer>();
   r->setRadius( element.attribute( u"radius"_s, u"50.0"_s ).toFloat() );
   r->setRadiusUnit( static_cast< Qgis::RenderUnit >( element.attribute( u"radius_unit"_s, u"0"_s ).toInt() ) );
   r->setRadiusMapUnitScale( QgsSymbolLayerUtils::decodeMapUnitScale( element.attribute( u"radius_map_unit_scale"_s, QString() ) ) );
@@ -387,17 +387,17 @@ QSet<QString> QgsHeatmapRenderer::usedAttributes( const QgsRenderContext & ) con
   return attributes;
 }
 
-QgsHeatmapRenderer *QgsHeatmapRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
+std::unique_ptr<QgsHeatmapRenderer> QgsHeatmapRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
   if ( renderer->type() == "heatmapRenderer"_L1 )
   {
-    return dynamic_cast<QgsHeatmapRenderer *>( renderer->clone() );
+    return std::unique_ptr<QgsHeatmapRenderer>( dynamic_cast<QgsHeatmapRenderer *>( renderer->clone() ) );
   }
   else
   {
     auto res = std::make_unique< QgsHeatmapRenderer >();
     renderer->copyRendererData( res.get() );
-    return res.release();
+    return res;
   }
 }
 

--- a/src/core/symbology/qgsheatmaprenderer.h
+++ b/src/core/symbology/qgsheatmaprenderer.h
@@ -52,9 +52,9 @@ class CORE_EXPORT QgsHeatmapRenderer : public QgsFeatureRenderer
     QString dump() const override;
     QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
     //! Creates a new heatmap renderer instance from XML
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
-    static QgsHeatmapRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<QgsHeatmapRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
     QList<QgsLayerTreeModelLegendNode *> createLegendNodes( QgsLayerTreeLayer *nodeLayer ) const override SIP_FACTORY;
 

--- a/src/core/symbology/qgsinterpolatedlinerenderer.cpp
+++ b/src/core/symbology/qgsinterpolatedlinerenderer.cpp
@@ -817,12 +817,12 @@ void QgsInterpolatedLineSymbolLayer::stopRender( QgsSymbolRenderContext & )
 
 QgsInterpolatedLineSymbolLayer *QgsInterpolatedLineSymbolLayer::clone() const
 {
-  QgsInterpolatedLineSymbolLayer *l = static_cast<QgsInterpolatedLineSymbolLayer *>( create( properties() ) );
-  copyCommonProperties( l );
-  return l;
+  auto l = qgis::unique_ptr_static_cast<QgsInterpolatedLineSymbolLayer>( create( properties() ) );
+  copyCommonProperties( l.get() );
+  return l.release();
 }
 
-QgsSymbolLayer *QgsInterpolatedLineSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsInterpolatedLineSymbolLayer::create( const QVariantMap &properties )
 {
   std::unique_ptr<QgsInterpolatedLineSymbolLayer> symbolLayer;
   symbolLayer = std::make_unique<QgsInterpolatedLineSymbolLayer>();
@@ -863,7 +863,7 @@ QgsSymbolLayer *QgsInterpolatedLineSymbolLayer::create( const QVariantMap &prope
   if ( properties.contains( u"coloring_method"_s ) )
     symbolLayer->mLineRender.mStrokeColoring.setColoringMethod( static_cast<QgsInterpolatedLineColor::ColoringMethod>( properties.value( u"coloring_method"_s ).toInt() ) );
 
-  return symbolLayer.release();
+  return symbolLayer;
 }
 
 Qgis::SymbolLayerFlags QgsInterpolatedLineSymbolLayer::flags() const

--- a/src/core/symbology/qgsinterpolatedlinerenderer.h
+++ b/src/core/symbology/qgsinterpolatedlinerenderer.h
@@ -286,7 +286,7 @@ class CORE_EXPORT QgsInterpolatedLineSymbolLayer : public QgsLineSymbolLayer
     QgsInterpolatedLineSymbolLayer();
 
     //! Creates the symbol layer
-    static QgsSymbolLayer *create( const QVariantMap &properties ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties );
 
     Qgis::SymbolLayerFlags flags() const override;
     QString layerType() const override;

--- a/src/core/symbology/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.cpp
@@ -37,7 +37,7 @@ QgsInvertedPolygonRenderer::QgsInvertedPolygonRenderer( QgsFeatureRenderer *subR
 {
   if ( !subRenderer )
   {
-    mSubRenderer.reset( QgsFeatureRenderer::defaultRenderer( Qgis::GeometryType::Polygon ) );
+    mSubRenderer = QgsFeatureRenderer::defaultRenderer( Qgis::GeometryType::Polygon );
   }
   mOperation = InvertOnly;
 }
@@ -67,15 +67,15 @@ QgsInvertedPolygonRenderer *QgsInvertedPolygonRenderer::clone() const
   return newRenderer;
 }
 
-QgsFeatureRenderer *QgsInvertedPolygonRenderer::create( QDomElement &element, const QgsReadWriteContext &context ) // cppcheck-suppress duplInheritedMember
+std::unique_ptr<QgsFeatureRenderer> QgsInvertedPolygonRenderer::create( QDomElement &element, const QgsReadWriteContext &context ) // cppcheck-suppress duplInheritedMember
 {
-  QgsInvertedPolygonRenderer *r = new QgsInvertedPolygonRenderer();
+  auto r = std::make_unique<QgsInvertedPolygonRenderer>();
   //look for an embedded renderer <renderer-v2>
   QDomElement embeddedRendererElem = element.firstChildElement( u"renderer-v2"_s );
   if ( !embeddedRendererElem.isNull() )
   {
-    QgsFeatureRenderer *renderer = QgsFeatureRenderer::load( embeddedRendererElem, context );
-    r->setEmbeddedRenderer( renderer );
+    std::unique_ptr<QgsFeatureRenderer> renderer = QgsFeatureRenderer::load( embeddedRendererElem, context );
+    r->setEmbeddedRenderer( renderer.release() );
   }
   r->setPreprocessingEnabled( element.attribute( u"preprocessing"_s, u"0"_s ).toInt() == 1 );
   return r;
@@ -100,23 +100,23 @@ QDomElement QgsInvertedPolygonRenderer::save( QDomDocument &doc, const QgsReadWr
   return rendererElem;
 }
 
-QgsInvertedPolygonRenderer *QgsInvertedPolygonRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer ) // cppcheck-suppress duplInheritedMember
+std::unique_ptr<QgsInvertedPolygonRenderer> QgsInvertedPolygonRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer ) // cppcheck-suppress duplInheritedMember
 {
   if ( renderer->type() == "invertedPolygonRenderer"_L1 )
   {
-    return dynamic_cast<QgsInvertedPolygonRenderer *>( renderer->clone() );
+    return std::unique_ptr<QgsInvertedPolygonRenderer>( dynamic_cast<QgsInvertedPolygonRenderer *>( renderer->clone() ) );
   }
   else if ( renderer->type() == "singleSymbol"_L1 || renderer->type() == "categorizedSymbol"_L1 || renderer->type() == "graduatedSymbol"_L1 || renderer->type() == "RuleRenderer"_L1 )
   {
     auto res = std::make_unique< QgsInvertedPolygonRenderer >( renderer->clone() );
     renderer->copyRendererData( res.get() );
-    return res.release();
+    return res;
   }
   else if ( renderer->type() == "mergedFeatureRenderer"_L1 )
   {
     auto res = std::make_unique< QgsInvertedPolygonRenderer >( renderer->embeddedRenderer() ? renderer->embeddedRenderer()->clone() : nullptr );
     renderer->copyRendererData( res.get() );
-    return res.release();
+    return res;
   }
   return nullptr;
 }

--- a/src/core/symbology/qgsinvertedpolygonrenderer.h
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.h
@@ -59,7 +59,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsMergedFeatureRenderer
     QString dump() const override;
 
     //! Creates a renderer out of an XML, for loading
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY; // cppcheck-suppress duplInheritedMember
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context ); // cppcheck-suppress duplInheritedMember
 
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
 
@@ -86,7 +86,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsMergedFeatureRenderer
      * Creates a QgsInvertedPolygonRenderer by a conversion from an existing renderer.
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsInvertedPolygonRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY; // cppcheck-suppress duplInheritedMember
+    static std::unique_ptr<QgsInvertedPolygonRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer ); // cppcheck-suppress duplInheritedMember
 };
 
 

--- a/src/core/symbology/qgslinearreferencingsymbollayer.cpp
+++ b/src/core/symbology/qgslinearreferencingsymbollayer.cpp
@@ -113,7 +113,7 @@ QgsLinearReferencingSymbolLayer::QgsLinearReferencingSymbolLayer()
 
 QgsLinearReferencingSymbolLayer::~QgsLinearReferencingSymbolLayer() = default;
 
-QgsSymbolLayer *QgsLinearReferencingSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsLinearReferencingSymbolLayer::create( const QVariantMap &properties )
 {
   auto res = std::make_unique< QgsLinearReferencingSymbolLayer >();
   res->setPlacement( qgsEnumKeyToValue( properties.value( u"placement"_s ).toString(), Qgis::LinearReferencingPlacement::IntervalCartesian2D ) );
@@ -179,7 +179,7 @@ QgsSymbolLayer *QgsLinearReferencingSymbolLayer::create( const QVariantMap &prop
     res->setAverageAngleMapUnitScale( QgsSymbolLayerUtils::decodeMapUnitScale( properties[u"average_angle_map_unit_scale"_s].toString() ) );
   }
 
-  return res.release();
+  return res;
 }
 
 QgsLinearReferencingSymbolLayer *QgsLinearReferencingSymbolLayer::clone() const

--- a/src/core/symbology/qgslinearreferencingsymbollayer.h
+++ b/src/core/symbology/qgslinearreferencingsymbollayer.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsLinearReferencingSymbolLayer : public QgsLineSymbolLayer
      *
      * The caller takes ownership of the returned object.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     QgsLinearReferencingSymbolLayer *clone() const override SIP_FACTORY;
     QVariantMap properties() const override;

--- a/src/core/symbology/qgslinesymbol.cpp
+++ b/src/core/symbology/qgslinesymbol.cpp
@@ -22,12 +22,12 @@
 
 std::unique_ptr< QgsLineSymbol > QgsLineSymbol::createSimple( const QVariantMap &properties )
 {
-  QgsSymbolLayer *sl = QgsSimpleLineSymbolLayer::create( properties );
+  std::unique_ptr<QgsSymbolLayer> sl = QgsSimpleLineSymbolLayer::create( properties );
   if ( !sl )
     return nullptr;
 
   QgsSymbolLayerList layers;
-  layers.append( sl );
+  layers.append( sl.release() );
   return std::make_unique< QgsLineSymbol >( layers );
 }
 

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -104,7 +104,7 @@ QgsMapUnitScale QgsSimpleLineSymbolLayer::mapUnitScale() const
   return QgsMapUnitScale();
 }
 
-QgsSymbolLayer *QgsSimpleLineSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsSimpleLineSymbolLayer::create( const QVariantMap &props )
 {
   QColor color = DEFAULT_SIMPLELINE_COLOR;
   double width = DEFAULT_SIMPLELINE_WIDTH;
@@ -149,7 +149,7 @@ QgsSymbolLayer *QgsSimpleLineSymbolLayer::create( const QVariantMap &props )
     penStyle = QgsSymbolLayerUtils::decodePenStyle( props[u"penstyle"_s].toString() );
   }
 
-  QgsSimpleLineSymbolLayer *l = new QgsSimpleLineSymbolLayer( color, width, penStyle );
+  auto l = std::make_unique<QgsSimpleLineSymbolLayer>( color, width, penStyle );
   if ( props.contains( u"line_width_unit"_s ) )
   {
     l->setWidthUnit( QgsUnitTypes::decodeRenderUnit( props[u"line_width_unit"_s].toString() ) );
@@ -651,7 +651,7 @@ QString QgsSimpleLineSymbolLayer::ogrFeatureStyle( double mmScaleFactor, double 
   }
 }
 
-QgsSymbolLayer *QgsSimpleLineSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsSimpleLineSymbolLayer::createFromSld( QDomElement &element )
 {
   QgsDebugMsgLevel( u"Entered."_s, 4 );
 
@@ -685,7 +685,7 @@ QgsSymbolLayer *QgsSimpleLineSymbolLayer::createFromSld( QDomElement &element )
   width = width * scaleFactor;
   offset = offset * scaleFactor;
 
-  QgsSimpleLineSymbolLayer *l = new QgsSimpleLineSymbolLayer( color, width, penStyle );
+  auto l = std::make_unique<QgsSimpleLineSymbolLayer>( color, width, penStyle );
   l->setOutputUnit( sldUnitSize );
   l->setOffset( offset );
   l->setPenJoinStyle( penJoinStyle );
@@ -2556,7 +2556,7 @@ QgsMarkerLineSymbolLayer::QgsMarkerLineSymbolLayer( bool rotateMarker, double in
 
 QgsMarkerLineSymbolLayer::~QgsMarkerLineSymbolLayer() = default;
 
-QgsSymbolLayer *QgsMarkerLineSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsMarkerLineSymbolLayer::create( const QVariantMap &props )
 {
   bool rotate = DEFAULT_MARKERLINE_ROTATE;
   double interval = DEFAULT_MARKERLINE_INTERVAL;
@@ -2568,7 +2568,7 @@ QgsSymbolLayer *QgsMarkerLineSymbolLayer::create( const QVariantMap &props )
 
   auto x = std::make_unique< QgsMarkerLineSymbolLayer >( rotate, interval );
   setCommonProperties( x.get(), props );
-  return x.release();
+  return x;
 }
 
 QString QgsMarkerLineSymbolLayer::layerType() const
@@ -2695,7 +2695,7 @@ bool QgsMarkerLineSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, Q
   return true;
 }
 
-QgsSymbolLayer *QgsMarkerLineSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsMarkerLineSymbolLayer::createFromSld( QDomElement &element )
 {
   QgsDebugMsgLevel( u"Entered."_s, 4 );
 
@@ -2770,7 +2770,7 @@ QgsSymbolLayer *QgsMarkerLineSymbolLayer::createFromSld( QDomElement &element )
   interval = interval * scaleFactor;
   offset = offset * scaleFactor;
 
-  QgsMarkerLineSymbolLayer *x = new QgsMarkerLineSymbolLayer( rotateMarker );
+  auto x = std::make_unique<QgsMarkerLineSymbolLayer>( rotateMarker );
   x->setOutputUnit( sldUnitSize );
   x->setPlacements( placement );
   x->setInterval( interval );
@@ -2893,7 +2893,7 @@ QgsHashedLineSymbolLayer::QgsHashedLineSymbolLayer( bool rotateSymbol, double in
 
 QgsHashedLineSymbolLayer::~QgsHashedLineSymbolLayer() = default;
 
-QgsSymbolLayer *QgsHashedLineSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsHashedLineSymbolLayer::create( const QVariantMap &props )
 {
   bool rotate = DEFAULT_MARKERLINE_ROTATE;
   double interval = DEFAULT_MARKERLINE_INTERVAL;
@@ -2919,7 +2919,7 @@ QgsSymbolLayer *QgsHashedLineSymbolLayer::create( const QVariantMap &props )
   if ( props.contains( u"hash_length_map_unit_scale"_s ) )
     x->setHashLengthMapUnitScale( QgsSymbolLayerUtils::decodeMapUnitScale( props[u"hash_length_map_unit_scale"_s].toString() ) );
 
-  return x.release();
+  return x;
 }
 
 QString QgsHashedLineSymbolLayer::layerType() const
@@ -3470,7 +3470,7 @@ QgsRasterLineSymbolLayer::QgsRasterLineSymbolLayer( const QString &path )
 
 QgsRasterLineSymbolLayer::~QgsRasterLineSymbolLayer() = default;
 
-QgsSymbolLayer *QgsRasterLineSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsRasterLineSymbolLayer::create( const QVariantMap &properties )
 {
   auto res = std::make_unique<QgsRasterLineSymbolLayer>();
 
@@ -3513,7 +3513,7 @@ QgsSymbolLayer *QgsRasterLineSymbolLayer::create( const QVariantMap &properties 
     res->setOpacity( properties[u"alpha"_s].toDouble() );
   }
 
-  return res.release();
+  return res;
 }
 
 
@@ -3719,7 +3719,7 @@ QgsLineburstSymbolLayer::QgsLineburstSymbolLayer( const QColor &color, const QCo
 
 QgsLineburstSymbolLayer::~QgsLineburstSymbolLayer() = default;
 
-QgsSymbolLayer *QgsLineburstSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsLineburstSymbolLayer::create( const QVariantMap &properties )
 {
   auto res = std::make_unique<QgsLineburstSymbolLayer>();
 
@@ -3769,14 +3769,14 @@ QgsSymbolLayer *QgsLineburstSymbolLayer::create( const QVariantMap &properties )
   //attempt to create color ramp from props
   if ( properties.contains( u"rampType"_s ) && properties[u"rampType"_s] == QgsCptCityColorRamp::typeString() )
   {
-    res->setColorRamp( QgsCptCityColorRamp::create( properties ) );
+    res->setColorRamp( QgsCptCityColorRamp::create( properties ).release() );
   }
   else
   {
-    res->setColorRamp( QgsGradientColorRamp::create( properties ) );
+    res->setColorRamp( QgsGradientColorRamp::create( properties ).release() );
   }
 
-  return res.release();
+  return res;
 }
 
 QVariantMap QgsLineburstSymbolLayer::properties() const
@@ -3963,7 +3963,7 @@ QgsFilledLineSymbolLayer::QgsFilledLineSymbolLayer( double width, QgsFillSymbol 
 
 QgsFilledLineSymbolLayer::~QgsFilledLineSymbolLayer() = default;
 
-QgsSymbolLayer *QgsFilledLineSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsFilledLineSymbolLayer::create( const QVariantMap &props )
 {
   double width = DEFAULT_SIMPLELINE_WIDTH;
 
@@ -4013,7 +4013,7 @@ QgsSymbolLayer *QgsFilledLineSymbolLayer::create( const QVariantMap &props )
 
   l->restoreOldDataDefinedProperties( props );
 
-  return l.release();
+  return l;
 }
 
 QString QgsFilledLineSymbolLayer::layerType() const
@@ -4191,7 +4191,7 @@ QVariantMap QgsFilledLineSymbolLayer::properties() const
 
 QgsFilledLineSymbolLayer *QgsFilledLineSymbolLayer::clone() const
 {
-  std::unique_ptr< QgsFilledLineSymbolLayer > res( qgis::down_cast< QgsFilledLineSymbolLayer * >( QgsFilledLineSymbolLayer::create( properties() ) ) );
+  auto res = qgis::unique_ptr_static_cast<QgsFilledLineSymbolLayer>( QgsFilledLineSymbolLayer::create( properties() ) );
   copyCommonProperties( res.get() );
   res->setSubSymbol( mFill->clone() );
   return res.release();

--- a/src/core/symbology/qgslinesymbollayer.h
+++ b/src/core/symbology/qgslinesymbollayer.h
@@ -61,12 +61,12 @@ class CORE_EXPORT QgsSimpleLineSymbolLayer : public QgsLineSymbolLayer
      * serialized in the \a properties map (corresponding to the output from
      * QgsSimpleLineSymbolLayer::properties() ).
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Creates a new QgsSimpleLineSymbolLayer from an SLD XML DOM \a element.
      */
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     QString layerType() const override;
     Qgis::SymbolLayerFlags flags() const override;
@@ -1122,12 +1122,12 @@ class CORE_EXPORT QgsMarkerLineSymbolLayer : public QgsTemplatedLineSymbolLayerB
      * serialized in the \a properties map (corresponding to the output from
      * QgsMarkerLineSymbolLayer::properties() ).
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Creates a new QgsMarkerLineSymbolLayer from an SLD XML DOM \a element.
      */
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     // implemented from base classes
 
@@ -1209,7 +1209,7 @@ class CORE_EXPORT QgsHashedLineSymbolLayer : public QgsTemplatedLineSymbolLayerB
      * serialized in the \a properties map (corresponding to the output from
      * QgsHashedLineSymbolLayer::properties() ).
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     QString layerType() const override;
     void startRender( QgsSymbolRenderContext &context ) override;
@@ -1388,7 +1388,7 @@ class CORE_EXPORT QgsRasterLineSymbolLayer : public QgsAbstractBrushedLineSymbol
      * serialized in the \a properties map (corresponding to the output from
      * QgsRasterLineSymbolLayer::properties() ).
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Turns relative paths in properties map to absolute when reading and vice versa when writing.
@@ -1469,7 +1469,7 @@ class CORE_EXPORT QgsLineburstSymbolLayer : public QgsAbstractBrushedLineSymbolL
      * serialized in the \a properties map (corresponding to the output from
      * QgsLineburstSymbolLayer::properties() ).
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     QString layerType() const override;
     Qgis::SymbolLayerFlags flags() const override;
@@ -1563,7 +1563,7 @@ class CORE_EXPORT QgsFilledLineSymbolLayer : public QgsLineSymbolLayer
      * serialized in the \a properties map (corresponding to the output from
      * QgsFilledLineSymbolLayer::properties() ).
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     QString layerType() const override;
     void startRender( QgsSymbolRenderContext &context ) override;

--- a/src/core/symbology/qgsmapinfosymbolconverter.cpp
+++ b/src/core/symbology/qgsmapinfosymbolconverter.cpp
@@ -38,7 +38,9 @@ void QgsMapInfoSymbolConversionContext::pushWarning( const QString &warning )
 }
 
 
-QgsLineSymbol *QgsMapInfoSymbolConverter::convertLineSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, double size, Qgis::RenderUnit sizeUnit, bool interleaved )
+std::unique_ptr<QgsLineSymbol> QgsMapInfoSymbolConverter::convertLineSymbol(
+  int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, double size, Qgis::RenderUnit sizeUnit, bool interleaved
+)
 {
   auto simpleLine = std::make_unique< QgsSimpleLineSymbolLayer >( foreColor, size );
   simpleLine->setWidthUnit( sizeUnit );
@@ -1102,10 +1104,10 @@ QgsLineSymbol *QgsMapInfoSymbolConverter::convertLineSymbol( int identifier, Qgs
     symbol->appendSymbolLayer( simpleLine2.release() );
   }
 
-  return symbol.release();
+  return symbol;
 }
 
-QgsFillSymbol *QgsMapInfoSymbolConverter::convertFillSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, const QColor &backColor )
+std::unique_ptr<QgsFillSymbol> QgsMapInfoSymbolConverter::convertFillSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, const QColor &backColor )
 {
   Qt::BrushStyle style = Qt::SolidPattern;
 
@@ -1393,10 +1395,10 @@ QgsFillSymbol *QgsMapInfoSymbolConverter::convertFillSymbol( int identifier, Qgs
 
     layers << lineFill.release();
   }
-  return new QgsFillSymbol( layers );
+  return std::make_unique<QgsFillSymbol>( layers );
 }
 
-QgsMarkerSymbol *QgsMapInfoSymbolConverter::convertMarkerSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &color, double size, Qgis::RenderUnit sizeUnit )
+std::unique_ptr<QgsMarkerSymbol> QgsMapInfoSymbolConverter::convertMarkerSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &color, double size, Qgis::RenderUnit sizeUnit )
 {
   Qgis::MarkerShape shape;
   bool isFilled = true;
@@ -1564,5 +1566,5 @@ QgsMarkerSymbol *QgsMapInfoSymbolConverter::convertMarkerSymbol( int identifier,
     symbols << simpleMarker.release();
   }
 
-  return new QgsMarkerSymbol( symbols );
+  return std::make_unique<QgsMarkerSymbol>( symbols );
 }

--- a/src/core/symbology/qgsmapinfosymbolconverter.h
+++ b/src/core/symbology/qgsmapinfosymbolconverter.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsMapInfoSymbolConverter
      *
      * The caller takes ownership of the returned symbol.
      */
-    static QgsLineSymbol *convertLineSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, double size, Qgis::RenderUnit sizeUnit, bool interleaved = false ) SIP_FACTORY;
+    static std::unique_ptr<QgsLineSymbol> convertLineSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, double size, Qgis::RenderUnit sizeUnit, bool interleaved = false );
     // clang-format on
 
     /**
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsMapInfoSymbolConverter
      *
      * The caller takes ownership of the returned symbol.
      */
-    static QgsFillSymbol *convertFillSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, const QColor &backColor = QColor() ) SIP_FACTORY;
+    static std::unique_ptr<QgsFillSymbol> convertFillSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &foreColor, const QColor &backColor = QColor() );
 
     /**
      * Converts the MapInfo marker symbol with the specified \a identifier to a QgsMarkerSymbol.
@@ -87,7 +87,7 @@ class CORE_EXPORT QgsMapInfoSymbolConverter
      *
      * The caller takes ownership of the returned symbol.
      */
-    static QgsMarkerSymbol *convertMarkerSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &color, double size, Qgis::RenderUnit sizeUnit ) SIP_FACTORY;
+    static std::unique_ptr<QgsMarkerSymbol> convertMarkerSymbol( int identifier, QgsMapInfoSymbolConversionContext &context, const QColor &color, double size, Qgis::RenderUnit sizeUnit );
 };
 
 #endif // QGSMAPINFOSYMBOLCONVERTER_H

--- a/src/core/symbology/qgsmarkersymbol.cpp
+++ b/src/core/symbology/qgsmarkersymbol.cpp
@@ -25,12 +25,12 @@
 
 std::unique_ptr< QgsMarkerSymbol > QgsMarkerSymbol::createSimple( const QVariantMap &properties )
 {
-  QgsSymbolLayer *sl = QgsSimpleMarkerSymbolLayer::create( properties );
+  std::unique_ptr<QgsSymbolLayer> sl = QgsSimpleMarkerSymbolLayer::create( properties );
   if ( !sl )
     return nullptr;
 
   QgsSymbolLayerList layers;
-  layers.append( sl );
+  layers.append( sl.release() );
   return std::make_unique< QgsMarkerSymbol >( layers );
 }
 

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -945,7 +945,7 @@ QgsSimpleMarkerSymbolLayer::QgsSimpleMarkerSymbolLayer(
 
 QgsSimpleMarkerSymbolLayer::~QgsSimpleMarkerSymbolLayer() = default;
 
-QgsSymbolLayer *QgsSimpleMarkerSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsSimpleMarkerSymbolLayer::create( const QVariantMap &props )
 {
   Qgis::MarkerShape shape = Qgis::MarkerShape::Circle;
   QColor color = DEFAULT_SIMPLEMARKER_COLOR;
@@ -985,7 +985,7 @@ QgsSymbolLayer *QgsSimpleMarkerSymbolLayer::create( const QVariantMap &props )
   if ( props.contains( u"scale_method"_s ) )
     scaleMethod = QgsSymbolLayerUtils::decodeScaleMethod( props[u"scale_method"_s].toString() );
 
-  QgsSimpleMarkerSymbolLayer *m = new QgsSimpleMarkerSymbolLayer( shape, size, angle, scaleMethod, color, strokeColor, penJoinStyle );
+  auto m = std::make_unique<QgsSimpleMarkerSymbolLayer>( shape, size, angle, scaleMethod, color, strokeColor, penJoinStyle );
   if ( props.contains( u"offset"_s ) )
     m->setOffset( QgsSymbolLayerUtils::decodePoint( props[u"offset"_s].toString() ) );
   if ( props.contains( u"offset_unit"_s ) )
@@ -1501,7 +1501,7 @@ QString QgsSimpleMarkerSymbolLayer::ogrFeatureStyle( double mmScaleFactor, doubl
   return ogrString;
 }
 
-QgsSymbolLayer *QgsSimpleMarkerSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsSimpleMarkerSymbolLayer::createFromSld( QDomElement &element )
 {
   QgsDebugMsgLevel( u"Entered."_s, 4 );
 
@@ -1539,7 +1539,7 @@ QgsSymbolLayer *QgsSimpleMarkerSymbolLayer::createFromSld( QDomElement &element 
   offset.setX( offset.x() * scaleFactor );
   offset.setY( offset.y() * scaleFactor );
 
-  QgsSimpleMarkerSymbolLayer *m = new QgsSimpleMarkerSymbolLayer( shape, size );
+  auto m = std::make_unique<QgsSimpleMarkerSymbolLayer>( shape, size );
   m->setOutputUnit( sldUnitSize );
   m->setColor( color );
   m->setStrokeColor( strokeColor );
@@ -1869,7 +1869,7 @@ QgsFilledMarkerSymbolLayer::QgsFilledMarkerSymbolLayer( Qgis::MarkerShape shape,
 
 QgsFilledMarkerSymbolLayer::~QgsFilledMarkerSymbolLayer() = default;
 
-QgsSymbolLayer *QgsFilledMarkerSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsFilledMarkerSymbolLayer::create( const QVariantMap &props )
 {
   QString name = DEFAULT_SIMPLEMARKER_NAME;
   double size = DEFAULT_SIMPLEMARKER_SIZE;
@@ -1885,7 +1885,7 @@ QgsSymbolLayer *QgsFilledMarkerSymbolLayer::create( const QVariantMap &props )
   if ( props.contains( u"scale_method"_s ) )
     scaleMethod = QgsSymbolLayerUtils::decodeScaleMethod( props[u"scale_method"_s].toString() );
 
-  QgsFilledMarkerSymbolLayer *m = new QgsFilledMarkerSymbolLayer( decodeShape( name ), size, angle, scaleMethod );
+  auto m = std::make_unique<QgsFilledMarkerSymbolLayer>( decodeShape( name ), size, angle, scaleMethod );
   if ( props.contains( u"offset"_s ) )
     m->setOffset( QgsSymbolLayerUtils::decodePoint( props[u"offset"_s].toString() ) );
   if ( props.contains( u"offset_unit"_s ) )
@@ -1974,10 +1974,10 @@ QVariantMap QgsFilledMarkerSymbolLayer::properties() const
 
 QgsFilledMarkerSymbolLayer *QgsFilledMarkerSymbolLayer::clone() const
 {
-  QgsFilledMarkerSymbolLayer *m = static_cast< QgsFilledMarkerSymbolLayer * >( QgsFilledMarkerSymbolLayer::create( properties() ) );
-  copyCommonProperties( m );
+  auto m = qgis::unique_ptr_static_cast<QgsFilledMarkerSymbolLayer>( QgsFilledMarkerSymbolLayer::create( properties() ) );
+  copyCommonProperties( m.get() );
   m->setSubSymbol( mFill->clone() );
-  return m;
+  return m.release();
 }
 
 QgsSymbol *QgsFilledMarkerSymbolLayer::subSymbol()
@@ -2128,7 +2128,7 @@ QgsSvgMarkerSymbolLayer::QgsSvgMarkerSymbolLayer( const QgsSvgMarkerSymbolLayer 
 
 QgsSvgMarkerSymbolLayer::~QgsSvgMarkerSymbolLayer() = default;
 
-QgsSymbolLayer *QgsSvgMarkerSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsSvgMarkerSymbolLayer::create( const QVariantMap &props )
 {
   QString name;
   double size = DEFAULT_SVGMARKER_SIZE;
@@ -2144,7 +2144,7 @@ QgsSymbolLayer *QgsSvgMarkerSymbolLayer::create( const QVariantMap &props )
   if ( props.contains( u"scale_method"_s ) )
     scaleMethod = QgsSymbolLayerUtils::decodeScaleMethod( props[u"scale_method"_s].toString() );
 
-  QgsSvgMarkerSymbolLayer *m = new QgsSvgMarkerSymbolLayer( name, size, angle, scaleMethod );
+  auto m = std::make_unique<QgsSvgMarkerSymbolLayer>( name, size, angle, scaleMethod );
 
   if ( props.contains( u"size_unit"_s ) )
     m->setSizeUnit( QgsUnitTypes::decodeRenderUnit( props[u"size_unit"_s].toString() ) );
@@ -2740,7 +2740,7 @@ bool QgsSvgMarkerSymbolLayer::writeSldMarker( QDomDocument &doc, QDomElement &el
   return true;
 }
 
-QgsSymbolLayer *QgsSvgMarkerSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsSvgMarkerSymbolLayer::createFromSld( QDomElement &element )
 {
   QgsDebugMsgLevel( u"Entered."_s, 4 );
 
@@ -2797,7 +2797,7 @@ QgsSymbolLayer *QgsSvgMarkerSymbolLayer::createFromSld( QDomElement &element )
     realPath = svgUrl.path();
   }
 
-  QgsSvgMarkerSymbolLayer *m = new QgsSvgMarkerSymbolLayer( realPath, size );
+  auto m = std::make_unique<QgsSvgMarkerSymbolLayer>( realPath, size );
 
   QMap<QString, QgsProperty> params;
 
@@ -3043,7 +3043,7 @@ QgsRasterMarkerSymbolLayer::QgsRasterMarkerSymbolLayer( const QString &path, dou
 
 QgsRasterMarkerSymbolLayer::~QgsRasterMarkerSymbolLayer() = default;
 
-QgsSymbolLayer *QgsRasterMarkerSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsRasterMarkerSymbolLayer::create( const QVariantMap &props )
 {
   QString path;
   double size = DEFAULT_RASTERMARKER_SIZE;
@@ -3061,10 +3061,10 @@ QgsSymbolLayer *QgsRasterMarkerSymbolLayer::create( const QVariantMap &props )
 
   auto m = std::make_unique< QgsRasterMarkerSymbolLayer >( path, size, angle, scaleMethod );
   m->setCommonProperties( props );
-  return m.release();
+  return m;
 }
 
-QgsSymbolLayer *QgsRasterMarkerSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsRasterMarkerSymbolLayer::createFromSld( QDomElement &element )
 {
   const QDomElement graphicElem = element.firstChildElement( u"Graphic"_s );
   if ( graphicElem.isNull() )
@@ -3092,7 +3092,7 @@ QgsSymbolLayer *QgsRasterMarkerSymbolLayer::createFromSld( QDomElement &element 
     return nullptr;
   }
 
-  QgsRasterMarkerSymbolLayer *m = new QgsRasterMarkerSymbolLayer( url );
+  auto m = std::make_unique<QgsRasterMarkerSymbolLayer>( url );
   // TODO: parse other attributes from the SLD spec (Opacity, Size, Rotation, AnchorPoint, Displacement)
   return m;
 }
@@ -3593,7 +3593,7 @@ QgsFontMarkerSymbolLayer::QgsFontMarkerSymbolLayer( const QString &fontFamily, Q
 
 QgsFontMarkerSymbolLayer::~QgsFontMarkerSymbolLayer() = default;
 
-QgsSymbolLayer *QgsFontMarkerSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsFontMarkerSymbolLayer::create( const QVariantMap &props )
 {
   QString fontFamily = DEFAULT_FONTMARKER_FONT;
   QString string = DEFAULT_FONTMARKER_CHR;
@@ -3623,7 +3623,7 @@ QgsSymbolLayer *QgsFontMarkerSymbolLayer::create( const QVariantMap &props )
   if ( props.contains( u"angle"_s ) )
     angle = props[u"angle"_s].toDouble();
 
-  QgsFontMarkerSymbolLayer *m = new QgsFontMarkerSymbolLayer( fontFamily, string, pointSize, color, angle );
+  auto m = std::make_unique<QgsFontMarkerSymbolLayer>( fontFamily, string, pointSize, color, angle );
 
   if ( props.contains( u"font_style"_s ) )
     m->setFontStyle( props[u"font_style"_s].toString() );
@@ -4121,7 +4121,7 @@ QRectF QgsFontMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &
   return symbolBounds;
 }
 
-QgsSymbolLayer *QgsFontMarkerSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsFontMarkerSymbolLayer::createFromSld( QDomElement &element )
 {
   QgsDebugMsgLevel( u"Entered."_s, 4 );
 
@@ -4162,7 +4162,7 @@ QgsSymbolLayer *QgsFontMarkerSymbolLayer::createFromSld( QDomElement &element )
   offset.setY( offset.y() * scaleFactor );
   size = size * scaleFactor;
 
-  QgsMarkerSymbolLayer *m = new QgsFontMarkerSymbolLayer( fontFamily, QChar( chr ), size, color );
+  auto m = std::make_unique<QgsFontMarkerSymbolLayer>( fontFamily, QChar( chr ), size, color );
   m->setOutputUnit( sldUnitSize );
   m->setAngle( angle );
   m->setOffset( offset );
@@ -4213,7 +4213,7 @@ QgsAnimatedMarkerSymbolLayer::QgsAnimatedMarkerSymbolLayer( const QString &path,
 
 QgsAnimatedMarkerSymbolLayer::~QgsAnimatedMarkerSymbolLayer() = default;
 
-QgsSymbolLayer *QgsAnimatedMarkerSymbolLayer::create( const QVariantMap &properties ) // cppcheck-suppress duplInheritedMember
+std::unique_ptr<QgsSymbolLayer> QgsAnimatedMarkerSymbolLayer::create( const QVariantMap &properties ) // cppcheck-suppress duplInheritedMember
 {
   QString path;
   double size = DEFAULT_RASTERMARKER_SIZE;
@@ -4230,7 +4230,7 @@ QgsSymbolLayer *QgsAnimatedMarkerSymbolLayer::create( const QVariantMap &propert
   m->setFrameRate( properties.value( u"frameRate"_s, u"10"_s ).toDouble() );
 
   m->setCommonProperties( properties );
-  return m.release();
+  return m;
 }
 
 QString QgsAnimatedMarkerSymbolLayer::layerType() const

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -201,14 +201,14 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayer : public QgsSimpleMarkerSymbolLayer
      * \param properties a property map containing symbol properties (see properties())
      * \returns new QgsSimpleMarkerSymbolLayer
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Creates a new QgsSimpleMarkerSymbolLayer from an SLD XML element.
      * \param element XML element containing SLD definition of symbol
      * \returns new QgsSimpleMarkerSymbolLayer
      */
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     // reimplemented from base classes
 
@@ -448,7 +448,7 @@ class CORE_EXPORT QgsFilledMarkerSymbolLayer : public QgsSimpleMarkerSymbolLayer
      * \param properties a property map containing symbol properties (see properties())
      * \returns new QgsFilledMarkerSymbolLayer
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     QString layerType() const override;
     void startRender( QgsSymbolRenderContext &context ) override;
@@ -501,8 +501,8 @@ class CORE_EXPORT QgsSvgMarkerSymbolLayer : public QgsMarkerSymbolLayer
     // static stuff
 
     //! Creates the symbol
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     /**
      * Turns relative paths in properties map to absolute when reading and vice versa when writing.
@@ -689,7 +689,7 @@ class CORE_EXPORT QgsRasterMarkerSymbolLayer : public QgsMarkerSymbolLayer
      * Creates a raster marker symbol layer from a string map of properties.
      * \param properties QVariantMap properties object
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Creates a new QgsRasterMarkerSymbolLayer from an SLD XML element.
@@ -698,7 +698,7 @@ class CORE_EXPORT QgsRasterMarkerSymbolLayer : public QgsMarkerSymbolLayer
      *
      * \since QGIS 3.44
      */
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     /**
      * Turns relative paths in properties map to absolute when reading and vice versa when writing.
@@ -875,12 +875,12 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
     /**
      * Creates a new QgsFontMarkerSymbolLayer from a property map (see properties())
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     /**
      * Creates a new QgsFontMarkerSymbolLayer from an SLD XML \a element.
      */
-    static QgsSymbolLayer *createFromSld( QDomElement &element ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     /**
      * Resolves fonts from a \a properties map, raising warnings in the specified \a context if the
@@ -1097,7 +1097,7 @@ class CORE_EXPORT QgsAnimatedMarkerSymbolLayer : public QgsRasterMarkerSymbolLay
     /**
      * Creates an animated marker symbol layer from a string map of \a properties.
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY; // cppcheck-suppress duplInheritedMember
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() ); // cppcheck-suppress duplInheritedMember
 
     // implemented from base classes
 

--- a/src/core/symbology/qgsmasksymbollayer.cpp
+++ b/src/core/symbology/qgsmasksymbollayer.cpp
@@ -47,9 +47,9 @@ bool QgsMaskMarkerSymbolLayer::setSubSymbol( QgsSymbol *symbol )
   return false;
 }
 
-QgsSymbolLayer *QgsMaskMarkerSymbolLayer::create( const QVariantMap &props )
+std::unique_ptr<QgsSymbolLayer> QgsMaskMarkerSymbolLayer::create( const QVariantMap &props )
 {
-  QgsMaskMarkerSymbolLayer *l = new QgsMaskMarkerSymbolLayer();
+  auto l = std::make_unique<QgsMaskMarkerSymbolLayer>();
 
   l->setSubSymbol( QgsMarkerSymbol::createSimple( props ).release() );
 
@@ -62,11 +62,11 @@ QgsSymbolLayer *QgsMaskMarkerSymbolLayer::create( const QVariantMap &props )
 
 QgsMaskMarkerSymbolLayer *QgsMaskMarkerSymbolLayer::clone() const
 {
-  QgsMaskMarkerSymbolLayer *l = static_cast<QgsMaskMarkerSymbolLayer *>( create( properties() ) );
+  auto l = qgis::unique_ptr_static_cast<QgsMaskMarkerSymbolLayer>( create( properties() ) );
   l->setSubSymbol( mSymbol->clone() );
   l->setMasks( mMaskedSymbolLayers );
-  copyCommonProperties( l );
-  return l;
+  copyCommonProperties( l.get() );
+  return l.release();
 }
 
 QgsSymbol *QgsMaskMarkerSymbolLayer::subSymbol()

--- a/src/core/symbology/qgsmasksymbollayer.h
+++ b/src/core/symbology/qgsmasksymbollayer.h
@@ -46,7 +46,7 @@ class CORE_EXPORT QgsMaskMarkerSymbolLayer : public QgsMarkerSymbolLayer
      *
      * \returns A new QgsMaskMarkerSymbolLayer
      */
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
 
     QgsMaskMarkerSymbolLayer *clone() const override SIP_FACTORY;
     QgsSymbol *subSymbol() override;

--- a/src/core/symbology/qgsmergedfeaturerenderer.cpp
+++ b/src/core/symbology/qgsmergedfeaturerenderer.cpp
@@ -451,15 +451,15 @@ QgsMergedFeatureRenderer *QgsMergedFeatureRenderer::clone() const
   return newRenderer;
 }
 
-QgsFeatureRenderer *QgsMergedFeatureRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsMergedFeatureRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
-  QgsMergedFeatureRenderer *r = new QgsMergedFeatureRenderer( nullptr );
+  auto r = std::make_unique<QgsMergedFeatureRenderer>( nullptr );
   //look for an embedded renderer <renderer-v2>
   QDomElement embeddedRendererElem = element.firstChildElement( u"renderer-v2"_s );
   if ( !embeddedRendererElem.isNull() )
   {
-    QgsFeatureRenderer *renderer = QgsFeatureRenderer::load( embeddedRendererElem, context );
-    r->setEmbeddedRenderer( renderer );
+    std::unique_ptr<QgsFeatureRenderer> renderer = QgsFeatureRenderer::load( embeddedRendererElem, context );
+    r->setEmbeddedRenderer( renderer.release() );
   }
   return r;
 }
@@ -579,24 +579,24 @@ bool QgsMergedFeatureRenderer::willRenderFeature( const QgsFeature &feature, Qgs
   return mSubRenderer->willRenderFeature( feature, context );
 }
 
-QgsMergedFeatureRenderer *QgsMergedFeatureRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
+std::unique_ptr<QgsMergedFeatureRenderer> QgsMergedFeatureRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
   if ( renderer->type() == "mergedFeatureRenderer"_L1 )
   {
-    return dynamic_cast<QgsMergedFeatureRenderer *>( renderer->clone() );
+    return std::unique_ptr<QgsMergedFeatureRenderer>( dynamic_cast<QgsMergedFeatureRenderer *>( renderer->clone() ) );
   }
 
   if ( renderer->type() == "singleSymbol"_L1 || renderer->type() == "categorizedSymbol"_L1 || renderer->type() == "graduatedSymbol"_L1 || renderer->type() == "RuleRenderer"_L1 )
   {
     auto res = std::make_unique< QgsMergedFeatureRenderer >( renderer->clone() );
     renderer->copyRendererData( res.get() );
-    return res.release();
+    return res;
   }
   else if ( renderer->type() == "invertedPolygonRenderer"_L1 )
   {
     auto res = std::make_unique< QgsMergedFeatureRenderer >( renderer->embeddedRenderer() ? renderer->embeddedRenderer()->clone() : nullptr );
     renderer->copyRendererData( res.get() );
-    return res.release();
+    return res;
   }
   return nullptr;
 }

--- a/src/core/symbology/qgsmergedfeaturerenderer.h
+++ b/src/core/symbology/qgsmergedfeaturerenderer.h
@@ -52,7 +52,7 @@ class CORE_EXPORT QgsMergedFeatureRenderer : public QgsFeatureRenderer
     QgsMergedFeatureRenderer &operator=( const QgsMergedFeatureRenderer & ) = delete;
 
     //! Creates a renderer out of an XML, for loading
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 
     QgsMergedFeatureRenderer *clone() const override SIP_FACTORY;
     void startRender( QgsRenderContext &context, const QgsFields &fields ) override;
@@ -102,7 +102,7 @@ class CORE_EXPORT QgsMergedFeatureRenderer : public QgsFeatureRenderer
      * Creates a QgsMergedFeatureRenderer by a conversion from an existing renderer.
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsMergedFeatureRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<QgsMergedFeatureRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 
   protected:
     /**

--- a/src/core/symbology/qgsnullsymbolrenderer.cpp
+++ b/src/core/symbology/qgsnullsymbolrenderer.cpp
@@ -54,7 +54,7 @@ bool QgsNullSymbolRenderer::renderFeature( const QgsFeature &feature, QgsRenderC
   if ( !mSymbol )
   {
     //create default symbol
-    mSymbol.reset( QgsSymbol::defaultSymbol( feature.geometry().type() ) );
+    mSymbol = QgsSymbol::defaultSymbol( feature.geometry().type() );
     mSymbol->startRender( context );
   }
 
@@ -101,11 +101,11 @@ QgsSymbolList QgsNullSymbolRenderer::symbols( QgsRenderContext & ) const
   return QgsSymbolList();
 }
 
-QgsFeatureRenderer *QgsNullSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsNullSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
   Q_UNUSED( element )
   Q_UNUSED( context )
-  QgsNullSymbolRenderer *r = new QgsNullSymbolRenderer();
+  auto r = std::make_unique<QgsNullSymbolRenderer>();
   return r;
 }
 
@@ -120,9 +120,9 @@ QDomElement QgsNullSymbolRenderer::save( QDomDocument &doc, const QgsReadWriteCo
   return rendererElem;
 }
 
-QgsNullSymbolRenderer *QgsNullSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
+std::unique_ptr<QgsNullSymbolRenderer> QgsNullSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
   auto res = std::make_unique< QgsNullSymbolRenderer >();
   renderer->copyRendererData( res.get() );
-  return res.release();
+  return res;
 }

--- a/src/core/symbology/qgsnullsymbolrenderer.h
+++ b/src/core/symbology/qgsnullsymbolrenderer.h
@@ -53,7 +53,7 @@ class CORE_EXPORT QgsNullSymbolRenderer : public QgsFeatureRenderer
      * \param context reading context
      * \returns new null symbol renderer
      */
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
 
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsNullSymbolRenderer : public QgsFeatureRenderer
      * \param renderer renderer to convert from
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsNullSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<QgsNullSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 
   private:
     //! Symbol to use for rendering selected features

--- a/src/core/symbology/qgspointclusterrenderer.cpp
+++ b/src/core/symbology/qgspointclusterrenderer.cpp
@@ -111,9 +111,9 @@ void QgsPointClusterRenderer::stopRender( QgsRenderContext &context )
   }
 }
 
-QgsFeatureRenderer *QgsPointClusterRenderer::create( QDomElement &symbologyElem, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsPointClusterRenderer::create( QDomElement &symbologyElem, const QgsReadWriteContext &context )
 {
-  QgsPointClusterRenderer *r = new QgsPointClusterRenderer();
+  auto r = std::make_unique<QgsPointClusterRenderer>();
   r->setTolerance( symbologyElem.attribute( u"tolerance"_s, u"0.00001"_s ).toDouble() );
   r->setToleranceUnit( QgsUnitTypes::decodeRenderUnit( symbologyElem.attribute( u"toleranceUnit"_s, u"MapUnit"_s ) ) );
   r->setToleranceMapUnitScale( QgsSymbolLayerUtils::decodeMapUnitScale( symbologyElem.attribute( u"toleranceUnitScale"_s ) ) );
@@ -122,7 +122,7 @@ QgsFeatureRenderer *QgsPointClusterRenderer::create( QDomElement &symbologyElem,
   QDomElement embeddedRendererElem = symbologyElem.firstChildElement( u"renderer-v2"_s );
   if ( !embeddedRendererElem.isNull() )
   {
-    r->setEmbeddedRenderer( QgsFeatureRenderer::load( embeddedRendererElem, context ) );
+    r->setEmbeddedRenderer( QgsFeatureRenderer::load( embeddedRendererElem, context ).release() );
   }
 
   //center symbol
@@ -191,29 +191,29 @@ void QgsPointClusterRenderer::setClusterSymbol( QgsMarkerSymbol *symbol )
   mClusterSymbol.reset( symbol );
 }
 
-QgsPointClusterRenderer *QgsPointClusterRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
+std::unique_ptr<QgsPointClusterRenderer> QgsPointClusterRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
   if ( renderer->type() == "pointCluster"_L1 )
   {
-    return dynamic_cast<QgsPointClusterRenderer *>( renderer->clone() );
+    return std::unique_ptr<QgsPointClusterRenderer>( dynamic_cast<QgsPointClusterRenderer *>( renderer->clone() ) );
   }
   else if ( renderer->type() == "singleSymbol"_L1 || renderer->type() == "categorizedSymbol"_L1 || renderer->type() == "graduatedSymbol"_L1 || renderer->type() == "RuleRenderer"_L1 )
   {
-    QgsPointClusterRenderer *pointRenderer = new QgsPointClusterRenderer();
+    auto pointRenderer = std::make_unique<QgsPointClusterRenderer>();
     pointRenderer->setEmbeddedRenderer( renderer->clone() );
-    renderer->copyRendererData( pointRenderer );
+    renderer->copyRendererData( pointRenderer.get() );
     return pointRenderer;
   }
   else if ( renderer->type() == "pointDisplacement"_L1 )
   {
-    QgsPointClusterRenderer *pointRenderer = new QgsPointClusterRenderer();
+    auto pointRenderer = std::make_unique<QgsPointClusterRenderer>();
     const QgsPointDisplacementRenderer *displacementRenderer = static_cast< const QgsPointDisplacementRenderer * >( renderer );
     if ( displacementRenderer->embeddedRenderer() )
       pointRenderer->setEmbeddedRenderer( displacementRenderer->embeddedRenderer()->clone() );
     pointRenderer->setTolerance( displacementRenderer->tolerance() );
     pointRenderer->setToleranceUnit( displacementRenderer->toleranceUnit() );
     pointRenderer->setToleranceMapUnitScale( displacementRenderer->toleranceMapUnitScale() );
-    renderer->copyRendererData( pointRenderer );
+    renderer->copyRendererData( pointRenderer.get() );
     return pointRenderer;
   }
   else

--- a/src/core/symbology/qgspointclusterrenderer.h
+++ b/src/core/symbology/qgspointclusterrenderer.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsPointClusterRenderer : public QgsPointDistanceRenderer
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     //! Creates a renderer from XML element
-    static QgsFeatureRenderer *create( QDomElement &symbologyElem, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &symbologyElem, const QgsReadWriteContext &context );
 
     /**
      * Returns the symbol used for rendering clustered groups (but not ownership of the symbol).
@@ -60,7 +60,7 @@ class CORE_EXPORT QgsPointClusterRenderer : public QgsPointDistanceRenderer
      * Creates a QgsPointClusterRenderer from an existing renderer.
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsPointClusterRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<QgsPointClusterRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 
   private:
 #ifdef SIP_RUN

--- a/src/core/symbology/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology/qgspointdisplacementrenderer.cpp
@@ -167,9 +167,9 @@ void QgsPointDisplacementRenderer::stopRender( QgsRenderContext &context )
   }
 }
 
-QgsFeatureRenderer *QgsPointDisplacementRenderer::create( QDomElement &symbologyElem, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsPointDisplacementRenderer::create( QDomElement &symbologyElem, const QgsReadWriteContext &context )
 {
-  QgsPointDisplacementRenderer *r = new QgsPointDisplacementRenderer();
+  auto r = std::make_unique<QgsPointDisplacementRenderer>();
   r->setLabelAttributeName( symbologyElem.attribute( u"labelAttributeName"_s ) );
   QFont labelFont;
   if ( !QgsFontUtils::setFromXmlChildNode( labelFont, symbologyElem, u"labelFontProperties"_s ) )
@@ -192,7 +192,7 @@ QgsFeatureRenderer *QgsPointDisplacementRenderer::create( QDomElement &symbology
   QDomElement embeddedRendererElem = symbologyElem.firstChildElement( u"renderer-v2"_s );
   if ( !embeddedRendererElem.isNull() )
   {
-    r->setEmbeddedRenderer( QgsFeatureRenderer::load( embeddedRendererElem, context ) );
+    r->setEmbeddedRenderer( QgsFeatureRenderer::load( embeddedRendererElem, context ).release() );
   }
 
   //center symbol
@@ -489,29 +489,29 @@ void QgsPointDisplacementRenderer::drawSymbols( const ClusteredGroup &group, Qgs
   }
 }
 
-QgsPointDisplacementRenderer *QgsPointDisplacementRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
+std::unique_ptr<QgsPointDisplacementRenderer> QgsPointDisplacementRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
   if ( renderer->type() == "pointDisplacement"_L1 )
   {
-    return dynamic_cast<QgsPointDisplacementRenderer *>( renderer->clone() );
+    return std::unique_ptr<QgsPointDisplacementRenderer>( dynamic_cast<QgsPointDisplacementRenderer *>( renderer->clone() ) );
   }
   else if ( renderer->type() == "singleSymbol"_L1 || renderer->type() == "categorizedSymbol"_L1 || renderer->type() == "graduatedSymbol"_L1 || renderer->type() == "RuleRenderer"_L1 )
   {
-    QgsPointDisplacementRenderer *pointRenderer = new QgsPointDisplacementRenderer();
+    auto pointRenderer = std::make_unique<QgsPointDisplacementRenderer>();
     pointRenderer->setEmbeddedRenderer( renderer->clone() );
-    renderer->copyRendererData( pointRenderer );
+    renderer->copyRendererData( pointRenderer.get() );
     return pointRenderer;
   }
   else if ( renderer->type() == "pointCluster"_L1 )
   {
-    QgsPointDisplacementRenderer *pointRenderer = new QgsPointDisplacementRenderer();
+    auto pointRenderer = std::make_unique<QgsPointDisplacementRenderer>();
     const QgsPointClusterRenderer *clusterRenderer = static_cast< const QgsPointClusterRenderer * >( renderer );
     if ( clusterRenderer->embeddedRenderer() )
       pointRenderer->setEmbeddedRenderer( clusterRenderer->embeddedRenderer()->clone() );
     pointRenderer->setTolerance( clusterRenderer->tolerance() );
     pointRenderer->setToleranceUnit( clusterRenderer->toleranceUnit() );
     pointRenderer->setToleranceMapUnitScale( clusterRenderer->toleranceMapUnitScale() );
-    renderer->copyRendererData( pointRenderer );
+    renderer->copyRendererData( pointRenderer.get() );
     return pointRenderer;
   }
   else

--- a/src/core/symbology/qgspointdisplacementrenderer.h
+++ b/src/core/symbology/qgspointdisplacementrenderer.h
@@ -55,7 +55,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer : public QgsPointDistanceRenderer
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     //! Create a renderer from XML element
-    static QgsFeatureRenderer *create( QDomElement &symbologyElem, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &symbologyElem, const QgsReadWriteContext &context );
 
     /**
      * Sets the line width for the displacement group circle.
@@ -145,7 +145,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer : public QgsPointDistanceRenderer
      * Creates a QgsPointDisplacementRenderer from an existing renderer.
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsPointDisplacementRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<QgsPointDisplacementRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 
   private:
 #ifdef SIP_RUN

--- a/src/core/symbology/qgspointdistancerenderer.cpp
+++ b/src/core/symbology/qgspointdistancerenderer.cpp
@@ -36,7 +36,7 @@ QgsPointDistanceRenderer::QgsPointDistanceRenderer( const QString &rendererName,
   : QgsFeatureRenderer( rendererName )
   , mLabelAttributeName( labelAttributeName )
 {
-  mRenderer.reset( QgsFeatureRenderer::defaultRenderer( Qgis::GeometryType::Point ) );
+  mRenderer = QgsFeatureRenderer::defaultRenderer( Qgis::GeometryType::Point );
 }
 
 void QgsPointDistanceRenderer::toSld( QDomDocument &doc, QDomElement &element, const QVariantMap &props ) const

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -82,9 +82,9 @@ const QgsPropertiesDefinition &QgsFeatureRenderer::propertyDefinitions()
   return sPropertyDefinitions;
 }
 
-QgsFeatureRenderer *QgsFeatureRenderer::defaultRenderer( Qgis::GeometryType geomType )
+std::unique_ptr<QgsFeatureRenderer> QgsFeatureRenderer::defaultRenderer( Qgis::GeometryType geomType )
 {
-  return new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( geomType ) );
+  return std::make_unique<QgsSingleSymbolRenderer>( QgsSymbol::defaultSymbol( geomType ).release() );
 }
 
 QgsSymbol *QgsFeatureRenderer::originalSymbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const
@@ -172,7 +172,7 @@ QgsSymbolList QgsFeatureRenderer::symbols( QgsRenderContext &context ) const
   return QgsSymbolList();
 }
 
-QgsFeatureRenderer *QgsFeatureRenderer::load( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsFeatureRenderer::load( QDomElement &element, const QgsReadWriteContext &context )
 {
   // <renderer-v2 type=""> ... </renderer-v2>
 
@@ -186,7 +186,7 @@ QgsFeatureRenderer *QgsFeatureRenderer::load( QDomElement &element, const QgsRea
   if ( !m )
     return nullptr;
 
-  QgsFeatureRenderer *r = m->createRenderer( element, context );
+  std::unique_ptr<QgsFeatureRenderer> r = std::unique_ptr<QgsFeatureRenderer>( m->createRenderer( element, context ) );
   if ( r )
   {
     r->setUsingSymbolLevels( element.attribute( u"symbollevels"_s, u"0"_s ).toInt() );
@@ -245,7 +245,7 @@ void QgsFeatureRenderer::saveRendererData( QDomDocument &doc, QDomElement &rende
   rendererElem.setAttribute( u"enableorderby"_s, ( mOrderByEnabled ? u"1"_s : u"0"_s ) );
 }
 
-QgsFeatureRenderer *QgsFeatureRenderer::loadSld( const QDomNode &node, Qgis::GeometryType geomType, QString &errorMessage )
+std::unique_ptr<QgsFeatureRenderer> QgsFeatureRenderer::loadSld( const QDomNode &node, Qgis::GeometryType geomType, QString &errorMessage )
 {
   const QDomElement element = node.toElement();
   if ( element.isNull() )
@@ -352,7 +352,7 @@ QgsFeatureRenderer *QgsFeatureRenderer::loadSld( const QDomNode &node, Qgis::Geo
     return nullptr;
   }
 
-  QgsFeatureRenderer *r = m->createRendererFromSld( mergedFeatTypeStyle, geomType );
+  std::unique_ptr<QgsFeatureRenderer> r = std::unique_ptr<QgsFeatureRenderer>( m->createRendererFromSld( mergedFeatTypeStyle, geomType ) );
   return r;
 }
 

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -165,7 +165,7 @@ class CORE_EXPORT QgsFeatureRenderer
     // renderer takes ownership of its symbols!
 
     //! Returns a new renderer - used by default in vector layers
-    static QgsFeatureRenderer *defaultRenderer( Qgis::GeometryType geomType ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> defaultRenderer( Qgis::GeometryType geomType );
 
     QString type() const { return mType; }
 
@@ -338,7 +338,7 @@ class CORE_EXPORT QgsFeatureRenderer
     void setUsingSymbolLevels( bool usingSymbolLevels ) { mUsingSymbolLevels = usingSymbolLevels; }
 
     //! create a renderer from XML element
-    static QgsFeatureRenderer *load( QDomElement &symbologyElem, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> load( QDomElement &symbologyElem, const QgsReadWriteContext &context );
 
     /**
      * Stores renderer properties to an XML element.
@@ -364,7 +364,7 @@ class CORE_EXPORT QgsFeatureRenderer
      * went wrong
      * \returns the renderer
      */
-    static QgsFeatureRenderer *loadSld( const QDomNode &node, Qgis::GeometryType geomType, QString &errorMessage ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> loadSld( const QDomNode &node, Qgis::GeometryType geomType, QString &errorMessage );
 
     /**
      * Used from subclasses to create SLD Rule elements following SLD v1.1 specs

--- a/src/core/symbology/qgsrendererregistry.h
+++ b/src/core/symbology/qgsrendererregistry.h
@@ -141,9 +141,9 @@ class CORE_EXPORT QgsRendererAbstractMetadata
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsRendererAbstractMetadata::LayerTypes )
 
 
-typedef QgsFeatureRenderer *( *QgsRendererCreateFunc )( QDomElement &, const QgsReadWriteContext & ) SIP_SKIP;
+typedef std::unique_ptr<QgsFeatureRenderer> ( *QgsRendererCreateFunc )( QDomElement &, const QgsReadWriteContext & ) SIP_SKIP;
 typedef QgsRendererWidget *( *QgsRendererWidgetFunc )( QgsVectorLayer *, QgsStyle *, QgsFeatureRenderer * ) SIP_SKIP;
-typedef QgsFeatureRenderer *( *QgsRendererCreateFromSldFunc )( QDomElement &, Qgis::GeometryType geomType ) SIP_SKIP;
+typedef std::unique_ptr<QgsFeatureRenderer> ( *QgsRendererCreateFromSldFunc )( QDomElement &, Qgis::GeometryType geomType ) SIP_SKIP;
 
 /**
  * \ingroup core
@@ -186,12 +186,15 @@ class CORE_EXPORT QgsRendererMetadata : public QgsRendererAbstractMetadata
                  mLayerTypes( layerTypes )
     {}
 
-    QgsFeatureRenderer *createRenderer( QDomElement &elem, const QgsReadWriteContext &context ) override SIP_FACTORY { return mCreateFunc ? mCreateFunc( elem, context ) : nullptr; }
+    QgsFeatureRenderer *createRenderer( QDomElement &elem, const QgsReadWriteContext &context ) override SIP_FACTORY { return mCreateFunc ? mCreateFunc( elem, context ).release() : nullptr; }
     QgsRendererWidget *createRendererWidget( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer ) override SIP_FACTORY
     {
       return mWidgetFunc ? mWidgetFunc( layer, style, renderer ) : nullptr;
     }
-    QgsFeatureRenderer *createRendererFromSld( QDomElement &elem, Qgis::GeometryType geomType ) override SIP_FACTORY { return mCreateFromSldFunc ? mCreateFromSldFunc( elem, geomType ) : nullptr; }
+    QgsFeatureRenderer *createRendererFromSld( QDomElement &elem, Qgis::GeometryType geomType ) override SIP_FACTORY
+    {
+      return mCreateFromSldFunc ? mCreateFromSldFunc( elem, geomType ).release() : nullptr;
+    }
 
     //! \note not available in Python bindings
     QgsRendererCreateFunc createFunction() const SIP_SKIP { return mCreateFunc; }

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -309,15 +309,15 @@ bool QgsRuleBasedRenderer::Rule::isScaleOK( double scale ) const
   return true;
 }
 
-QgsRuleBasedRenderer::Rule *QgsRuleBasedRenderer::Rule::clone() const
+std::unique_ptr<QgsRuleBasedRenderer::Rule> QgsRuleBasedRenderer::Rule::clone() const
 {
   QgsSymbol *sym = mSymbol ? mSymbol->clone() : nullptr;
-  Rule *newrule = new Rule( sym, mMaximumScale, mMinimumScale, mFilterExp, mLabel, mDescription );
+  auto newrule = std::make_unique<Rule>( sym, mMaximumScale, mMinimumScale, mFilterExp, mLabel, mDescription );
   newrule->setActive( mIsActive );
   // clone children
   const auto constMChildren = mChildren;
   for ( Rule *rule : constMChildren )
-    newrule->appendChild( rule->clone() );
+    newrule->appendChild( rule->clone().release() );
   return newrule;
 }
 
@@ -786,7 +786,7 @@ void QgsRuleBasedRenderer::Rule::stopRender( QgsRenderContext &context )
   mSymbolNormZLevels.clear();
 }
 
-QgsRuleBasedRenderer::Rule *QgsRuleBasedRenderer::Rule::create( QDomElement &ruleElem, QgsSymbolMap &symbolMap, bool reuseId, const QgsReadWriteContext &context )
+std::unique_ptr<QgsRuleBasedRenderer::Rule> QgsRuleBasedRenderer::Rule::create( QDomElement &ruleElem, QgsSymbolMap &symbolMap, bool reuseId, const QgsReadWriteContext &context )
 {
   QString symbolIdx = ruleElem.attribute( u"symbol"_s );
   QgsSymbol *symbol = nullptr;
@@ -814,7 +814,7 @@ QgsRuleBasedRenderer::Rule *QgsRuleBasedRenderer::Rule::create( QDomElement &rul
     ruleKey = ruleElem.attribute( u"key"_s );
   else
     ruleKey = QUuid::createUuid().toString();
-  Rule *rule = new Rule( symbol, scaleMinDenom, scaleMaxDenom, filterExp, label, description );
+  auto rule = std::make_unique<Rule>( symbol, scaleMinDenom, scaleMaxDenom, filterExp, label, description );
 
   if ( !ruleKey.isEmpty() )
     rule->mRuleKey = ruleKey;
@@ -824,10 +824,10 @@ QgsRuleBasedRenderer::Rule *QgsRuleBasedRenderer::Rule::create( QDomElement &rul
   QDomElement childRuleElem = ruleElem.firstChildElement( u"rule"_s );
   while ( !childRuleElem.isNull() )
   {
-    Rule *childRule = create( childRuleElem, symbolMap, true, context );
+    std::unique_ptr<Rule> childRule = create( childRuleElem, symbolMap, true, context );
     if ( childRule )
     {
-      rule->appendChild( childRule );
+      rule->appendChild( childRule.release() );
     }
     else
     {
@@ -850,7 +850,7 @@ QgsRuleBasedRenderer::RuleList QgsRuleBasedRenderer::Rule::descendants() const
   return l;
 }
 
-QgsRuleBasedRenderer::Rule *QgsRuleBasedRenderer::Rule::createFromSld( QDomElement &ruleElem, Qgis::GeometryType geomType )
+std::unique_ptr<QgsRuleBasedRenderer::Rule> QgsRuleBasedRenderer::Rule::createFromSld( QDomElement &ruleElem, Qgis::GeometryType geomType )
 {
   if ( ruleElem.localName() != "Rule"_L1 )
   {
@@ -966,7 +966,7 @@ QgsRuleBasedRenderer::Rule *QgsRuleBasedRenderer::Rule::createFromSld( QDomEleme
   }
 
   // and then create and return the new rule
-  return new Rule( symbol, scaleMinDenom, scaleMaxDenom, filterExp, label, description );
+  return std::make_unique<Rule>( symbol, scaleMinDenom, scaleMaxDenom, filterExp, label, description );
 }
 
 
@@ -1127,7 +1127,7 @@ bool QgsRuleBasedRenderer::filterNeedsGeometry() const
 
 QgsRuleBasedRenderer *QgsRuleBasedRenderer::clone() const
 {
-  QgsRuleBasedRenderer::Rule *clonedRoot = mRootRule->clone();
+  std::unique_ptr<QgsRuleBasedRenderer::Rule> clonedRoot = mRootRule->clone();
 
   // normally with clone() the individual rules get new keys (UUID), but here we want to keep
   // the tree of rules intact, so that other components that may use the rule keys work nicely (e.g. map themes)
@@ -1138,7 +1138,7 @@ QgsRuleBasedRenderer *QgsRuleBasedRenderer::clone() const
   for ( int i = 0; i < origDescendants.count(); ++i )
     clonedDescendants[i]->setRuleKey( origDescendants[i]->ruleKey() );
 
-  QgsRuleBasedRenderer *r = new QgsRuleBasedRenderer( clonedRoot );
+  QgsRuleBasedRenderer *r = new QgsRuleBasedRenderer( clonedRoot.release() );
 
   copyRendererData( r );
   return r;
@@ -1290,7 +1290,7 @@ QgsLegendSymbolList QgsRuleBasedRenderer::legendSymbolItems() const
 }
 
 
-QgsFeatureRenderer *QgsRuleBasedRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsRuleBasedRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
   // load symbols
   QDomElement symbolsElem = element.firstChildElement( u"symbols"_s );
@@ -1301,11 +1301,11 @@ QgsFeatureRenderer *QgsRuleBasedRenderer::create( QDomElement &element, const Qg
 
   QDomElement rulesElem = element.firstChildElement( u"rules"_s );
 
-  Rule *root = Rule::create( rulesElem, symbolMap, true, context );
+  std::unique_ptr<Rule> root = Rule::create( rulesElem, symbolMap, true, context );
   if ( !root )
     return nullptr;
 
-  QgsRuleBasedRenderer *r = new QgsRuleBasedRenderer( root );
+  auto r = std::make_unique<QgsRuleBasedRenderer>( root.release() );
 
   // delete symbols if there are any more
   QgsSymbolLayerUtils::clearSymbolMap( symbolMap );
@@ -1313,7 +1313,7 @@ QgsFeatureRenderer *QgsRuleBasedRenderer::create( QDomElement &element, const Qg
   return r;
 }
 
-QgsFeatureRenderer *QgsRuleBasedRenderer::createFromSld( QDomElement &element, Qgis::GeometryType geomType )
+std::unique_ptr<QgsFeatureRenderer> QgsRuleBasedRenderer::createFromSld( QDomElement &element, Qgis::GeometryType geomType )
 {
   // retrieve child rules
   Rule *root = nullptr;
@@ -1321,14 +1321,14 @@ QgsFeatureRenderer *QgsRuleBasedRenderer::createFromSld( QDomElement &element, Q
   QDomElement ruleElem = element.firstChildElement( u"Rule"_s );
   while ( !ruleElem.isNull() )
   {
-    Rule *child = Rule::createFromSld( ruleElem, geomType );
+    std::unique_ptr<Rule> child = Rule::createFromSld( ruleElem, geomType );
     if ( child )
     {
       // create the root rule if not done before
       if ( !root )
         root = new Rule( nullptr );
 
-      root->appendChild( child );
+      root->appendChild( child.release() );
     }
 
     ruleElem = ruleElem.nextSiblingElement( u"Rule"_s );
@@ -1341,7 +1341,7 @@ QgsFeatureRenderer *QgsRuleBasedRenderer::createFromSld( QDomElement &element, Q
   }
 
   // create and return the new renderer
-  return new QgsRuleBasedRenderer( root );
+  return std::make_unique<QgsRuleBasedRenderer>( root );
 }
 
 #include "qgscategorizedsymbolrenderer.h"
@@ -1462,7 +1462,7 @@ bool QgsRuleBasedRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) con
   return mRootRule->accept( visitor );
 }
 
-QgsRuleBasedRenderer *QgsRuleBasedRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer )
+std::unique_ptr<QgsRuleBasedRenderer> QgsRuleBasedRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer )
 {
   std::unique_ptr< QgsRuleBasedRenderer > r;
   if ( renderer->type() == "RuleRenderer"_L1 )
@@ -1655,12 +1655,12 @@ QgsRuleBasedRenderer *QgsRuleBasedRenderer::convertFromRenderer( const QgsFeatur
   else if ( renderer->type() == "invertedPolygonRenderer"_L1 )
   {
     if ( const QgsInvertedPolygonRenderer *invertedPolygonRenderer = dynamic_cast<const QgsInvertedPolygonRenderer *>( renderer ) )
-      r.reset( convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() ) );
+      r = convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() );
   }
   else if ( renderer->type() == "mergedFeatureRenderer"_L1 )
   {
     if ( const QgsMergedFeatureRenderer *mergedRenderer = dynamic_cast<const QgsMergedFeatureRenderer *>( renderer ) )
-      r.reset( convertFromRenderer( mergedRenderer->embeddedRenderer() ) );
+      r = convertFromRenderer( mergedRenderer->embeddedRenderer() );
   }
   else if ( renderer->type() == "embeddedSymbol"_L1 && layer )
   {
@@ -1699,7 +1699,7 @@ QgsRuleBasedRenderer *QgsRuleBasedRenderer::convertFromRenderer( const QgsFeatur
     renderer->copyRendererData( r.get() );
   }
 
-  return r.release();
+  return r;
 }
 
 void QgsRuleBasedRenderer::convertToDataDefinedSymbology( QgsSymbol *symbol, const QString &sizeScaleField, const QString &rotationField )

--- a/src/core/symbology/qgsrulebasedrenderer.h
+++ b/src/core/symbology/qgsrulebasedrenderer.h
@@ -317,7 +317,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
         void setActive( bool state ) { mIsActive = state; }
 
         //! clone this rule, return new instance
-        QgsRuleBasedRenderer::Rule *clone() const SIP_FACTORY;
+        std::unique_ptr<QgsRuleBasedRenderer::Rule> clone() const;
 
         /**
          * Saves the symbol layer as SLD.
@@ -336,7 +336,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
         /**
          * Create a rule from the SLD provided in element and for the specified geometry type.
          */
-        static QgsRuleBasedRenderer::Rule *createFromSld( QDomElement &element, Qgis::GeometryType geomType ) SIP_FACTORY;
+        static std::unique_ptr<QgsRuleBasedRenderer::Rule> createFromSld( QDomElement &element, Qgis::GeometryType geomType );
 
         QDomElement save( QDomDocument &doc, QgsSymbolMap &symbolMap ) const;
 
@@ -410,7 +410,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
          *
          * \returns A new rule
          */
-        static QgsRuleBasedRenderer::Rule *create( QDomElement &ruleElem, QgsSymbolMap &symbolMap, bool reuseId = true, const QgsReadWriteContext &context = QgsReadWriteContext() ) SIP_FACTORY;
+        static std::unique_ptr<QgsRuleBasedRenderer::Rule> create( QDomElement &ruleElem, QgsSymbolMap &symbolMap, bool reuseId = true, const QgsReadWriteContext &context = QgsReadWriteContext() );
 
         /**
          * Returns all children rules of this rule
@@ -517,7 +517,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
     /////
 
     //! Creates a new rule-based renderer instance from XML
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 
     //! Constructs the renderer from given tree of rules (takes ownership)
     QgsRuleBasedRenderer( QgsRuleBasedRenderer::Rule *root SIP_TRANSFER );
@@ -550,7 +550,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
     /**
      * Creates a new rule based renderer from an SLD XML element.
      */
-    static QgsFeatureRenderer *createFromSld( QDomElement &element, Qgis::GeometryType geomType ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> createFromSld( QDomElement &element, Qgis::GeometryType geomType );
 
     QgsSymbolList symbols( QgsRenderContext &context ) const override;
 
@@ -591,7 +591,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
      *
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsRuleBasedRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer = nullptr ) SIP_FACTORY;
+    static std::unique_ptr<QgsRuleBasedRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer, QgsVectorLayer *layer = nullptr );
 
     //! helper function to convert the size scale and rotation fields present in some other renderers to data defined symbology
     static void convertToDataDefinedSymbology( QgsSymbol *symbol, const QString &sizeScaleField, const QString &rotationField = QString() );

--- a/src/core/symbology/qgssinglesymbolrenderer.cpp
+++ b/src/core/symbology/qgssinglesymbolrenderer.cpp
@@ -169,7 +169,7 @@ QgsSymbolList QgsSingleSymbolRenderer::symbols( QgsRenderContext &context ) cons
 }
 
 
-QgsFeatureRenderer *QgsSingleSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
+std::unique_ptr<QgsFeatureRenderer> QgsSingleSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )
 {
   QDomElement symbolsElem = element.firstChildElement( u"symbols"_s );
   if ( symbolsElem.isNull() )
@@ -180,7 +180,7 @@ QgsFeatureRenderer *QgsSingleSymbolRenderer::create( QDomElement &element, const
   if ( !symbolMap.contains( u"0"_s ) )
     return nullptr;
 
-  QgsSingleSymbolRenderer *r = new QgsSingleSymbolRenderer( symbolMap.take( u"0"_s ) );
+  auto r = std::make_unique<QgsSingleSymbolRenderer>( symbolMap.take( u"0"_s ) );
 
   // delete symbols if there are any more
   QgsSymbolLayerUtils::clearSymbolMap( symbolMap );
@@ -207,7 +207,7 @@ QgsFeatureRenderer *QgsSingleSymbolRenderer::create( QDomElement &element, const
   return r;
 }
 
-QgsFeatureRenderer *QgsSingleSymbolRenderer::createFromSld( QDomElement &element, Qgis::GeometryType geomType )
+std::unique_ptr<QgsFeatureRenderer> QgsSingleSymbolRenderer::createFromSld( QDomElement &element, Qgis::GeometryType geomType )
 {
   // XXX this renderer can handle only one Rule!
 
@@ -292,7 +292,7 @@ QgsFeatureRenderer *QgsSingleSymbolRenderer::createFromSld( QDomElement &element
   }
 
   // and finally return the new renderer
-  return new QgsSingleSymbolRenderer( symbol.release() );
+  return std::make_unique<QgsSingleSymbolRenderer>( symbol.release() );
 }
 
 QDomElement QgsSingleSymbolRenderer::save( QDomDocument &doc, const QgsReadWriteContext &context )
@@ -369,12 +369,12 @@ void QgsSingleSymbolRenderer::setLegendSymbolItem( const QString &key, QgsSymbol
   setSymbol( symbol );
 }
 
-QgsSingleSymbolRenderer *QgsSingleSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
+std::unique_ptr<QgsSingleSymbolRenderer> QgsSingleSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
-  QgsSingleSymbolRenderer *r = nullptr;
+  std::unique_ptr<QgsSingleSymbolRenderer> r;
   if ( renderer->type() == "singleSymbol"_L1 )
   {
-    r = dynamic_cast<QgsSingleSymbolRenderer *>( renderer->clone() );
+    r = std::unique_ptr<QgsSingleSymbolRenderer>( dynamic_cast<QgsSingleSymbolRenderer *>( renderer->clone() ) );
   }
   else if ( renderer->type() == "pointDisplacement"_L1 || renderer->type() == "pointCluster"_L1 )
   {
@@ -395,13 +395,13 @@ QgsSingleSymbolRenderer *QgsSingleSymbolRenderer::convertFromRenderer( const Qgs
     const QgsSymbolList symbols = const_cast<QgsFeatureRenderer *>( renderer )->symbols( context );
     if ( !symbols.isEmpty() )
     {
-      r = new QgsSingleSymbolRenderer( symbols.at( 0 )->clone() );
+      r = std::make_unique<QgsSingleSymbolRenderer>( symbols.at( 0 )->clone() );
     }
   }
 
   if ( r )
   {
-    renderer->copyRendererData( r );
+    renderer->copyRendererData( r.get() );
   }
 
   return r;

--- a/src/core/symbology/qgssinglesymbolrenderer.h
+++ b/src/core/symbology/qgssinglesymbolrenderer.h
@@ -73,7 +73,7 @@ class CORE_EXPORT QgsSingleSymbolRenderer : public QgsFeatureRenderer
      *
      * The caller takes ownership of the returned renderer.
      */
-    static QgsFeatureRenderer *createFromSld( QDomElement &element, Qgis::GeometryType geomType ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> createFromSld( QDomElement &element, Qgis::GeometryType geomType );
 
     QgsFeatureRenderer::Capabilities capabilities() override { return SymbolLevels; }
     QgsSymbolList symbols( QgsRenderContext &context ) const override;
@@ -83,7 +83,7 @@ class CORE_EXPORT QgsSingleSymbolRenderer : public QgsFeatureRenderer
      *
      * The caller takes ownership of the returned renderer.
      */
-    static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
+    static std::unique_ptr<QgsFeatureRenderer> create( QDomElement &element, const QgsReadWriteContext &context );
 
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
     QgsLegendSymbolList legendSymbolItems() const override;
@@ -95,7 +95,7 @@ class CORE_EXPORT QgsSingleSymbolRenderer : public QgsFeatureRenderer
      * Creates a new single symbol renderer from an existing \a renderer.
      * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
      */
-    static QgsSingleSymbolRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    static std::unique_ptr<QgsSingleSymbolRenderer> convertFromRenderer( const QgsFeatureRenderer *renderer );
 
     /**
      * Configures appearance of legend when renderer is configured to use data-defined size for marker symbols.

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -335,7 +335,7 @@ bool QgsStyle::renameEntity( QgsStyle::StyleEntity type, const QString &oldName,
   return false;
 }
 
-QgsSymbol *QgsStyle::symbol( const QString &name )
+std::unique_ptr<QgsSymbol> QgsStyle::symbol( const QString &name )
 {
   const QgsSymbol *symbol = symbolRef( name );
   if ( !symbol )
@@ -344,7 +344,7 @@ QgsSymbol *QgsStyle::symbol( const QString &name )
   QgsSymbol *newSymbol = symbol->clone();
   QgsSymbolLayerUtils::resetSymbolLayerIds( newSymbol );
 
-  return newSymbol;
+  return std::unique_ptr<QgsSymbol>( newSymbol );
 }
 
 const QgsSymbol *QgsStyle::symbolRef( const QString &name ) const
@@ -534,10 +534,10 @@ bool QgsStyle::removeColorRamp( const QString &name )
   return removeEntityByName( ColorrampEntity, name );
 }
 
-QgsColorRamp *QgsStyle::colorRamp( const QString &name ) const
+std::unique_ptr<QgsColorRamp> QgsStyle::colorRamp( const QString &name ) const
 {
   const QgsColorRamp *ramp = colorRampRef( name );
-  return ramp ? ramp->clone() : nullptr;
+  return std::unique_ptr<QgsColorRamp>( ramp ? ramp->clone() : nullptr );
 }
 
 const QgsColorRamp *QgsStyle::colorRampRef( const QString &name ) const
@@ -2385,11 +2385,11 @@ Qgis::SymbolType QgsStyle::legendPatchShapeSymbolType( const QString &name ) con
   return it.value().symbolType();
 }
 
-QgsAbstract3DSymbol *QgsStyle::symbol3D( const QString &name ) const
+std::unique_ptr<QgsAbstract3DSymbol> QgsStyle::symbol3D( const QString &name ) const
 {
   auto it = m3dSymbols.constFind( name );
   if ( it != m3dSymbols.constEnd() )
-    return it.value()->clone();
+    return std::unique_ptr<QgsAbstract3DSymbol>( it.value()->clone() );
   return nullptr;
 }
 

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -407,7 +407,7 @@ class CORE_EXPORT QgsStyle : public QObject
      * Returns a new copy of the specified color ramp. The caller
      * takes responsibility for deleting the returned object.
      */
-    QgsColorRamp *colorRamp( const QString &name ) const SIP_FACTORY;
+    std::unique_ptr<QgsColorRamp> colorRamp( const QString &name ) const;
 
     //! Returns count of color ramps
     int colorRampCount();
@@ -485,7 +485,7 @@ class CORE_EXPORT QgsStyle : public QObject
      *
      * \since QGIS 3.16
      */
-    QgsAbstract3DSymbol *symbol3D( const QString &name ) const SIP_FACTORY;
+    std::unique_ptr<QgsAbstract3DSymbol> symbol3D( const QString &name ) const;
 
     /**
      * Returns count of 3D symbols in the style.
@@ -595,7 +595,7 @@ class CORE_EXPORT QgsStyle : public QObject
     bool renameSymbol( const QString &oldName, const QString &newName );
 
     //! Returns a NEW copy of symbol
-    QgsSymbol *symbol( const QString &name ) SIP_FACTORY;
+    std::unique_ptr<QgsSymbol> symbol( const QString &name );
 
     //! Returns a const pointer to a symbol (doesn't create new instance)
     const QgsSymbol *symbolRef( const QString &name ) const;

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -811,7 +811,7 @@ void QgsSymbol::setAnimationSettings( const QgsSymbolAnimationSettings &settings
   mAnimationSettings = settings;
 }
 
-QgsSymbol *QgsSymbol::defaultSymbol( Qgis::GeometryType geomType )
+std::unique_ptr<QgsSymbol> QgsSymbol::defaultSymbol( Qgis::GeometryType geomType )
 {
   std::unique_ptr< QgsSymbol > s;
 
@@ -873,7 +873,7 @@ QgsSymbol *QgsSymbol::defaultSymbol( Qgis::GeometryType geomType )
     s->setColor( s->color().toRgb() );
   }
 
-  return s.release();
+  return s;
 }
 
 QgsSymbolLayer *QgsSymbol::symbolLayer( int layer )

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -288,7 +288,7 @@ class CORE_EXPORT QgsSymbol
      *
      * The caller takes ownership of the returned object.
      */
-    static QgsSymbol *defaultSymbol( Qgis::GeometryType geomType ) SIP_FACTORY;
+    static std::unique_ptr<QgsSymbol> defaultSymbol( Qgis::GeometryType geomType );
 
     /**
      * Returns the symbol's type.

--- a/src/core/symbology/qgssymbollayerregistry.h
+++ b/src/core/symbology/qgssymbollayerregistry.h
@@ -95,9 +95,9 @@ class CORE_EXPORT QgsSymbolLayerAbstractMetadata
     Qgis::SymbolType mType;
 };
 
-typedef QgsSymbolLayer *( *QgsSymbolLayerCreateFunc )( const QVariantMap & ) SIP_SKIP;
+typedef std::unique_ptr<QgsSymbolLayer> ( *QgsSymbolLayerCreateFunc )( const QVariantMap & ) SIP_SKIP;
 typedef QgsSymbolLayerWidget *( *QgsSymbolLayerWidgetFunc )( QgsVectorLayer * ) SIP_SKIP;
-typedef QgsSymbolLayer *( *QgsSymbolLayerCreateFromSldFunc )( QDomElement & ) SIP_SKIP;
+typedef std::unique_ptr<QgsSymbolLayer> ( *QgsSymbolLayerCreateFromSldFunc )( QDomElement & ) SIP_SKIP;
 typedef void ( *QgsSymbolLayerPathResolverFunc )( QVariantMap &, const QgsPathResolver &, bool ) SIP_SKIP;
 typedef void ( *QgsSymbolLayerFontResolverFunc )( const QVariantMap &, const QgsReadWriteContext & ) SIP_SKIP;
 
@@ -138,9 +138,9 @@ class CORE_EXPORT QgsSymbolLayerMetadata : public QgsSymbolLayerAbstractMetadata
     //! \note not available in Python bindings
     void setWidgetFunction( QgsSymbolLayerWidgetFunc f ) SIP_SKIP { mWidgetFunc = f; }
 
-    QgsSymbolLayer *createSymbolLayer( const QVariantMap &map ) override SIP_FACTORY { return mCreateFunc ? mCreateFunc( map ) : nullptr; }
+    QgsSymbolLayer *createSymbolLayer( const QVariantMap &map ) override SIP_FACTORY { return mCreateFunc ? mCreateFunc( map ).release() : nullptr; }
     QgsSymbolLayerWidget *createSymbolLayerWidget( QgsVectorLayer *vl ) override SIP_FACTORY { return mWidgetFunc ? mWidgetFunc( vl ) : nullptr; }
-    QgsSymbolLayer *createSymbolLayerFromSld( QDomElement &elem ) override SIP_FACTORY { return mCreateFromSldFunc ? mCreateFromSldFunc( elem ) : nullptr; }
+    QgsSymbolLayer *createSymbolLayerFromSld( QDomElement &elem ) override SIP_FACTORY { return mCreateFromSldFunc ? mCreateFromSldFunc( elem ).release() : nullptr; }
     void resolvePaths( QVariantMap &properties, const QgsPathResolver &pathResolver, bool saving ) override
     {
       if ( mPathResolverFunc )

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -3534,7 +3534,7 @@ void QgsSymbolLayerUtils::clearSymbolMap( QgsSymbolMap &symbols )
   symbols.clear();
 }
 
-QMimeData *QgsSymbolLayerUtils::symbolToMimeData( const QgsSymbol *symbol )
+std::unique_ptr<QMimeData> QgsSymbolLayerUtils::symbolToMimeData( const QgsSymbol *symbol )
 {
   if ( !symbol )
     return nullptr;
@@ -3549,7 +3549,7 @@ QMimeData *QgsSymbolLayerUtils::symbolToMimeData( const QgsSymbol *symbol )
   mimeData->setImageData( symbolPreviewPixmap( symbol, QSize( 100, 100 ), 18 ).toImage() );
   mimeData->setColorData( symbol->color() );
 
-  return mimeData.release();
+  return mimeData;
 }
 
 std::unique_ptr< QgsSymbol > QgsSymbolLayerUtils::symbolFromMimeData( const QMimeData *data )
@@ -3744,11 +3744,11 @@ QList<QColor> QgsSymbolLayerUtils::parseColorList( const QString &colorStr )
   return colors;
 }
 
-QMimeData *QgsSymbolLayerUtils::colorToMimeData( const QColor &color )
+std::unique_ptr<QMimeData> QgsSymbolLayerUtils::colorToMimeData( const QColor &color )
 {
   //set both the mime color data (which includes alpha channel), and the text (which is the color's hex
   //value, and can be used when pasting colors outside of QGIS).
-  QMimeData *mimeData = new QMimeData;
+  auto mimeData = std::make_unique<QMimeData>();
   mimeData->setColorData( QVariant( color ) );
   mimeData->setText( color.name() );
   return mimeData;
@@ -3901,10 +3901,10 @@ QgsNamedColorList QgsSymbolLayerUtils::colorListFromMimeData( const QMimeData *d
   return mimeColors;
 }
 
-QMimeData *QgsSymbolLayerUtils::colorListToMimeData( const QgsNamedColorList &colorList, const bool allFormats )
+std::unique_ptr<QMimeData> QgsSymbolLayerUtils::colorListToMimeData( const QgsNamedColorList &colorList, const bool allFormats )
 {
   //native format
-  QMimeData *mimeData = new QMimeData();
+  auto mimeData = std::make_unique<QMimeData>();
   QDomDocument xmlDoc;
   QDomElement xmlRootElement = xmlDoc.createElement( u"ColorSchemeModelDragData"_s );
   xmlDoc.appendChild( xmlRootElement );

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -766,7 +766,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * can be paste in places where a color is expected.
      * \see symbolFromMimeData()
      */
-    static QMimeData *symbolToMimeData( const QgsSymbol *symbol ) SIP_FACTORY;
+    static std::unique_ptr<QMimeData> symbolToMimeData( const QgsSymbol *symbol );
 
     /**
      * Attempts to parse \a mime data as a symbol. A new symbol instance will be returned
@@ -830,7 +830,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * \param color color to encode as mime data
      * \see colorFromMimeData
      */
-    static QMimeData *colorToMimeData( const QColor &color ) SIP_FACTORY;
+    static std::unique_ptr<QMimeData> colorToMimeData( const QColor &color );
 
     /**
      * Attempts to parse mime data as a color
@@ -854,7 +854,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * \param allFormats set to TRUE to include additional mime formats, include text/plain and application/x-color
      * \returns mime data containing encoded colors
      */
-    static QMimeData *colorListToMimeData( const QgsNamedColorList &colorList, bool allFormats = true ) SIP_FACTORY;
+    static std::unique_ptr<QMimeData> colorListToMimeData( const QgsNamedColorList &colorList, bool allFormats = true );
 
     /**
      * Exports colors to a gpl GIMP palette file

--- a/src/core/symbology/qgsvectorfieldsymbollayer.cpp
+++ b/src/core/symbology/qgsvectorfieldsymbollayer.cpp
@@ -65,9 +65,9 @@ QgsMapUnitScale QgsVectorFieldSymbolLayer::mapUnitScale() const
   return QgsMapUnitScale();
 }
 
-QgsSymbolLayer *QgsVectorFieldSymbolLayer::create( const QVariantMap &properties )
+std::unique_ptr<QgsSymbolLayer> QgsVectorFieldSymbolLayer::create( const QVariantMap &properties )
 {
-  QgsVectorFieldSymbolLayer *symbolLayer = new QgsVectorFieldSymbolLayer();
+  auto symbolLayer = std::make_unique<QgsVectorFieldSymbolLayer>();
   if ( properties.contains( u"x_attribute"_s ) )
   {
     symbolLayer->setXAttribute( properties[u"x_attribute"_s].toString() );
@@ -258,12 +258,12 @@ void QgsVectorFieldSymbolLayer::stopRender( QgsSymbolRenderContext &context )
 
 QgsVectorFieldSymbolLayer *QgsVectorFieldSymbolLayer::clone() const
 {
-  QgsSymbolLayer *clonedLayer = QgsVectorFieldSymbolLayer::create( properties() );
+  auto clonedLayer = qgis::unique_ptr_static_cast<QgsVectorFieldSymbolLayer>( QgsVectorFieldSymbolLayer::create( properties() ) );
   if ( mLineSymbol )
   {
     clonedLayer->setSubSymbol( mLineSymbol->clone() );
   }
-  return static_cast< QgsVectorFieldSymbolLayer * >( clonedLayer );
+  return clonedLayer.release();
 }
 
 QVariantMap QgsVectorFieldSymbolLayer::properties() const
@@ -310,7 +310,7 @@ bool QgsVectorFieldSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, 
   return false;
 }
 
-QgsSymbolLayer *QgsVectorFieldSymbolLayer::createFromSld( QDomElement &element )
+std::unique_ptr<QgsSymbolLayer> QgsVectorFieldSymbolLayer::createFromSld( QDomElement &element )
 {
   Q_UNUSED( element )
   return nullptr;

--- a/src/core/symbology/qgsvectorfieldsymbollayer.h
+++ b/src/core/symbology/qgsvectorfieldsymbollayer.h
@@ -58,8 +58,8 @@ class CORE_EXPORT QgsVectorFieldSymbolLayer : public QgsMarkerSymbolLayer
     ~QgsVectorFieldSymbolLayer() override;
 
     //! Creates the symbol layer
-    static QgsSymbolLayer *create( const QVariantMap &properties = QVariantMap() );
-    static QgsSymbolLayer *createFromSld( QDomElement &element );
+    static std::unique_ptr<QgsSymbolLayer> create( const QVariantMap &properties = QVariantMap() );
+    static std::unique_ptr<QgsSymbolLayer> createFromSld( QDomElement &element );
 
     QString layerType() const override { return u"VectorField"_s; }
 

--- a/src/core/textrenderer/qgstextrenderer.cpp
+++ b/src/core/textrenderer/qgstextrenderer.cpp
@@ -1219,8 +1219,8 @@ void QgsTextRenderer::drawBackground( QgsRenderContext &context, const QgsTextRe
         }
         renderedSymbol.reset();
 
-        QgsSymbolLayer *symL = QgsSvgMarkerSymbolLayer::create( map );
-        renderedSymbol = std::make_unique<QgsMarkerSymbol>( QgsSymbolLayerList() << symL );
+        std::unique_ptr<QgsSymbolLayer> symL = QgsSvgMarkerSymbolLayer::create( map );
+        renderedSymbol = std::make_unique<QgsMarkerSymbol>( QgsSymbolLayerList() << symL.release() );
       }
       else
       {

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2164,7 +2164,7 @@ void QgsVectorLayer::setDataSourcePrivate( const QString &dataSource, const QStr
     if ( !defaultLoadedFlag )
     {
       // add single symbol renderer for spatial layers
-      setRenderer( isSpatial() ? QgsFeatureRenderer::defaultRenderer( geometryType() ) : nullptr );
+      setRenderer( isSpatial() ? QgsFeatureRenderer::defaultRenderer( geometryType() ).release() : nullptr );
     }
 
     if ( !mSetLegendFromStyle )
@@ -2939,10 +2939,10 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage, Qgs
       QDomElement rendererElement = node.firstChildElement( RENDERER_TAG_NAME );
       if ( !rendererElement.isNull() )
       {
-        QgsFeatureRenderer *r = QgsFeatureRenderer::load( rendererElement, context );
+        std::unique_ptr<QgsFeatureRenderer> r = QgsFeatureRenderer::load( rendererElement, context );
         if ( r )
         {
-          setRenderer( r );
+          setRenderer( r.release() );
         }
         else
         {
@@ -2952,7 +2952,7 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage, Qgs
       // make sure layer has a renderer - if none exists, fallback to a default renderer
       if ( isSpatial() && !renderer() )
       {
-        setRenderer( QgsFeatureRenderer::defaultRenderer( geometryType() ) );
+        setRenderer( QgsFeatureRenderer::defaultRenderer( geometryType() ).release() );
       }
 
       if ( mSelectionProperties )
@@ -3521,7 +3521,7 @@ bool QgsVectorLayer::readSld( const QDomNode &node, QString &errorMessage )
 
   if ( isSpatial() )
   {
-    QgsFeatureRenderer *r = QgsFeatureRenderer::loadSld( node, geometryType(), errorMessage );
+    std::unique_ptr<QgsFeatureRenderer> r = QgsFeatureRenderer::loadSld( node, geometryType(), errorMessage );
     if ( !r )
       return false;
 
@@ -3529,7 +3529,7 @@ bool QgsVectorLayer::readSld( const QDomNode &node, QString &errorMessage )
     // we don't want multiple signals!
     ScopedIntIncrementor styleChangedSignalBlocker( &mBlockStyleChangedSignal );
 
-    setRenderer( r );
+    setRenderer( r.release() );
 
     // labeling
     readSldLabeling( node );

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -689,7 +689,7 @@ void QgsVectorLayerRenderer::drawRendererLevels( QgsFeatureRenderer *renderer, Q
   QgsSingleSymbolRenderer *selRenderer = nullptr;
   if ( !mSelectedFeatureIds.isEmpty() )
   {
-    selRenderer = new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( mGeometryType ) );
+    selRenderer = new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( mGeometryType ).release() );
     selRenderer->symbol()->setColor( context.selectionColor() );
     selRenderer->setVertexMarkerAppearance( mVertexMarkerStyle, mVertexMarkerSize );
     selRenderer->startRender( context, mFields );

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -159,7 +159,7 @@ void QgsCreateMarkerItemMapTool::cadCanvasReleaseEvent( QgsMapMouseEvent *event 
 
   std::unique_ptr<QgsMarkerSymbol> markerSymbol = QgsApplication::recentStyleHandler()->recentSymbol<QgsMarkerSymbol>( u"marker_annotation_item"_s );
   if ( !markerSymbol )
-    markerSymbol.reset( qgis::down_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
+    markerSymbol = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   createdItem->setSymbol( markerSymbol.release() );
 
   // set reference scale to match canvas scale, but don't enable it by default for marker items
@@ -195,7 +195,7 @@ void QgsCreateLineItemMapTool::lineCaptured( const QgsCurve *line )
 
     std::unique_ptr<QgsLineSymbol> lineSymbol = QgsApplication::recentStyleHandler()->recentSymbol<QgsLineSymbol>( u"line_annotation_item"_s );
     if ( !lineSymbol )
-      lineSymbol.reset( qgis::down_cast<QgsLineSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ) ) );
+      lineSymbol = qgis::unique_ptr_static_cast<QgsLineSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ) );
     createdItem->setSymbol( lineSymbol.release() );
 
     // set reference scale to match canvas scale, but don't enable it by default for marker items
@@ -229,7 +229,7 @@ void QgsCreatePolygonItemMapTool::polygonCaptured( const QgsCurvePolygon *polygo
 
     std::unique_ptr<QgsFillSymbol> fillSymbol = QgsApplication::recentStyleHandler()->recentSymbol<QgsFillSymbol>( u"polygon_annotation_item"_s );
     if ( !fillSymbol )
-      fillSymbol.reset( qgis::down_cast<QgsFillSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) ) );
+      fillSymbol = qgis::unique_ptr_static_cast<QgsFillSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
     createdItem->setSymbol( fillSymbol.release() );
 
     // set reference scale to match canvas scale, but don't enable it by default for marker items
@@ -521,7 +521,7 @@ void QgsCreateLineTextItemMapTool::lineCaptured( const QgsCurve *line )
 
     std::unique_ptr<QgsLineSymbol> lineSymbol = QgsApplication::recentStyleHandler()->recentSymbol<QgsLineSymbol>( u"line_annotation_item"_s );
     if ( !lineSymbol )
-      lineSymbol.reset( qgis::down_cast<QgsLineSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ) ) );
+      lineSymbol = qgis::unique_ptr_static_cast<QgsLineSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ) );
 
     QgsTextFormat format = QgsStyle::defaultTextFormatForProject( QgsProject::instance(), QgsStyle::TextFormatContext::Labeling );
     // default to HTML formatting

--- a/src/gui/attributetable/qgsfieldconditionalformatwidget.cpp
+++ b/src/gui/attributetable/qgsfieldconditionalformatwidget.cpp
@@ -290,7 +290,7 @@ QgsEditConditionalFormatRuleWidget::QgsEditConditionalFormatRuleWidget( QWidget 
   mPresetsList->setModel( mPresetsModel );
 
   btnChangeIcon->setSymbolType( Qgis::SymbolType::Marker );
-  btnChangeIcon->setSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  btnChangeIcon->setSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
   connect( checkIcon, &QCheckBox::toggled, btnChangeIcon, &QWidget::setEnabled );
 }
 

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -34,6 +34,7 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QMenu>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPushButton>
@@ -274,7 +275,7 @@ void QgsColorButton::mouseMoveEvent( QMouseEvent *e )
 
   //user is dragging color
   QDrag *drag = new QDrag( this );
-  drag->setMimeData( QgsSymbolLayerUtils::colorToMimeData( c ) );
+  drag->setMimeData( QgsSymbolLayerUtils::colorToMimeData( c ).release() );
   drag->setPixmap( QgsColorWidget::createDragIcon( c ) );
   drag->exec( Qt::CopyAction );
   setDown( false );
@@ -748,7 +749,7 @@ void QgsColorButton::copyColor()
   QColor c = linkedProjectColor();
   if ( !c.isValid() )
     c = mColor;
-  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( c ) );
+  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( c ).release() );
 }
 
 void QgsColorButton::pasteColor()

--- a/src/gui/qgscolorschemelist.cpp
+++ b/src/gui/qgscolorschemelist.cpp
@@ -140,8 +140,8 @@ void QgsColorSchemeList::copyColors()
   }
 
   //copy colors
-  QMimeData *mimeData = QgsSymbolLayerUtils::colorListToMimeData( colorsToCopy );
-  QApplication::clipboard()->setMimeData( mimeData );
+  std::unique_ptr<QMimeData> mimeData = QgsSymbolLayerUtils::colorListToMimeData( colorsToCopy );
+  QApplication::clipboard()->setMimeData( mimeData.release() );
 }
 
 void QgsColorSchemeList::showImportColorsDialog()
@@ -520,8 +520,8 @@ QMimeData *QgsColorSchemeModel::mimeData( const QModelIndexList &indexes ) const
     colorList << qMakePair( mColors[( *indexIt ).row()].first, mColors[( *indexIt ).row()].second );
   }
 
-  QMimeData *mimeData = QgsSymbolLayerUtils::colorListToMimeData( colorList );
-  return mimeData;
+  std::unique_ptr<QMimeData> mimeData = QgsSymbolLayerUtils::colorListToMimeData( colorList );
+  return mimeData.release();
 }
 
 bool QgsColorSchemeModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent )

--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -32,6 +32,7 @@
 #include <QLineEdit>
 #include <QLineF>
 #include <QMenu>
+#include <QMimeData>
 #include <QPainter>
 #include <QRectF>
 #include <QResizeEvent>
@@ -1832,7 +1833,7 @@ void QgsColorPreviewWidget::mouseMoveEvent( QMouseEvent *e )
   }
 
   QDrag *drag = new QDrag( this );
-  drag->setMimeData( QgsSymbolLayerUtils::colorToMimeData( dragColor ) );
+  drag->setMimeData( QgsSymbolLayerUtils::colorToMimeData( dragColor ).release() );
   drag->setPixmap( createDragIcon( dragColor ) );
   drag->exec( Qt::CopyAction );
 }

--- a/src/gui/qgsfontbutton.cpp
+++ b/src/gui/qgsfontbutton.cpp
@@ -981,7 +981,7 @@ void QgsFontButton::updatePreview( const QColor &color, QgsTextFormat *format, Q
 void QgsFontButton::copyColor()
 {
   //copy color
-  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( mFormat.color() ) );
+  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( mFormat.color() ).release() );
 }
 
 void QgsFontButton::pasteColor()

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -485,7 +485,7 @@ QgsPropertyColorAssistantWidget::QgsPropertyColorAssistantWidget( QWidget *paren
     std::unique_ptr<QgsColorRamp> colorRamp( QgsProject::instance()->styleSettings()->defaultColorRamp() );
     if ( !colorRamp )
     {
-      colorRamp.reset( QgsStyle::defaultStyle()->colorRamp( u"Blues"_s ) );
+      colorRamp = QgsStyle::defaultStyle()->colorRamp( u"Blues"_s );
     }
     if ( colorRamp )
       mColorRampButton->setColorRamp( colorRamp.get() );

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -38,6 +38,7 @@
 #include <QClipboard>
 #include <QDrag>
 #include <QMenu>
+#include <QMimeData>
 #include <QString>
 
 #include "moc_qgssymbolbutton.cpp"
@@ -163,13 +164,13 @@ void QgsSymbolButton::showSettingsDialog()
     switch ( mType )
     {
       case Qgis::SymbolType::Marker:
-        newSymbol.reset( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+        newSymbol = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
         break;
       case Qgis::SymbolType::Line:
-        newSymbol.reset( QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ) );
+        newSymbol = QgsSymbol::defaultSymbol( Qgis::GeometryType::Line );
         break;
       case Qgis::SymbolType::Fill:
-        newSymbol.reset( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
+        newSymbol = QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon );
         break;
       case Qgis::SymbolType::Hybrid:
         break;
@@ -281,7 +282,7 @@ void QgsSymbolButton::setColor( const QColor &color )
 
 void QgsSymbolButton::copySymbol()
 {
-  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( mSymbol.get() ) );
+  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( mSymbol.get() ).release() );
 }
 
 void QgsSymbolButton::pasteSymbol()
@@ -293,7 +294,7 @@ void QgsSymbolButton::pasteSymbol()
 
 void QgsSymbolButton::copyColor()
 {
-  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( mSymbol->color() ) );
+  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::colorToMimeData( mSymbol->color() ).release() );
 }
 
 void QgsSymbolButton::pasteColor()
@@ -356,7 +357,7 @@ void QgsSymbolButton::mouseMoveEvent( QMouseEvent *e )
 
   //user is dragging
   QDrag *drag = new QDrag( this );
-  drag->setMimeData( QgsSymbolLayerUtils::colorToMimeData( mSymbol->color() ) );
+  drag->setMimeData( QgsSymbolLayerUtils::colorToMimeData( mSymbol->color() ).release() );
   drag->setPixmap( QgsColorWidget::createDragIcon( mSymbol->color() ) );
   drag->exec( Qt::CopyAction );
   setDown( false );

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1231,8 +1231,8 @@ void QgsTextFormatWidget::updateWidgetForFormat( const QgsTextFormat &format )
   }
   mBackgroundEffectWidget->setPaintEffect( mBackgroundEffect.get() );
 
-  mBackgroundMarkerSymbolButton->setSymbol( background.markerSymbol() ? background.markerSymbol()->clone() : QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
-  mBackgroundFillSymbolButton->setSymbol( background.fillSymbol() ? background.fillSymbol()->clone() : QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
+  mBackgroundMarkerSymbolButton->setSymbol( background.markerSymbol() ? background.markerSymbol()->clone() : QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
+  mBackgroundFillSymbolButton->setSymbol( background.fillSymbol() ? background.fillSymbol()->clone() : QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ).release() );
 
   // drop shadow
   mShadowDrawChkBx->setChecked( shadow.enabled() );

--- a/src/gui/symbology/qgs25drendererwidget.cpp
+++ b/src/gui/symbology/qgs25drendererwidget.cpp
@@ -66,7 +66,7 @@ Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer *layer, QgsStyle *sty
 
   if ( renderer )
   {
-    mRenderer.reset( Qgs25DRenderer::convertFromRenderer( renderer ) );
+    mRenderer = Qgs25DRenderer::convertFromRenderer( renderer );
   }
 
   mHeightWidget->setLayer( layer );

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -290,7 +290,7 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
   // (null renderer means "no previous renderer")
   if ( renderer )
   {
-    mRenderer.reset( QgsCategorizedSymbolRenderer::convertFromRenderer( renderer, layer ) );
+    mRenderer = QgsCategorizedSymbolRenderer::convertFromRenderer( renderer, layer );
   }
   if ( !mRenderer )
   {
@@ -324,7 +324,7 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
     btnColorRamp->setRandomColorRamp();
   }
 
-  mCategorizedSymbol.reset( QgsSymbol::defaultSymbol( mLayer->geometryType() ) );
+  mCategorizedSymbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
   if ( mCategorizedSymbol )
   {
     btnChangeCategorizedSymbol->setSymbolType( mCategorizedSymbol->type() );
@@ -521,7 +521,7 @@ void QgsCategorizedSymbolRendererWidget::changeCategorySymbol()
   }
   else
   {
-    symbol.reset( QgsSymbol::defaultSymbol( mLayer->geometryType() ) );
+    symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
   }
 
   QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
@@ -773,8 +773,8 @@ void QgsCategorizedSymbolRendererWidget::addCategory()
 {
   if ( !mModel )
     return;
-  QgsSymbol *symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
-  const QgsRendererCategory cat( QVariant(), symbol, QString(), true );
+  std::unique_ptr<QgsSymbol> symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
+  const QgsRendererCategory cat( QVariant(), symbol.release(), QString(), true );
   mModel->addCategory( cat );
   emit widgetChanged();
 }

--- a/src/gui/symbology/qgsembeddedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsembeddedsymbolrendererwidget.cpp
@@ -66,12 +66,12 @@ QgsEmbeddedSymbolRendererWidget::QgsEmbeddedSymbolRendererWidget( QgsVectorLayer
   // (null renderer means "no previous renderer")
   if ( renderer )
   {
-    mRenderer.reset( QgsEmbeddedSymbolRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsEmbeddedSymbolRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {
     // use default embedded renderer
-    mRenderer = std::make_unique<QgsEmbeddedSymbolRenderer>( QgsSymbol::defaultSymbol( type ) );
+    mRenderer = std::make_unique<QgsEmbeddedSymbolRenderer>( QgsSymbol::defaultSymbol( type ).release() );
     if ( renderer )
       renderer->copyRendererData( mRenderer.get() );
   }

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -473,7 +473,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   // (null renderer means "no previous renderer")
   if ( renderer )
   {
-    mRenderer.reset( QgsGraduatedSymbolRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsGraduatedSymbolRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {
@@ -533,7 +533,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
 
   viewGraduated->setStyle( new QgsGraduatedSymbolRendererViewStyle( viewGraduated ) );
 
-  mGraduatedSymbol.reset( QgsSymbol::defaultSymbol( mLayer->geometryType() ) );
+  mGraduatedSymbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
   if ( mGraduatedSymbol )
   {
     btnChangeGraduatedSymbol->setSymbolType( mGraduatedSymbol->type() );

--- a/src/gui/symbology/qgsheatmaprendererwidget.cpp
+++ b/src/gui/symbology/qgsheatmaprendererwidget.cpp
@@ -107,7 +107,7 @@ QgsHeatmapRendererWidget::QgsHeatmapRendererWidget( QgsVectorLayer *layer, QgsSt
 
   if ( renderer )
   {
-    mRenderer.reset( QgsHeatmapRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsHeatmapRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {

--- a/src/gui/symbology/qgsinvertedpolygonrendererwidget.cpp
+++ b/src/gui/symbology/qgsinvertedpolygonrendererwidget.cpp
@@ -69,7 +69,7 @@ QgsInvertedPolygonRendererWidget::QgsInvertedPolygonRendererWidget( QgsVectorLay
 
   if ( renderer )
   {
-    mRenderer.reset( QgsInvertedPolygonRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsInvertedPolygonRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {

--- a/src/gui/symbology/qgsmergedfeaturerendererwidget.cpp
+++ b/src/gui/symbology/qgsmergedfeaturerendererwidget.cpp
@@ -67,12 +67,12 @@ QgsMergedFeatureRendererWidget::QgsMergedFeatureRendererWidget( QgsVectorLayer *
   // (null renderer means "no previous renderer")
   if ( renderer )
   {
-    mRenderer.reset( QgsMergedFeatureRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsMergedFeatureRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {
     // use default embedded renderer
-    mRenderer = std::make_unique<QgsMergedFeatureRenderer>( QgsFeatureRenderer::defaultRenderer( type ) );
+    mRenderer = std::make_unique<QgsMergedFeatureRenderer>( QgsFeatureRenderer::defaultRenderer( type ).release() );
     if ( renderer )
       renderer->copyRendererData( mRenderer.get() );
   }

--- a/src/gui/symbology/qgsnullsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsnullsymbolrendererwidget.cpp
@@ -32,7 +32,7 @@ QgsNullSymbolRendererWidget::QgsNullSymbolRendererWidget( QgsVectorLayer *layer,
 {
   if ( renderer )
   {
-    mRenderer.reset( QgsNullSymbolRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsNullSymbolRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {

--- a/src/gui/symbology/qgspointclusterrendererwidget.cpp
+++ b/src/gui/symbology/qgspointclusterrendererwidget.cpp
@@ -68,7 +68,7 @@ QgsPointClusterRendererWidget::QgsPointClusterRendererWidget( QgsVectorLayer *la
 
   if ( renderer )
   {
-    mRenderer.reset( QgsPointClusterRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsPointClusterRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {

--- a/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
@@ -77,7 +77,7 @@ QgsPointDisplacementRendererWidget::QgsPointDisplacementRendererWidget( QgsVecto
 
   if ( renderer )
   {
-    mRenderer.reset( QgsPointDisplacementRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsPointDisplacementRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -312,7 +312,7 @@ void QgsRendererWidget::copySymbol()
     return;
   }
 
-  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( symbolList.at( 0 ) ) );
+  QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( symbolList.at( 0 ) ).release() );
 }
 
 void QgsRendererWidget::updateDataDefinedProperty()

--- a/src/gui/symbology/qgsrulebasedrendererwidget.cpp
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.cpp
@@ -66,14 +66,14 @@ QgsRuleBasedRendererWidget::QgsRuleBasedRendererWidget( QgsVectorLayer *layer, Q
 
   if ( renderer )
   {
-    mRenderer.reset( QgsRuleBasedRenderer::convertFromRenderer( renderer, layer ) );
+    mRenderer = QgsRuleBasedRenderer::convertFromRenderer( renderer, layer );
   }
   if ( !mRenderer )
   {
     // some default options
-    QgsSymbol *symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
+    std::unique_ptr<QgsSymbol> symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
 
-    mRenderer = std::make_unique<QgsRuleBasedRenderer>( symbol );
+    mRenderer = std::make_unique<QgsRuleBasedRenderer>( symbol.release() );
     if ( renderer )
       renderer->copyRendererData( mRenderer.get() );
   }
@@ -161,8 +161,8 @@ void QgsRuleBasedRendererWidget::setDockMode( bool dockMode )
 
 void QgsRuleBasedRendererWidget::addRule()
 {
-  QgsSymbol *s = QgsSymbol::defaultSymbol( mLayer->geometryType() );
-  QgsRuleBasedRenderer::Rule *newrule = new QgsRuleBasedRenderer::Rule( s );
+  std::unique_ptr<QgsSymbol> s = QgsSymbol::defaultSymbol( mLayer->geometryType() );
+  QgsRuleBasedRenderer::Rule *newrule = new QgsRuleBasedRenderer::Rule( s.release() );
 
   QgsRuleBasedRenderer::Rule *current = currentRule();
   if ( current )
@@ -406,7 +406,7 @@ QgsRuleBasedRenderer::RuleList QgsRuleBasedRendererWidget::selectedRules()
     const QgsRuleBasedRenderer::RuleList &children = parentRule->children();
     for ( int row = range.top(); row <= range.bottom(); row++ )
     {
-      rl.append( children.at( row )->clone() );
+      rl.append( children.at( row )->clone().release() );
     }
   }
   return rl;
@@ -443,7 +443,7 @@ void QgsRuleBasedRendererWidget::keyPressEvent( QKeyEvent *event )
     for ( ; rIt != mCopyBuffer.constEnd(); ++rIt )
     {
       int rows = mModel->rowCount();
-      mModel->insertRule( QModelIndex(), rows, ( *rIt )->clone() );
+      mModel->insertRule( QModelIndex(), rows, ( *rIt )->clone().release() );
     }
   }
 }
@@ -748,7 +748,7 @@ QgsRendererRulePropsWidget::QgsRendererRulePropsWidget( QgsRuleBasedRenderer::Ru
   else
   {
     groupSymbol->setChecked( false );
-    mSymbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
+    mSymbol = QgsSymbol::defaultSymbol( mLayer->geometryType() ).release();
   }
 
   mSymbolSelector = new QgsSymbolSelectorWidget( mSymbol, style, mLayer, this );
@@ -1176,7 +1176,7 @@ QMimeData *QgsRuleBasedRendererModel::mimeData( const QModelIndexList &indexes )
 
     // we use a clone of the existing rule because it has a new unique rule key
     // non-unique rule keys would confuse other components using them (e.g. legend)
-    QgsRuleBasedRenderer::Rule *rule = ruleForIndex( index )->clone();
+    std::unique_ptr<QgsRuleBasedRenderer::Rule> rule = ruleForIndex( index )->clone();
     QDomDocument doc;
     QgsSymbolMap symbols;
 
@@ -1187,8 +1187,6 @@ QMimeData *QgsRuleBasedRendererModel::mimeData( const QModelIndexList &indexes )
     QDomElement symbolsElem = QgsSymbolLayerUtils::saveSymbols( symbols, u"symbols"_s, doc, QgsReadWriteContext() );
     rootElem.appendChild( symbolsElem );
     doc.appendChild( rootElem );
-
-    delete rule;
 
     stream << doc.toString( -1 );
   }
@@ -1258,9 +1256,9 @@ bool QgsRuleBasedRendererModel::dropMimeData( const QMimeData *data, Qt::DropAct
     QDomElement ruleElem = rootElem.firstChildElement( u"rule"_s );
     if ( rootElem.attribute( u"type"_s ) == "labeling"_L1 )
       _labeling2rendererRules( ruleElem );
-    QgsRuleBasedRenderer::Rule *rule = QgsRuleBasedRenderer::Rule::create( ruleElem, symbolMap, false );
+    std::unique_ptr<QgsRuleBasedRenderer::Rule> rule = QgsRuleBasedRenderer::Rule::create( ruleElem, symbolMap, false );
 
-    insertRule( parent, row + rows, rule );
+    insertRule( parent, row + rows, rule.release() );
 
     ++rows;
   }

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
@@ -40,14 +40,14 @@ QgsSingleSymbolRendererWidget::QgsSingleSymbolRendererWidget( QgsVectorLayer *la
 
   if ( renderer )
   {
-    mRenderer.reset( QgsSingleSymbolRenderer::convertFromRenderer( renderer ) );
+    mRenderer = QgsSingleSymbolRenderer::convertFromRenderer( renderer );
   }
   if ( !mRenderer )
   {
-    QgsSymbol *symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
+    std::unique_ptr<QgsSymbol> symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
 
     if ( symbol )
-      mRenderer = std::make_unique<QgsSingleSymbolRenderer>( symbol );
+      mRenderer = std::make_unique<QgsSingleSymbolRenderer>( symbol.release() );
 
     if ( renderer )
       renderer->copyRendererData( mRenderer.get() );

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -740,7 +740,7 @@ void QgsStyleManagerDialog::copyItem()
       std::unique_ptr<QgsSymbol> symbol( mStyle->symbol( details.name ) );
       if ( !symbol )
         return;
-      QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( symbol.get() ) );
+      QApplication::clipboard()->setMimeData( QgsSymbolLayerUtils::symbolToMimeData( symbol.get() ).release() );
       break;
     }
 

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -426,7 +426,7 @@ void QgsVectorTileBasicRendererWidget::apply()
 void QgsVectorTileBasicRendererWidget::addStyle( Qgis::GeometryType geomType )
 {
   QgsVectorTileBasicRendererStyle style( QString(), QString(), geomType );
-  style.setSymbol( QgsSymbol::defaultSymbol( geomType ) );
+  style.setSymbol( QgsSymbol::defaultSymbol( geomType ).release() );
 
   switch ( geomType )
   {

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3543,7 +3543,7 @@ namespace QgsWms
       // create renderer from sld document
       std::unique_ptr<QgsFeatureRenderer> renderer;
       QDomElement el = sldDoc.documentElement();
-      renderer.reset( QgsFeatureRenderer::loadSld( el, param.mGeom.type(), errorMsg ) );
+      renderer = QgsFeatureRenderer::loadSld( el, param.mGeom.type(), errorMsg );
       if ( !renderer )
       {
         QgsMessageLog::logMessage( errorMsg, "Server", Qgis::MessageLevel::Info );

--- a/tests/src/3d/testqgs3dannotationlayerrendering.cpp
+++ b/tests/src/3d/testqgs3dannotationlayerrendering.cpp
@@ -99,33 +99,33 @@ void TestQgs3DAnnotationLayerRendering::testAnnotationLayerBillboards()
   auto annotationLayer = std::make_unique<QgsAnnotationLayer>( "test", QgsAnnotationLayer::LayerOptions( QgsCoordinateTransformContext() ) );
 
   auto marker1 = std::make_unique< QgsAnnotationMarkerItem >( QgsPoint( 1000, 1000 ) );
-  QgsMarkerSymbol *markerSymbol = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto markerSymbol = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   markerSymbol->setColor( QColor( 255, 0, 0 ) );
   markerSymbol->setSize( 4 );
   QgsSimpleMarkerSymbolLayer *sl = static_cast<QgsSimpleMarkerSymbolLayer *>( markerSymbol->symbolLayer( 0 ) );
   sl->setStrokeColor( QColor( 0, 0, 255 ) );
   sl->setStrokeWidth( 2 );
-  marker1->setSymbol( markerSymbol );
+  marker1->setSymbol( markerSymbol.release() );
   annotationLayer->addItem( marker1.release() );
 
   auto marker2 = std::make_unique< QgsAnnotationMarkerItem >( QgsPoint( 1000, 2000 ) );
-  markerSymbol = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  markerSymbol = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   markerSymbol->setColor( QColor( 0, 255, 0 ) );
   markerSymbol->setSize( 20 );
   sl = static_cast<QgsSimpleMarkerSymbolLayer *>( markerSymbol->symbolLayer( 0 ) );
   sl->setStrokeColor( QColor( 255, 0, 255 ) );
   sl->setStrokeWidth( 2 );
-  marker2->setSymbol( markerSymbol );
+  marker2->setSymbol( markerSymbol.release() );
   annotationLayer->addItem( marker2.release() );
 
   auto marker3 = std::make_unique< QgsAnnotationMarkerItem >( QgsPoint( 2000, 2000 ) );
-  markerSymbol = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  markerSymbol = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   markerSymbol->setColor( QColor( 0, 0, 255 ) );
   markerSymbol->setSize( 30 );
   sl = static_cast<QgsSimpleMarkerSymbolLayer *>( markerSymbol->symbolLayer( 0 ) );
   sl->setStrokeColor( QColor( 0, 255, 255 ) );
   sl->setStrokeWidth( 2 );
-  marker3->setSymbol( markerSymbol );
+  marker3->setSymbol( markerSymbol.release() );
   annotationLayer->addItem( marker3.release() );
 
   auto renderer = std::make_unique< QgsAnnotationLayer3DRenderer >();

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -1785,14 +1785,14 @@ void TestQgs3DRendering::testBillboardRendering()
   featureList << f1 << f2 << f3;
   layerPointsZ->dataProvider()->addFeatures( featureList );
 
-  QgsMarkerSymbol *markerSymbol = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto markerSymbol = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   markerSymbol->setColor( QColor( 255, 0, 0 ) );
   markerSymbol->setSize( 4 );
   QgsSimpleMarkerSymbolLayer *sl = static_cast<QgsSimpleMarkerSymbolLayer *>( markerSymbol->symbolLayer( 0 ) );
   sl->setStrokeColor( QColor( 0, 0, 255 ) );
   sl->setStrokeWidth( 2 );
   QgsPoint3DSymbol *point3DSymbol = new QgsPoint3DSymbol();
-  point3DSymbol->setBillboardSymbol( markerSymbol );
+  point3DSymbol->setBillboardSymbol( markerSymbol.release() );
   point3DSymbol->setShape( Qgis::Point3DShape::Billboard );
 
   layerPointsZ->setRenderer3D( new QgsVectorLayer3DRenderer( point3DSymbol ) );

--- a/tests/src/3d/testqgspointcloud3drendering.cpp
+++ b/tests/src/3d/testqgspointcloud3drendering.cpp
@@ -113,7 +113,7 @@ void TestQgsPointCloud3DRendering::testSync3DRendererTo2DRenderer()
   QgsPointCloudAttributeByRampRenderer *colorramp2DRenderer = new QgsPointCloudAttributeByRampRenderer();
   colorramp2DRenderer->setAttribute( u"Z"_s );
   QgsColorRampShader shader = QgsColorRampShader( 0.98, 1.25 );
-  shader.setSourceColorRamp( QgsStyle::defaultStyle()->colorRamp( u"Viridis"_s ) );
+  shader.setSourceColorRamp( QgsStyle::defaultStyle()->colorRamp( u"Viridis"_s ).release() );
   shader.classifyColorRamp( 5, -1, QgsRectangle(), nullptr );
   colorramp2DRenderer->setColorRampShader( shader );
   QgsPointCloudRgbRenderer *rgb2DRenderer = new QgsPointCloudRgbRenderer();
@@ -185,7 +185,7 @@ void TestQgsPointCloud3DRendering::testDisableSync3DRendererTo2DRenderer()
   QgsPointCloudAttributeByRampRenderer *colorramp2DRenderer = new QgsPointCloudAttributeByRampRenderer();
   colorramp2DRenderer->setAttribute( u"Z"_s );
   QgsColorRampShader shader = QgsColorRampShader( 0.98, 1.25 );
-  shader.setSourceColorRamp( QgsStyle::defaultStyle()->colorRamp( u"Viridis"_s ) );
+  shader.setSourceColorRamp( QgsStyle::defaultStyle()->colorRamp( u"Viridis"_s ).release() );
   shader.classifyColorRamp( 5, -1, QgsRectangle(), nullptr );
   colorramp2DRenderer->setColorRampShader( shader );
   QgsPointCloudRgbRenderer *rgb2DRenderer = dynamic_cast<QgsPointCloudRgbRenderer *>( mLayer->renderer()->clone() );
@@ -372,7 +372,7 @@ void TestQgsPointCloud3DRendering::testPointCloudAttributeByRamp()
   QgsColorRampPointCloud3DSymbol *symbol = new QgsColorRampPointCloud3DSymbol();
   symbol->setAttribute( u"Intensity"_s );
   QgsColorRampShader shader = QgsColorRampShader( 199, 2086 );
-  shader.setSourceColorRamp( QgsStyle::defaultStyle()->colorRamp( u"Viridis"_s ) );
+  shader.setSourceColorRamp( QgsStyle::defaultStyle()->colorRamp( u"Viridis"_s ).release() );
   shader.classifyColorRamp( 5, -1, QgsRectangle(), nullptr );
   symbol->setColorRampShader( shader );
   symbol->setPointSize( 10 );

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -1188,7 +1188,7 @@ void TestQgsProcessingAlgsPt1::categorizeByStyle()
   QVERIFY( catRenderer->categories().at( catRenderer->categoryIndexForValue( u"b"_s ) ).symbol()->color().name() != "#00ff00"_L1 );
   QVERIFY( catRenderer->categories().at( catRenderer->categoryIndexForValue( u"c "_s ) ).symbol()->color().name() != "#0000ff"_L1 );
   // reset renderer
-  layer->setRenderer( new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
+  layer->setRenderer( new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() ) );
 
   // case insensitive
   parameters.insert( u"CASE_SENSITIVE"_s, false );
@@ -1209,7 +1209,7 @@ void TestQgsProcessingAlgsPt1::categorizeByStyle()
   QCOMPARE( catRenderer->categories().at( catRenderer->categoryIndexForValue( u"b"_s ) ).symbol()->color().name(), u"#00ff00"_s );
   QVERIFY( catRenderer->categories().at( catRenderer->categoryIndexForValue( u"c "_s ) ).symbol()->color().name() != "#0000ff"_L1 );
   // reset renderer
-  layer->setRenderer( new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
+  layer->setRenderer( new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() ) );
 
   // tolerant
   parameters.insert( u"CASE_SENSITIVE"_s, true );
@@ -1232,7 +1232,7 @@ void TestQgsProcessingAlgsPt1::categorizeByStyle()
   QVERIFY( catRenderer->categories().at( catRenderer->categoryIndexForValue( u"b"_s ) ).symbol()->color().name() != "#00ff00"_L1 );
   QCOMPARE( catRenderer->categories().at( catRenderer->categoryIndexForValue( u"c "_s ) ).symbol()->color().name(), u"#0000ff"_s );
   // reset renderer
-  layer->setRenderer( new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) ) );
+  layer->setRenderer( new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() ) );
 
   // no optional sinks
   parameters.insert( u"CASE_SENSITIVE"_s, false );
@@ -4436,14 +4436,14 @@ void TestQgsProcessingAlgsPt1::styleFromProject()
   QgsVectorLayer *vl2 = new QgsVectorLayer( u"Point?crs=epsg:4326&field=pk:int&field=col1:string"_s, u"vl2"_s, u"memory"_s );
   QVERIFY( vl2->isValid() );
   p.addMapLayer( vl2 );
-  QgsSymbol *s1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  std::unique_ptr<QgsSymbol> s1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
   s1->setColor( QColor( 0, 255, 0 ) );
-  QgsSymbol *s2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  std::unique_ptr<QgsSymbol> s2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
   s2->setColor( QColor( 0, 255, 255 ) );
   QgsRuleBasedRenderer::Rule *rootRule = new QgsRuleBasedRenderer::Rule( nullptr );
-  QgsRuleBasedRenderer::Rule *rule2 = new QgsRuleBasedRenderer::Rule( s1, 0, 0, u"fld >= 5 and fld <= 20"_s );
+  QgsRuleBasedRenderer::Rule *rule2 = new QgsRuleBasedRenderer::Rule( s1.release(), 0, 0, u"fld >= 5 and fld <= 20"_s );
   rootRule->appendChild( rule2 );
-  QgsRuleBasedRenderer::Rule *rule3 = new QgsRuleBasedRenderer::Rule( s2, 0, 0, u"fld <= 10"_s );
+  QgsRuleBasedRenderer::Rule *rule3 = new QgsRuleBasedRenderer::Rule( s2.release(), 0, 0, u"fld <= 10"_s );
   rule2->appendChild( rule3 );
   vl2->setRenderer( new QgsRuleBasedRenderer( rootRule ) );
   // labeling
@@ -4476,12 +4476,12 @@ void TestQgsProcessingAlgsPt1::styleFromProject()
 
   // with annotations
   QgsTextAnnotation *annotation = new QgsTextAnnotation();
-  QgsSymbol *a1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  std::unique_ptr<QgsSymbol> a1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
   a1->setColor( QColor( 0, 200, 0 ) );
-  annotation->setMarkerSymbol( static_cast<QgsMarkerSymbol *>( a1 ) );
-  QgsSymbol *a2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon );
+  annotation->setMarkerSymbol( static_cast<QgsMarkerSymbol *>( a1.release() ) );
+  std::unique_ptr<QgsSymbol> a2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon );
   a2->setColor( QColor( 200, 200, 0 ) );
-  annotation->setFillSymbol( static_cast<QgsFillSymbol *>( a2 ) );
+  annotation->setFillSymbol( static_cast<QgsFillSymbol *>( a2.release() ) );
   p.annotationManager()->addAnnotation( annotation );
 
   // ok, run alg
@@ -4553,10 +4553,10 @@ void TestQgsProcessingAlgsPt1::combineStyles()
   s1.addSymbol( u"sym1"_s, markerSymbol, true );
   s1.tagSymbol( QgsStyle::SymbolEntity, u"sym1"_s, QStringList() << u"t1"_s << u"t2"_s );
 
-  QgsSymbol *sym1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
-  s2.addSymbol( u"sym2"_s, sym1, true );
-  QgsSymbol *sym2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
-  s2.addSymbol( u"sym1"_s, sym2, true );
+  std::unique_ptr<QgsSymbol> sym1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  s2.addSymbol( u"sym2"_s, sym1.release(), true );
+  std::unique_ptr<QgsSymbol> sym2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  s2.addSymbol( u"sym1"_s, sym2.release(), true );
 
   QgsPalLayerSettings settings;
   settings.fieldName = u"Class"_s;

--- a/tests/src/core/testqgscallout.cpp
+++ b/tests/src/core/testqgscallout.cpp
@@ -203,12 +203,12 @@ void TestQgsCallout::init()
   const QString filename = QStringLiteral( TEST_DATA_DIR ) + "/points.shp";
   vl = new QgsVectorLayer( filename, u"points"_s, u"ogr"_s );
   QVERIFY( vl->isValid() );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
 
-  vl->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
   QgsProject::instance()->addMapLayer( vl );
 }
 
@@ -1773,11 +1773,11 @@ void TestQgsCallout::calloutBehindIndividualLabels()
 void TestQgsCallout::calloutNoDrawToAllParts()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"MultiPoint?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 190040 << 5000030 );
@@ -1841,11 +1841,11 @@ void TestQgsCallout::calloutNoDrawToAllParts()
 void TestQgsCallout::calloutDrawToAllParts()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"MultiPoint?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 190040 << 5000030 );
@@ -1910,11 +1910,11 @@ void TestQgsCallout::calloutDrawToAllParts()
 void TestQgsCallout::calloutDataDefinedDrawToAllParts()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"MultiPoint?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 190040 << 5000030 );
@@ -1979,9 +1979,9 @@ void TestQgsCallout::calloutDataDefinedDrawToAllParts()
 void TestQgsCallout::calloutPointOnExterior()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"Polygon?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsFillSymbol *fill = static_cast<QgsFillSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
+  auto fill = qgis::unique_ptr_static_cast<QgsFillSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
   fill->setColor( QColor( 255, 0, 0 ) );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( fill ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( fill.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 189950 << 5000000 );
@@ -2042,9 +2042,9 @@ void TestQgsCallout::calloutPointOnExterior()
 void TestQgsCallout::calloutDataDefinedAnchorPoint()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"Polygon?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsFillSymbol *fill = static_cast<QgsFillSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
+  auto fill = qgis::unique_ptr_static_cast<QgsFillSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
   fill->setColor( QColor( 255, 0, 0 ) );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( fill ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( fill.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 189950 << 5000000 );
@@ -2105,9 +2105,9 @@ void TestQgsCallout::calloutDataDefinedAnchorPoint()
 void TestQgsCallout::calloutDataDefinedDestination()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"Polygon?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsFillSymbol *fill = static_cast<QgsFillSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
+  auto fill = qgis::unique_ptr_static_cast<QgsFillSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
   fill->setColor( QColor( 255, 0, 0 ) );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( fill ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( fill.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 189950 << 5000000 );
@@ -2170,9 +2170,9 @@ void TestQgsCallout::calloutDataDefinedDestination()
 void TestQgsCallout::calloutDataDefinedOrigin()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"Polygon?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsFillSymbol *fill = static_cast<QgsFillSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
+  auto fill = qgis::unique_ptr_static_cast<QgsFillSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
   fill->setColor( QColor( 255, 0, 0 ) );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( fill ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( fill.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 189950 << 5000000 );
@@ -2340,11 +2340,11 @@ void TestQgsCallout::manhattanRotated()
 void TestQgsCallout::manhattanNoDrawToAllParts()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"MultiPoint?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 190040 << 5000030 );
@@ -2408,11 +2408,11 @@ void TestQgsCallout::manhattanNoDrawToAllParts()
 void TestQgsCallout::manhattanDrawToAllParts()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"MultiPoint?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 190040 << 5000030 );
@@ -2477,11 +2477,11 @@ void TestQgsCallout::manhattanDrawToAllParts()
 void TestQgsCallout::manhattanDataDefinedDrawToAllParts()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"MultiPoint?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 190040 << 5000030 );
@@ -2546,9 +2546,9 @@ void TestQgsCallout::manhattanDataDefinedDrawToAllParts()
 void TestQgsCallout::manhattanDataDefinedDestination()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"Polygon?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsFillSymbol *fill = static_cast<QgsFillSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
+  auto fill = qgis::unique_ptr_static_cast<QgsFillSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
   fill->setColor( QColor( 255, 0, 0 ) );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( fill ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( fill.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 189950 << 5000000 );
@@ -2611,9 +2611,9 @@ void TestQgsCallout::manhattanDataDefinedDestination()
 void TestQgsCallout::manhattanDataDefinedOrigin()
 {
   auto vl2 = std::make_unique<QgsVectorLayer>( u"Polygon?crs=epsg:3946&field=id:integer&field=labelx:integer&field=labely:integer"_s, u"vl"_s, u"memory"_s );
-  QgsFillSymbol *fill = static_cast<QgsFillSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
+  auto fill = qgis::unique_ptr_static_cast<QgsFillSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
   fill->setColor( QColor( 255, 0, 0 ) );
-  vl2->setRenderer( new QgsSingleSymbolRenderer( fill ) );
+  vl2->setRenderer( new QgsSingleSymbolRenderer( fill.release() ) );
 
   QgsFeature f;
   f.setAttributes( QgsAttributes() << 1 << 189950 << 5000000 );

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -177,12 +177,12 @@ void TestQgsDxfExport::init()
   QVariantMap ggProps;
   ggProps.insert( u"SymbolType"_s, u"Fill"_s );
   ggProps.insert( u"geometryModifier"_s, u"buffer( $geometry, 0.1 )"_s );
-  QgsSymbolLayer *ggSymbolLayer = QgsGeometryGeneratorSymbolLayer::create( ggProps );
+  std::unique_ptr<QgsSymbolLayer> ggSymbolLayer = QgsGeometryGeneratorSymbolLayer::create( ggProps );
   QgsSymbolLayerList fillSymbolLayerList;
   fillSymbolLayerList << new QgsSimpleFillSymbolLayer();
   ggSymbolLayer->setSubSymbol( new QgsFillSymbol( fillSymbolLayerList ) );
   QgsSymbolLayerList slList;
-  slList << ggSymbolLayer;
+  slList << ggSymbolLayer.release();
   QgsMarkerSymbol *markerSymbol = new QgsMarkerSymbol( slList );
   QgsSingleSymbolRenderer *sr = new QgsSingleSymbolRenderer( markerSymbol );
   mPointLayerGeometryGenerator->setRenderer( sr );

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -7071,12 +7071,12 @@ void TestQgsLabelingEngine::testSymbologyScalingFactor()
   // test rendering labels with a layer with a reference scale set (with callout)
   auto vl = std::make_unique<QgsVectorLayer>( QStringLiteral( TEST_DATA_DIR ) + "/points.shp", u"points"_s, u"ogr"_s );
   QVERIFY( vl->isValid() );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
 
-  vl->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
 
   const QSize size( 640, 480 );
   QgsMapSettings mapSettings;
@@ -7134,12 +7134,12 @@ void TestQgsLabelingEngine::testSymbologyScalingFactor2()
   // test rendering labels with a layer with a reference scale set (with label background)
   auto vl = std::make_unique<QgsVectorLayer>( QStringLiteral( TEST_DATA_DIR ) + "/points.shp", u"points"_s, u"ogr"_s );
   QVERIFY( vl->isValid() );
-  QgsMarkerSymbol *marker = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsMarkerSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
   marker->setColor( QColor( 255, 0, 0 ) );
   marker->setSize( 3 );
   static_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) )->setStrokeStyle( Qt::NoPen );
 
-  vl->setRenderer( new QgsSingleSymbolRenderer( marker ) );
+  vl->setRenderer( new QgsSingleSymbolRenderer( marker.release() ) );
 
   const QSize size( 640, 480 );
   QgsMapSettings mapSettings;

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -335,9 +335,9 @@ void TestQgsLayerTree::testRestrictedSymbolSize()
   QgsProject project;
   project.addMapLayer( vl );
 
-  QgsMarkerSymbol *symbol = static_cast<QgsMarkerSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
-  symbol->setSize( 500.0 );
-  symbol->setSizeUnit( Qgis::RenderUnit::MapUnits );
+  std::unique_ptr<QgsSymbol> symbol = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  static_cast<QgsMarkerSymbol *>( symbol.get() )->setSize( 500.0 );
+  static_cast<QgsMarkerSymbol *>( symbol.get() )->setSizeUnit( Qgis::RenderUnit::MapUnits );
 
   //create a categorized renderer for layer
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
@@ -395,12 +395,12 @@ void TestQgsLayerTree::testRestrictedSymbolSizeWithGeometryGenerator()
   QVariantMap ggProps;
   ggProps.insert( u"SymbolType"_s, u"Fill"_s );
   ggProps.insert( u"geometryModifier"_s, u"buffer( $geometry, 200 )"_s );
-  QgsSymbolLayer *ggSymbolLayer = QgsGeometryGeneratorSymbolLayer::create( ggProps );
+  std::unique_ptr<QgsSymbolLayer> ggSymbolLayer = QgsGeometryGeneratorSymbolLayer::create( ggProps );
   QgsSymbolLayerList fillSymbolLayerList;
   fillSymbolLayerList << new QgsSimpleFillSymbolLayer();
   ggSymbolLayer->setSubSymbol( new QgsFillSymbol( fillSymbolLayerList ) );
   QgsSymbolLayerList slList;
-  slList << ggSymbolLayer;
+  slList << ggSymbolLayer.release();
   QgsMarkerSymbol *symbol = new QgsMarkerSymbol( slList );
 
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
@@ -438,10 +438,10 @@ void TestQgsLayerTree::testShowHideAllSymbolNodes()
   //create a categorized renderer for layer
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
   renderer->setClassAttribute( u"col1"_s );
-  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
-  renderer->addCategory( QgsRendererCategory( "a", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"a"_s ) );
-  renderer->addCategory( QgsRendererCategory( "b", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"b"_s ) );
-  renderer->addCategory( QgsRendererCategory( "c", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"c"_s ) );
+  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
+  renderer->addCategory( QgsRendererCategory( "a", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"a"_s ) );
+  renderer->addCategory( QgsRendererCategory( "b", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"b"_s ) );
+  renderer->addCategory( QgsRendererCategory( "c", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"c"_s ) );
   vl->setRenderer( renderer );
 
   //create legend with symbology nodes for categorized renderer
@@ -488,10 +488,10 @@ void TestQgsLayerTree::testFindLegendNode()
   //create a categorized renderer for layer
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
   renderer->setClassAttribute( u"col1"_s );
-  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
-  renderer->addCategory( QgsRendererCategory( "a", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"a"_s ) );
-  renderer->addCategory( QgsRendererCategory( "b", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"b"_s ) );
-  renderer->addCategory( QgsRendererCategory( "c", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"c"_s ) );
+  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
+  renderer->addCategory( QgsRendererCategory( "a", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"a"_s ) );
+  renderer->addCategory( QgsRendererCategory( "b", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"b"_s ) );
+  renderer->addCategory( QgsRendererCategory( "c", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"c"_s ) );
   vl->setRenderer( renderer );
 
   //create legend with symbology nodes for categorized renderer
@@ -523,7 +523,7 @@ void TestQgsLayerTree::testLegendSymbolCategorized()
   //test retrieving/setting a categorized renderer's symbol through the legend node
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
   renderer->setClassAttribute( u"col1"_s );
-  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
   QVariantMap props;
   props.insert( u"color"_s, u"#ff0000"_s );
   props.insert( u"outline_color"_s, u"#000000"_s );
@@ -540,7 +540,7 @@ void TestQgsLayerTree::testLegendSymbolGraduated()
   //test retrieving/setting a graduated renderer's symbol through the legend node
   QgsGraduatedSymbolRenderer *renderer = new QgsGraduatedSymbolRenderer();
   renderer->setClassAttribute( u"col1"_s );
-  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
   QVariantMap props;
   props.insert( u"color"_s, u"#ff0000"_s );
   props.insert( u"outline_color"_s, u"#000000"_s );
@@ -1029,10 +1029,10 @@ void TestQgsLayerTree::testSymbolText()
   //create a categorized renderer for layer
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
   renderer->setClassAttribute( u"col1"_s );
-  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
-  renderer->addCategory( QgsRendererCategory( "a", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"a [% 1 + 2 %]"_s ) );
-  renderer->addCategory( QgsRendererCategory( "b", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"b,c"_s ) );
-  renderer->addCategory( QgsRendererCategory( "c", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"c"_s ) );
+  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
+  renderer->addCategory( QgsRendererCategory( "a", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"a [% 1 + 2 %]"_s ) );
+  renderer->addCategory( QgsRendererCategory( "b", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"b,c"_s ) );
+  renderer->addCategory( QgsRendererCategory( "c", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"c"_s ) );
   vl->setRenderer( renderer );
 
   //create legend with symbology nodes for categorized renderer
@@ -1223,9 +1223,9 @@ void TestQgsLayerTree::testSymbolLegendNodeSetData()
 
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
   renderer->setClassAttribute( u"col1"_s );
-  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
-  renderer->addCategory( QgsRendererCategory( "a", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"a"_s ) );
-  renderer->addCategory( QgsRendererCategory( "b", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"b"_s ) );
+  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
+  renderer->addCategory( QgsRendererCategory( "a", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"a"_s ) );
+  renderer->addCategory( QgsRendererCategory( "b", QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"b"_s ) );
   vl->setRenderer( renderer );
 
   QgsLayerTree *root = new QgsLayerTree();

--- a/tests/src/core/testqgsmaprendererjob.cpp
+++ b/tests/src/core/testqgsmaprendererjob.cpp
@@ -1081,7 +1081,7 @@ void TestQgsMapRendererJob::testMapShading()
   vectorLayer->addFeature( ft0 );
   vectorLayer->commitChanges();
   QVERIFY( vectorLayer->featureCount() == 1 );
-  std::unique_ptr<QgsFillSymbol> fill( static_cast<QgsFillSymbol *>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) ) );
+  auto fill = qgis::unique_ptr_static_cast<QgsFillSymbol>( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
   fill->setColor( QColor( 255, 0, 255 ) );
   vectorLayer->setRenderer( new QgsSingleSymbolRenderer( fill.release() ) );
 

--- a/tests/src/core/testqgsmarkerlinesymbol.cpp
+++ b/tests/src/core/testqgsmarkerlinesymbol.cpp
@@ -151,12 +151,12 @@ void TestQgsMarkerLineSymbol::pointNumInterval()
   props[u"color"_s] = u"255,0,0"_s;
   props[u"size"_s] = u"2"_s;
   props[u"outline_style"_s] = u"no"_s;
-  QgsSimpleMarkerSymbolLayer *marker = static_cast<QgsSimpleMarkerSymbolLayer *>( QgsSimpleMarkerSymbolLayer::create( props ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsSimpleMarkerSymbolLayer>( QgsSimpleMarkerSymbolLayer::create( props ) );
 
   marker->setDataDefinedProperty( QgsSymbolLayer::Property::Size, QgsProperty::fromExpression( u"@geometry_point_num * 2"_s ) );
 
   QgsMarkerSymbol *subSymbol = new QgsMarkerSymbol();
-  subSymbol->changeSymbolLayer( 0, marker );
+  subSymbol->changeSymbolLayer( 0, marker.release() );
   ml->setSubSymbol( subSymbol );
 
   mLinesLayer->setRenderer( r );
@@ -180,12 +180,12 @@ void TestQgsMarkerLineSymbol::pointNumVertex()
   props[u"color"_s] = u"255,0,0"_s;
   props[u"size"_s] = u"2"_s;
   props[u"outline_style"_s] = u"no"_s;
-  QgsSimpleMarkerSymbolLayer *marker = static_cast<QgsSimpleMarkerSymbolLayer *>( QgsSimpleMarkerSymbolLayer::create( props ) );
+  auto marker = qgis::unique_ptr_static_cast<QgsSimpleMarkerSymbolLayer>( QgsSimpleMarkerSymbolLayer::create( props ) );
 
   marker->setDataDefinedProperty( QgsSymbolLayer::Property::Size, QgsProperty::fromExpression( u"@geometry_point_num * 2"_s ) );
 
   QgsMarkerSymbol *subSymbol = new QgsMarkerSymbol();
-  subSymbol->changeSymbolLayer( 0, marker );
+  subSymbol->changeSymbolLayer( 0, marker.release() );
   ml->setSubSymbol( subSymbol );
 
   mLinesLayer->setRenderer( r );

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -67,10 +67,9 @@ class TestQgsRuleBasedRenderer : public QgsTest
       xml2domElement( u"rulebasedrenderer_simple.xml"_s, doc );
       QDomElement elem = doc.documentElement();
 
-      QgsRuleBasedRenderer *r = static_cast<QgsRuleBasedRenderer *>( QgsRuleBasedRenderer::create( elem, QgsReadWriteContext() ) );
+      auto r = qgis::unique_ptr_static_cast<QgsRuleBasedRenderer>( QgsRuleBasedRenderer::create( elem, QgsReadWriteContext() ) );
       QVERIFY( r );
       check_tree_valid( r->rootRule() );
-      delete r;
     }
 
     void test_load_invalid_xml()
@@ -79,7 +78,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       xml2domElement( u"rulebasedrenderer_invalid.xml"_s, doc );
       QDomElement elem = doc.documentElement();
 
-      const std::shared_ptr<QgsRuleBasedRenderer> r( static_cast<QgsRuleBasedRenderer *>( QgsRuleBasedRenderer::create( elem, QgsReadWriteContext() ) ) );
+      auto r = qgis::unique_ptr_static_cast<QgsRuleBasedRenderer>( QgsRuleBasedRenderer::create( elem, QgsReadWriteContext() ) );
       QVERIFY( !r );
     }
 
@@ -100,11 +99,11 @@ class TestQgsRuleBasedRenderer : public QgsTest
       f3.setAttribute( idx, QVariant( 100 ) );
 
       // prepare renderer
-      QgsSymbol *s1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
-      QgsSymbol *s2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+      std::unique_ptr<QgsSymbol> s1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+      std::unique_ptr<QgsSymbol> s2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
       RRule *rootRule = new RRule( nullptr );
-      rootRule->appendChild( new RRule( s1, 0, 0, u"fld >= 5 and fld <= 20"_s ) );
-      rootRule->appendChild( new RRule( s2, 0, 0, u"fld <= 10"_s ) );
+      rootRule->appendChild( new RRule( s1.release(), 0, 0, u"fld >= 5 and fld <= 20"_s ) );
+      rootRule->appendChild( new RRule( s2.release(), 0, 0, u"fld <= 10"_s ) );
       QgsRuleBasedRenderer r( rootRule );
 
       QVERIFY( r.capabilities() & QgsFeatureRenderer::MoreSymbolsPerFeature );
@@ -847,7 +846,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       cats.append( QgsRendererCategory( QVariantList( { 3, 4 } ), new QgsMarkerSymbol(), "result 3/4" ) );
       c = std::make_unique<QgsCategorizedSymbolRenderer>( "id + 1", cats );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() );
       QCOMPARE( r->rootRule()->children().size(), 3 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "id + 1 = 1" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "id + 1 = 2" );
@@ -860,7 +859,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       cats.append( QgsRendererCategory( QVariantList( { 3, 4 } ), new QgsMarkerSymbol(), "result 3/4" ) );
       c = std::make_unique<QgsCategorizedSymbolRenderer>( "\"id\"", cats );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" = 1" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" = 2" );
       QCOMPARE( r->rootRule()->children()[2]->filterExpression(), "\"id\" IN (3,4)" );
@@ -871,7 +870,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       cats.append( QgsRendererCategory( 2, new QgsMarkerSymbol(), "fa_cy-fie+ld 2" ) );
       c = std::make_unique<QgsCategorizedSymbolRenderer>( "fa_cy-fie+ld", cats );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"fa_cy-fie+ld\" = 1" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"fa_cy-fie+ld\" = 2" );
     }
@@ -923,7 +922,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       cats.append( QgsRendererCategory( QVariantList( { 3, 4 } ), new QgsMarkerSymbol(), "result 3/4" ) );
       c = std::make_unique<QgsCategorizedSymbolRenderer>( "id + 1", cats );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get() );
       QCOMPARE( r->rootRule()->children().size(), 3 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "id + 1 = 1" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "id + 1 = 2" );
@@ -936,7 +935,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       cats.append( QgsRendererCategory( QVariantList( { 3, 4 } ), new QgsMarkerSymbol(), "result 3/4" ) );
       c = std::make_unique<QgsCategorizedSymbolRenderer>( "\"id\"", cats );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get() );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" = 1" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" = 2" );
       QCOMPARE( r->rootRule()->children()[2]->filterExpression(), "\"id\" IN (3,4)" );
@@ -948,7 +947,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       cats.append( QgsRendererCategory( 2, new QgsMarkerSymbol(), "fa_cy-fie+ld 2" ) );
       c = std::make_unique<QgsCategorizedSymbolRenderer>( "fa_cy-fie+ld", cats );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get() );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "fa_cy-fie+ld = 1" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "fa_cy-fie+ld = 2" );
     }
@@ -997,7 +996,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       ranges.append( QgsRendererRange( 0, 1, new QgsMarkerSymbol(), "0-1" ) );
       c = std::make_unique<QgsGraduatedSymbolRenderer>( "id", ranges );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() );
       QCOMPARE( r->rootRule()->children().size(), 3 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" > 2.0000000000000000" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.0000000000000000 AND \"id\" <= 2.0000000000000000" );
@@ -1009,7 +1008,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       ranges.append( QgsRendererRange( 1, 2, new QgsMarkerSymbol(), "1-2" ) );
       c = std::make_unique<QgsGraduatedSymbolRenderer>( "id / 2", ranges );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() );
       QCOMPARE( r->rootRule()->children().size(), 2 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) <= 1.0000000000000000" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.0000000000000000" );
@@ -1020,7 +1019,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       ranges.append( QgsRendererRange( 1, 2, new QgsMarkerSymbol(), "1-2" ) );
       c = std::make_unique<QgsGraduatedSymbolRenderer>( "\"id\"", ranges );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() );
       QCOMPARE( r->rootRule()->children().size(), 2 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.0000000000000000" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.0000000000000000" );
@@ -1031,7 +1030,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       ranges.append( QgsRendererRange( 1, 2, new QgsMarkerSymbol(), "1-2" ) );
       c = std::make_unique<QgsGraduatedSymbolRenderer>( "fa_cy-fie+ld", ranges );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() );
       QCOMPARE( r->rootRule()->children().size(), 2 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"fa_cy-fie+ld\" <= 1.0000000000000000" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"fa_cy-fie+ld\" > 1.0000000000000000" );
@@ -1072,7 +1071,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       ranges.append( QgsRendererRange( 1, 2, new QgsMarkerSymbol(), "1-2" ) );
       c = std::make_unique<QgsGraduatedSymbolRenderer>( "id / 2", ranges );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get() );
       QCOMPARE( r->rootRule()->children().size(), 2 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) <= 1.0000000000000000" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.0000000000000000" );
@@ -1083,7 +1082,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       ranges.append( QgsRendererRange( 1, 2, new QgsMarkerSymbol(), "1-2" ) );
       c = std::make_unique<QgsGraduatedSymbolRenderer>( "\"id\"", ranges );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get() );
       QCOMPARE( r->rootRule()->children().size(), 2 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.0000000000000000" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.0000000000000000" );
@@ -1095,7 +1094,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       ranges.append( QgsRendererRange( 1, 2, new QgsMarkerSymbol(), "1-2" ) );
       c = std::make_unique<QgsGraduatedSymbolRenderer>( "fa_cy-fie+ld", ranges );
 
-      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
+      r = QgsRuleBasedRenderer::convertFromRenderer( c.get() );
       QCOMPARE( r->rootRule()->children().size(), 2 );
       QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(fa_cy-fie+ld) <= 1.0000000000000000" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(fa_cy-fie+ld) > 1.0000000000000000" );
@@ -1380,10 +1379,10 @@ class TestQgsRuleBasedRenderer : public QgsTest
       QgsRuleBasedRenderer::Rule *rootRule = new QgsRuleBasedRenderer::Rule( nullptr );
       auto renderer = std::make_unique<QgsRuleBasedRenderer>( rootRule );
 
-      QgsRuleBasedRenderer::Rule *rule1 = new QgsRuleBasedRenderer::Rule( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), 0, 0, "\"field_name\" = 1" );
-      QgsRuleBasedRenderer::Rule *rule2 = new QgsRuleBasedRenderer::Rule( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), 0, 0, "\"field_name\" = 6" );
-      QgsRuleBasedRenderer::Rule *ruleElse = new QgsRuleBasedRenderer::Rule( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), 0, 0, "ELSE" );
-      QgsRuleBasedRenderer::Rule *ruleElse2 = new QgsRuleBasedRenderer::Rule( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), 0, 0, "ELSE" );
+      QgsRuleBasedRenderer::Rule *rule1 = new QgsRuleBasedRenderer::Rule( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), 0, 0, "\"field_name\" = 1" );
+      QgsRuleBasedRenderer::Rule *rule2 = new QgsRuleBasedRenderer::Rule( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), 0, 0, "\"field_name\" = 6" );
+      QgsRuleBasedRenderer::Rule *ruleElse = new QgsRuleBasedRenderer::Rule( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), 0, 0, "ELSE" );
+      QgsRuleBasedRenderer::Rule *ruleElse2 = new QgsRuleBasedRenderer::Rule( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), 0, 0, "ELSE" );
 
       Q_ASSERT( ruleElse->isElse() );
 

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -144,8 +144,8 @@ class TestQgsSnappingUtils : public QObject
     {
       QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
       renderer->setClassAttribute( u"fld"_s );
-      renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ) );
-      renderer->addCategory( QgsRendererCategory( "2", QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ), u"2"_s ) );
+      renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ).release() );
+      renderer->addCategory( QgsRendererCategory( "2", QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon ).release(), u"2"_s ) );
       mVL->setRenderer( renderer );
 
       //create legend with symbology nodes for categorized renderer

--- a/tests/src/core/testqgsstyle.cpp
+++ b/tests/src/core/testqgsstyle.cpp
@@ -468,13 +468,13 @@ void TestStyle::testCreate3dSymbol()
   QCOMPARE( mStyle->symbol3DCount(), 1 );
   QVERIFY( mStyle->symbol3DCompatibleGeometryTypes( u"blah"_s ).isEmpty() );
   QCOMPARE( mStyle->symbol3DCompatibleGeometryTypes( u"test_settings"_s ), QList<Qgis::GeometryType>() << Qgis::GeometryType::Point << Qgis::GeometryType::Line );
-  std::unique_ptr<Dummy3DSymbol> retrieved( dynamic_cast<Dummy3DSymbol *>( mStyle->symbol3D( u"test_settings"_s ) ) );
+  auto retrieved = qgis::unique_ptr_dynamic_cast<Dummy3DSymbol>( mStyle->symbol3D( u"test_settings"_s ) );
   QCOMPARE( retrieved->id, u"xxx"_s );
   symbol.id = u"yyy"_s;
   QVERIFY( mStyle->addSymbol3D( "test_settings", symbol.clone(), true ) );
   QVERIFY( mStyle->symbol3DNames().contains( u"test_settings"_s ) );
   QCOMPARE( mStyle->symbol3DCount(), 1 );
-  retrieved.reset( dynamic_cast<Dummy3DSymbol *>( mStyle->symbol3D( u"test_settings"_s ) ) );
+  retrieved = qgis::unique_ptr_dynamic_cast<Dummy3DSymbol>( mStyle->symbol3D( u"test_settings"_s ) );
   QCOMPARE( retrieved->id, u"yyy"_s );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spyChanged.count(), 1 );
@@ -483,9 +483,9 @@ void TestStyle::testCreate3dSymbol()
   QVERIFY( mStyle->addSymbol3D( "test_format2", symbol.clone(), true ) );
   QVERIFY( mStyle->symbol3DNames().contains( u"test_format2"_s ) );
   QCOMPARE( mStyle->symbol3DCount(), 2 );
-  retrieved.reset( dynamic_cast<Dummy3DSymbol *>( mStyle->symbol3D( u"test_settings"_s ) ) );
+  retrieved = qgis::unique_ptr_dynamic_cast<Dummy3DSymbol>( mStyle->symbol3D( u"test_settings"_s ) );
   QCOMPARE( retrieved->id, u"yyy"_s );
-  retrieved.reset( dynamic_cast<Dummy3DSymbol *>( mStyle->symbol3D( u"test_format2"_s ) ) );
+  retrieved = qgis::unique_ptr_dynamic_cast<Dummy3DSymbol>( mStyle->symbol3D( u"test_format2"_s ) );
   QCOMPARE( retrieved->id, u"zzz"_s );
   QCOMPARE( spy.count(), 2 );
   QCOMPARE( spyChanged.count(), 1 );
@@ -499,9 +499,9 @@ void TestStyle::testCreate3dSymbol()
   QVERIFY( style2.symbol3DNames().contains( u"test_settings"_s ) );
   QVERIFY( style2.symbol3DNames().contains( u"test_format2"_s ) );
   QCOMPARE( style2.symbol3DCount(), 2 );
-  retrieved.reset( dynamic_cast<Dummy3DSymbol *>( style2.symbol3D( u"test_settings"_s ) ) );
+  retrieved = qgis::unique_ptr_dynamic_cast<Dummy3DSymbol>( style2.symbol3D( u"test_settings"_s ) );
   QCOMPARE( retrieved->id, u"yyy"_s );
-  retrieved.reset( dynamic_cast<Dummy3DSymbol *>( style2.symbol3D( u"test_format2"_s ) ) );
+  retrieved = qgis::unique_ptr_dynamic_cast<Dummy3DSymbol>( style2.symbol3D( u"test_format2"_s ) );
   QCOMPARE( retrieved->id, u"zzz"_s );
 
   QCOMPARE( mStyle->allNames( QgsStyle::Symbol3DEntity ), QStringList() << u"test_format2"_s << u"test_settings"_s );
@@ -607,19 +607,17 @@ void TestStyle::testLoadColorRamps()
   {
     QgsDebugMsgLevel( "colorRamp " + name, 1 );
     QVERIFY( colorRamps.contains( name ) );
-    QgsColorRamp *ramp = mStyle->colorRamp( name );
-    QVERIFY( ramp != nullptr );
+    std::unique_ptr<QgsColorRamp> ramp = mStyle->colorRamp( name );
+    QVERIFY( ramp );
     // test colors
     if ( colorTests.contains( name ) )
     {
       const QList<QPair<double, QColor>> values = colorTests.values( name );
       for ( int i = 0; i < values.size(); ++i )
       {
-        QVERIFY( testValidColor( ramp, values.at( i ).first, values.at( i ).second ) );
+        QVERIFY( testValidColor( ramp.get(), values.at( i ).first, values.at( i ).second ) );
       }
     }
-    if ( ramp )
-      delete ramp;
   }
 }
 
@@ -635,10 +633,8 @@ void TestStyle::testSaveLoad()
   {
     QgsDebugMsgLevel( "colorRamp " + name, 1 );
     QVERIFY( colorRamps.contains( name ) );
-    QgsColorRamp *ramp = mStyle->colorRamp( name );
-    QVERIFY( ramp != nullptr );
-    if ( ramp )
-      delete ramp;
+    std::unique_ptr<QgsColorRamp> ramp = mStyle->colorRamp( name );
+    QVERIFY( ramp );
   }
   // test content again
   testLoadColorRamps();
@@ -1660,14 +1656,14 @@ void TestStyle::testVisitor()
   QgsVectorLayer *vl2 = new QgsVectorLayer( u"Point?crs=epsg:4326&field=pk:int&field=col1:string"_s, u"vl2"_s, u"memory"_s );
   QVERIFY( vl2->isValid() );
   p.addMapLayer( vl2 );
-  QgsSymbol *s1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  std::unique_ptr<QgsSymbol> s1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
   s1->setColor( QColor( 0, 255, 0 ) );
-  QgsSymbol *s2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  std::unique_ptr<QgsSymbol> s2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
   s2->setColor( QColor( 0, 255, 255 ) );
   QgsRuleBasedRenderer::Rule *rootRule = new QgsRuleBasedRenderer::Rule( nullptr );
-  QgsRuleBasedRenderer::Rule *rule2 = new QgsRuleBasedRenderer::Rule( s1, 0, 0, u"fld >= 5 and fld <= 20"_s );
+  QgsRuleBasedRenderer::Rule *rule2 = new QgsRuleBasedRenderer::Rule( s1.get(), 0, 0, u"fld >= 5 and fld <= 20"_s );
   rootRule->appendChild( rule2 );
-  QgsRuleBasedRenderer::Rule *rule3 = new QgsRuleBasedRenderer::Rule( s2, 0, 0, u"fld <= 10"_s );
+  QgsRuleBasedRenderer::Rule *rule3 = new QgsRuleBasedRenderer::Rule( s2.get(), 0, 0, u"fld <= 10"_s );
   rule2->appendChild( rule3 );
   vl2->setRenderer( new QgsRuleBasedRenderer( rootRule ) );
 
@@ -1805,12 +1801,12 @@ void TestStyle::testVisitor()
 
   // with annotations
   QgsTextAnnotation *annotation = new QgsTextAnnotation();
-  QgsSymbol *a1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
+  std::unique_ptr<QgsSymbol> a1 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Point );
   a1->setColor( QColor( 0, 200, 0 ) );
-  annotation->setMarkerSymbol( static_cast<QgsMarkerSymbol *>( a1 ) );
-  QgsSymbol *a2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon );
+  annotation->setMarkerSymbol( static_cast<QgsMarkerSymbol *>( a1.release() ) );
+  std::unique_ptr<QgsSymbol> a2 = QgsSymbol::defaultSymbol( Qgis::GeometryType::Polygon );
   a2->setColor( QColor( 200, 200, 0 ) );
-  annotation->setFillSymbol( static_cast<QgsFillSymbol *>( a2 ) );
+  annotation->setFillSymbol( static_cast<QgsFillSymbol *>( a2.release() ) );
   p.annotationManager()->addAnnotation( annotation );
 
   found.clear();

--- a/tests/src/core/testqgstracer.cpp
+++ b/tests/src/core/testqgstracer.cpp
@@ -197,8 +197,8 @@ void TestQgsTracer::testInvisible()
 
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer();
   renderer->setClassAttribute( u"fld"_s );
-  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ) );
-  renderer->addCategory( QgsRendererCategory( "2", QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ), u"2"_s ) );
+  renderer->setSourceSymbol( QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ).release() );
+  renderer->addCategory( QgsRendererCategory( "2", QgsSymbol::defaultSymbol( Qgis::GeometryType::Line ).release(), u"2"_s ) );
   mVL->setRenderer( renderer );
 
   //create legend with symbology nodes for categorized renderer

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -233,7 +233,7 @@ void TestQgsVectorLayer::setRenderer()
 {
   const QSignalSpy spy( mpPointsLayer, &QgsVectorLayer::rendererChanged );
 
-  QgsSingleSymbolRenderer *symbolRenderer = new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ) );
+  QgsSingleSymbolRenderer *symbolRenderer = new QgsSingleSymbolRenderer( QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release() );
 
   mpPointsLayer->setRenderer( symbolRenderer );
   QCOMPARE( spy.count(), 1 );

--- a/tests/src/gui/testqgscategorizedrendererwidget.cpp
+++ b/tests/src/gui/testqgscategorizedrendererwidget.cpp
@@ -100,8 +100,8 @@ void TestQgsCategorizedRendererWidget::testAddMissingCategories()
   // test with a value list category
   widget.reset();
   renderer = new QgsCategorizedSymbolRenderer( u"name"_s );
-  renderer->addCategory( QgsRendererCategory( u"b"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), QString() ) );
-  renderer->addCategory( QgsRendererCategory( QVariantList() << u"a"_s << u"c"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), QString() ) );
+  renderer->addCategory( QgsRendererCategory( u"b"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), QString() ) );
+  renderer->addCategory( QgsRendererCategory( QVariantList() << u"a"_s << u"c"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), QString() ) );
 
   vl->setRenderer( renderer );
 
@@ -284,9 +284,9 @@ void TestQgsCategorizedRendererWidget::model()
 
   QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer( u"name"_s );
   renderer = new QgsCategorizedSymbolRenderer( u"name"_s );
-  renderer->addCategory( QgsRendererCategory( u"b"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"aa"_s ) );
-  renderer->addCategory( QgsRendererCategory( QVariantList() << u"a"_s << u"c"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"list"_s ) );
-  renderer->addCategory( QgsRendererCategory( u"d"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ), u"dd"_s, false ) );
+  renderer->addCategory( QgsRendererCategory( u"b"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"aa"_s ) );
+  renderer->addCategory( QgsRendererCategory( QVariantList() << u"a"_s << u"c"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"list"_s ) );
+  renderer->addCategory( QgsRendererCategory( u"d"_s, QgsSymbol::defaultSymbol( Qgis::GeometryType::Point ).release(), u"dd"_s, false ) );
 
   vl->setRenderer( renderer );
 


### PR DESCRIPTION
## Description

This PR is part of QEP [#417](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-417-remove-sip-factory.md)

It concerns only core/symbology folder and method with non-QObject return type.

## AI tool usage

None

**Funded by the QGIS Grant programme 2026**