### PR TITLE
[feature] Add inclusive/exclusive bound info to graduated symbol renderer tooltips

### DIFF
--- a/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -126,6 +126,30 @@ ranges.
 :return: ``True`` if ranges have gaps
 %End
 
+    bool rangeLowerBoundIsInclusive( int rangeIndex ) const;
+%Docstring
+Returns ``True`` if the lower bound of the range at the specified
+``rangeIndex`` is inclusive, i.e. a feature value exactly equal to the
+range's :py:func:`~QgsGraduatedSymbolRenderer.lowerValue` will be
+classified into this range.
+
+.. seealso:: :py:func:`rangeUpperBoundIsInclusive`
+
+.. versionadded:: 4.4
+%End
+
+    bool rangeUpperBoundIsInclusive( int rangeIndex ) const;
+%Docstring
+Returns ``True`` if the upper bound of the range at the specified
+``rangeIndex`` is inclusive, i.e. a feature value exactly equal to the
+range's :py:func:`~QgsGraduatedSymbolRenderer.upperValue` will be
+classified into this range.
+
+.. seealso:: :py:func:`rangeLowerBoundIsInclusive`
+
+.. versionadded:: 4.4
+%End
+
     void sortByValue( Qt::SortOrder order = Qt::AscendingOrder );
     void sortByLabel( Qt::SortOrder order = Qt::AscendingOrder );
 

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -129,6 +129,34 @@ QgsSymbol *QgsGraduatedSymbolRenderer::symbolForValue( double value ) const
   return nullptr;
 }
 
+bool QgsGraduatedSymbolRenderer::rangeLowerBoundIsInclusive( int rangeIndex ) const
+{
+  if ( rangeIndex < 0 || rangeIndex >= mRanges.size() )
+    return true;
+
+  const double value = mRanges.at( rangeIndex ).lowerValue();
+  for ( int i = 0; i < rangeIndex; ++i )
+  {
+    if ( mRanges.at( i ).lowerValue() <= value && mRanges.at( i ).upperValue() >= value )
+      return false;
+  }
+  return true;
+}
+
+bool QgsGraduatedSymbolRenderer::rangeUpperBoundIsInclusive( int rangeIndex ) const
+{
+  if ( rangeIndex < 0 || rangeIndex >= mRanges.size() )
+    return true;
+
+  const double value = mRanges.at( rangeIndex ).upperValue();
+  for ( int i = 0; i < rangeIndex; ++i )
+  {
+    if ( mRanges.at( i ).lowerValue() <= value && mRanges.at( i ).upperValue() >= value )
+      return false;
+  }
+  return true;
+}
+
 QString QgsGraduatedSymbolRenderer::legendKeyForValue( double value ) const
 {
   if ( const QgsRendererRange *matchingRange = rangeForValue( value ) )

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -122,6 +122,26 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
      */
     bool rangesHaveGaps() const;
 
+    /**
+     * Returns TRUE if the lower bound of the range at the specified \a rangeIndex is
+     * inclusive, i.e. a feature value exactly equal to the range's lowerValue() will be
+     * classified into this range.
+     *
+     * \see rangeUpperBoundIsInclusive()
+     * \since QGIS 4.4
+     */
+    bool rangeLowerBoundIsInclusive( int rangeIndex ) const;
+
+    /**
+     * Returns TRUE if the upper bound of the range at the specified \a rangeIndex is
+     * inclusive, i.e. a feature value exactly equal to the range's upperValue() will be
+     * classified into this range.
+     *
+     * \see rangeLowerBoundIsInclusive()
+     * \since QGIS 4.4
+     */
+    bool rangeUpperBoundIsInclusive( int rangeIndex ) const;
+
     void sortByValue( Qt::SortOrder order = Qt::AscendingOrder );
     void sortByLabel( Qt::SortOrder order = Qt::AscendingOrder );
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -158,6 +158,28 @@ Qt::DropActions QgsGraduatedSymbolRendererModel::supportedDropActions() const
   return Qt::MoveAction;
 }
 
+QString QgsGraduatedSymbolRendererModel::formatRangeValue( double value ) const
+{
+  int decimalPlaces = mRenderer->classificationMethod()->labelPrecision() + 2;
+  if ( decimalPlaces < 0 )
+    decimalPlaces = 0;
+  return QLocale().toString( value, 'f', decimalPlaces );
+}
+
+QString QgsGraduatedSymbolRendererModel::tooltip( const QModelIndex &index ) const
+{
+  if ( !index.isValid() || !mRenderer || ( index.column() != 1 && index.column() != 2 ) )
+    return QString();
+
+  const QgsRendererRange range = mRenderer->ranges().value( index.row() );
+  const bool lowerInclusive = mRenderer->rangeLowerBoundIsInclusive( index.row() );
+  const bool upperInclusive = mRenderer->rangeUpperBoundIsInclusive( index.row() );
+  const QString lowerOperator = lowerInclusive ? u"<="_s : u"<"_s;
+  const QString upperOperator = upperInclusive ? u"<="_s : u"<"_s;
+
+  return QString( formatRangeValue( range.lowerValue() ) + " " + lowerOperator + " " + tr( "Values" ) + " " + upperOperator + " " + formatRangeValue( range.upperValue() ) );
+}
+
 QVariant QgsGraduatedSymbolRendererModel::data( const QModelIndex &index, int role ) const
 {
   if ( !index.isValid() || !mRenderer )
@@ -171,15 +193,13 @@ QVariant QgsGraduatedSymbolRendererModel::data( const QModelIndex &index, int ro
   }
   else if ( role == Qt::DisplayRole || role == Qt::ToolTipRole )
   {
+    if ( role == Qt::ToolTipRole )
+      return tooltip( index );
+
     switch ( index.column() )
     {
       case 1:
-      {
-        int decimalPlaces = mRenderer->classificationMethod()->labelPrecision() + 2;
-        if ( decimalPlaces < 0 )
-          decimalPlaces = 0;
-        return QString( QLocale().toString( range.lowerValue(), 'f', decimalPlaces ) + " - " + QLocale().toString( range.upperValue(), 'f', decimalPlaces ) );
-      }
+        return QString( formatRangeValue( range.lowerValue() ) + " - " + formatRangeValue( range.upperValue() ) );
       case 2:
         return range.label();
       default:

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -67,6 +67,9 @@ class GUI_EXPORT QgsGraduatedSymbolRendererModel : public QAbstractItemModel
     void rowsMoved();
 
   private:
+    QString formatRangeValue( double value ) const;
+    QString tooltip( const QModelIndex &index ) const;
+
     QgsGraduatedSymbolRenderer *mRenderer = nullptr;
     QString mMimeFormat;
     QPointer<QScreen> mScreen;

--- a/tests/src/core/testqgsgraduatedsymbolrenderer.cpp
+++ b/tests/src/core/testqgsgraduatedsymbolrenderer.cpp
@@ -14,10 +14,12 @@
  ***************************************************************************/
 #include "qgsclassificationequalinterval.h"
 #include "qgsclassificationquantile.h"
+#include "qgsfeature.h"
 #include "qgsgraduatedsymbolrenderer.h"
 #include "qgsmarkersymbol.h"
 #include "qgssymbollayerutils.h"
 #include "qgstest.h"
+#include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 
 #include <QObject>
@@ -45,6 +47,7 @@ class TestQgsGraduatedSymbolRenderer : public QObject
     void rangesHaveGaps();
     void classifySymmetric();
     void testMatchingRangeForValue();
+    void testRangeBoundInclusivity();
 
   private:
 };
@@ -308,6 +311,82 @@ void TestQgsGraduatedSymbolRenderer::testMatchingRangeForValue()
   // test values which fall just outside ranges, e.g. due to double precision (refs https://github.com/qgis/QGIS/issues/27420)
   QCOMPARE( renderer.rangeForValue( 1.1 - std::numeric_limits<double>::epsilon() * 2 )->label(), u"r1"_s );
   QCOMPARE( renderer.rangeForValue( 3.7 + std::numeric_limits<double>::epsilon() * 2 )->label(), u"r4"_s );
+}
+
+void TestQgsGraduatedSymbolRenderer::testRangeBoundInclusivity()
+{
+  // empty renderer - out of range indices
+  QgsGraduatedSymbolRenderer emptyRenderer;
+  QVERIFY( emptyRenderer.rangeLowerBoundIsInclusive( -1 ) );
+  QVERIFY( emptyRenderer.rangeLowerBoundIsInclusive( 0 ) );
+  QVERIFY( emptyRenderer.rangeUpperBoundIsInclusive( -1 ) );
+  QVERIFY( emptyRenderer.rangeUpperBoundIsInclusive( 0 ) );
+
+  // manually built contiguous ranges
+  QgsGraduatedSymbolRenderer renderer;
+  QgsMarkerSymbol ms;
+  ms.setColor( QColor( 255, 0, 0 ) );
+  const QgsRendererRange r1( 1.1, 3.2, ms.clone(), u"r1"_s );
+  renderer.addClass( r1 );
+  const QgsRendererRange r2( 3.2, 3.3, ms.clone(), u"r2"_s );
+  renderer.addClass( r2 );
+  const QgsRendererRange r3( 3.3, 3.6, ms.clone(), u"r3"_s );
+  renderer.addClass( r3 );
+
+  QVERIFY( renderer.rangeLowerBoundIsInclusive( 0 ) );
+  QVERIFY( renderer.rangeUpperBoundIsInclusive( 0 ) );
+  QVERIFY( !renderer.rangeLowerBoundIsInclusive( 1 ) );
+  QVERIFY( renderer.rangeUpperBoundIsInclusive( 1 ) );
+  QVERIFY( !renderer.rangeLowerBoundIsInclusive( 2 ) );
+  QVERIFY( renderer.rangeUpperBoundIsInclusive( 2 ) );
+
+  // render with a layer
+  QgsVectorLayer vl( u"None?field=value:double"_s, u"classification_layer"_s, u"memory"_s );
+  QVERIFY( vl.isValid() );
+  QgsFeatureList features;
+  const QList<double> values = { 1, 2, 3, 10, 20, 30, 40 };
+  for ( const double v : values )
+  {
+    QgsFeature f( vl.fields() );
+    f.setAttribute( u"value"_s, v );
+    features << f;
+  }
+  QVERIFY( vl.dataProvider()->addFeatures( features ) );
+
+  QgsGraduatedSymbolRenderer dataRenderer;
+  dataRenderer.setClassAttribute( u"value"_s );
+  dataRenderer.setSourceSymbol( new QgsMarkerSymbol() );
+  dataRenderer.setClassificationMethod( new QgsClassificationEqualInterval() );
+
+  QString error;
+  dataRenderer.updateClasses( &vl, 4, error );
+  QCOMPARE( dataRenderer.ranges().count(), 4 );
+
+  QVERIFY( dataRenderer.rangeLowerBoundIsInclusive( 0 ) );
+  QVERIFY( dataRenderer.rangeUpperBoundIsInclusive( 0 ) );
+  for ( int i = 1; i < dataRenderer.ranges().count(); ++i )
+  {
+    QVERIFY( !dataRenderer.rangeLowerBoundIsInclusive( i ) );
+    QVERIFY( dataRenderer.rangeUpperBoundIsInclusive( i ) );
+  }
+
+  // move the classes
+  dataRenderer.moveClass( 1, 0 );
+  dataRenderer.moveClass( 3, 1 );
+
+  // move classes are inclusive
+  QVERIFY( dataRenderer.rangeLowerBoundIsInclusive( 0 ) );
+  QVERIFY( dataRenderer.rangeUpperBoundIsInclusive( 0 ) );
+  QVERIFY( dataRenderer.rangeLowerBoundIsInclusive( 1 ) );
+  QVERIFY( dataRenderer.rangeUpperBoundIsInclusive( 1 ) );
+
+  // class on index 2 is inclusive for low and exclusive for high
+  QVERIFY( dataRenderer.rangeLowerBoundIsInclusive( 2 ) );
+  QVERIFY( !dataRenderer.rangeUpperBoundIsInclusive( 2 ) );
+
+  // class on index 3 is exclusive for both low and high
+  QVERIFY( !dataRenderer.rangeLowerBoundIsInclusive( 3 ) );
+  QVERIFY( !dataRenderer.rangeUpperBoundIsInclusive( 3 ) );
 }
 
 QGSTEST_MAIN( TestQgsGraduatedSymbolRenderer )


### PR DESCRIPTION
## Description

Changes the tooltips for the **Graduated symbol renderer** to the form `y ≤ Values ≤ x`, `y < Values < x`, or a mix of the two, to clearly show which bound is inclusive and which is exclusive.

<img width="640" height="400" alt="Screenshot From 2026-09-15 09-43-44" src="https://github.com/user-attachments/assets/a7dc373c-c989-4ab3-a25c-48c6c0f6578d" />

If there is previous class that overlaps with the current one, there is a message about that.

<img width="640" height="400" alt="Screenshot From 2026-09-15 09-44-17" src="https://github.com/user-attachments/assets/5d7e77b5-af8a-4199-a288-7f812e6989fe" />

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR.

